### PR TITLE
Remove thrift dependency from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ jdk:
   - oraclejdk6
   - openjdk6
 
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq thrift-compiler
-
 script: mvn verify
 
 notifications:


### PR DESCRIPTION
Build fails on thrift installation. We don't depend on thrift here anymore.
https://travis-ci.org/rackerlabs/blueflood/jobs/10416249
