### PR TITLE
Stop rolling up metrics forever

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
@@ -198,10 +198,6 @@ public class AstyanaxWriter extends AstyanaxIO {
                                 rollupEntry.getKey(),
                                 NumericSerializer.get(gran).toByteBuffer(rollupEntry.getValue()),
                                 ttl);
-                if (!AstyanaxWriter.isLocatorCurrent(locator)) {
-                    insertLocator(locator, mutationBatch);
-                    AstyanaxWriter.setLocatorCurrent(locator);
-                }
             }
             // send it.
             try {


### PR DESCRIPTION
Old behavior was to update metric locators when inserting fullres or rollups.

This causes us to continue to perform rollups regardless of whether any new data exists for those rollups. Forever.
![](http://31.media.tumblr.com/75c1b0f8a246b7be0c4b88ec2bd05606/tumblr_mrfi54Iutb1qmmkv6o1_400.gif)
