### PR TITLE
Implement retry policy

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
@@ -1,7 +1,5 @@
 package com.rackspacecloud.blueflood.io;
 
-import com.rackspacecloud.blueflood.service.Configuration;
-import com.rackspacecloud.blueflood.types.Locator;
 import com.netflix.astyanax.AstyanaxContext;
 import com.netflix.astyanax.Keyspace;
 import com.netflix.astyanax.connectionpool.NodeDiscoveryType;
@@ -9,9 +7,12 @@ import com.netflix.astyanax.connectionpool.impl.ConnectionPoolConfigurationImpl;
 import com.netflix.astyanax.connectionpool.impl.ConnectionPoolType;
 import com.netflix.astyanax.impl.AstyanaxConfigurationImpl;
 import com.netflix.astyanax.model.ColumnFamily;
+import com.netflix.astyanax.retry.RetryNTimes;
 import com.netflix.astyanax.serializers.LongSerializer;
 import com.netflix.astyanax.serializers.StringSerializer;
 import com.netflix.astyanax.thrift.ThriftFamilyFactory;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.types.Locator;
 
 import java.util.*;
 
@@ -83,9 +84,16 @@ class AstyanaxIO {
     }
 
     private static AstyanaxConfigurationImpl createPreferredAstyanaxConfiguration() {
-        return new AstyanaxConfigurationImpl()
+        AstyanaxConfigurationImpl config = new AstyanaxConfigurationImpl()
                 .setDiscoveryType(NodeDiscoveryType.NONE)
                 .setConnectionPoolType(ConnectionPoolType.ROUND_ROBIN);
+
+        int numRetries = Configuration.getIntegerProperty("CASSANDRA_MAX_RETRIES");
+        if (numRetries > 0) {
+            config.setRetryPolicy(new RetryNTimes(numRetries));
+        }
+
+        return config;
     }
 
     private static ConnectionPoolConfigurationImpl createPreferredConnectionPoolConfiguration() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -82,6 +82,8 @@ public class Configuration {
         props.put("INGEST_MODE", "true");
         props.put("ROLLUP_MODE", "true");
         props.put("QUERY_MODE", "true");
+
+        props.put("CASSANDRA_MAX_RETRIES", "5"); // set <= 0 to not retry
     }
 
     public static void init() throws IOException {


### PR DESCRIPTION
This will cause us to retry failed cassandra operations a maximum of 5 times.

Under current cluster configuration, we experience failures when 3 hosts (or more) are down. We wait a max of 1ms per host. This means we will wait a maximum of 78ms during a period of high connection contention. (16 hosts - 3 down) \* (1 original + 5 retries) = 78ms
