### PR TITLE
Fix maven resolution of cassandra_maven_plugin jar

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -320,6 +320,15 @@
 
   </dependencies>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>local-project-libraries</id>
+      <name>Local project libraries</name>
+      <url>file://${project.basedir}/../lib</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
       <id>local-project-libraries</id>

--- a/ele-blueflood/pom.xml
+++ b/ele-blueflood/pom.xml
@@ -303,6 +303,12 @@
       <url>http://maven.davidtrott.com/repository</url>
       <layout>default</layout>
     </pluginRepository>
+    <pluginRepository>
+      <id>local-project-libraries</id>
+      <name>Local project libraries</name>
+      <url>file://${project.basedir}/../lib</url>
+      <layout>default</layout>
+    </pluginRepository>
   </pluginRepositories>
 
   <repositories>


### PR DESCRIPTION
The cassandra_maven_plugin dependency is a maven plugin, and as a result
does not use the repositories listed under <repositories>.

Adding the local lib dir as a pluginRepository fixes the problem.
