### PR TITLE
Fail build when integration tests fail

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -143,6 +143,12 @@
               </excludes>
             </configuration>
           </execution>
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
 


### PR DESCRIPTION
Currently when integration tests fail, they do not fail the build.
Adding the verify goal to failsafe plugin fixes this.

Prevents this from happening: https://ord1-maas-dev-bb0.cm.k1k.me/builders/blueflood-os-tests/builds/3/steps/shell_1/logs/stdio
