### PR TITLE
Create mvn profile to add ele-blueflood as a module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
       </properties>
     </profile>
     <profile>
-      <id>ele-bf</id>
+      <id>ele</id>
       <modules>
         <module>ele-blueflood</module>
       </modules>


### PR DESCRIPTION
Create mvn profile to add ele-blueflood as a module. The public doesn't
need it in there, but we do.

This is a slightly nicer solution to getting ele-blueflood tests running again than adding additional steps to the builder.
