### PR TITLE
run cassandra in the foreground.

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -304,6 +304,8 @@
   </dependencies>
   
   <profiles>
+    <!-- We cannot override the script value from the command line, so the only way to run 'cassandra:run' is by
+         specifying it in a profile. -->
     <profile>
       <id>cassandra-only</id>
       <properties>


### PR DESCRIPTION
Create a profile that makes it so you can run cassandra from the command... line.  This is good because it means you don't have to have cassandra required to play around.  Do this when you want to run cassandra, and then point a BF at it from your IDE.

```
mvn test -Pcassandra-only
```
