### PR TITLE
CMD-196 package builds correct fat jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,15 @@
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
         </configuration>
+        <executions>
+          <execution>
+            <id>generate-fat-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>assembly</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
The fat jar was not including our classes unless they were accidentally already there.  This makes it so that `mvn package` builds a proper fat jar.

Also, made spacing consistent.
