### PR TITLE
Create ele-blueflood uberjar

### DIFF
--- a/ele-blueflood/pom.xml
+++ b/ele-blueflood/pom.xml
@@ -2,7 +2,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+    <artifactId>blueflood</artifactId>
+    <groupId>com.rackspacecloud</groupId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <name>ele-blueflood</name>
@@ -204,6 +207,15 @@
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.4</version>
+        <executions>
+          <execution>
+            <id>distro-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>assembly</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>


### PR DESCRIPTION
Correctly configure ele-blueflood as a child of the parent blueflood
project, and run assembly:assembly target when using the package target.

This will make it possible to build jars for all child modules from the
parent, and also create the uberjars when using the package target. The
package target makes it possible to use another module as a dependency
without having to install those modules into your local maven
repository; the assembly:assembly target does not support this. By
piggy-backing assembly:assembly on package, we get the best of both
worlds.
