### PR TITLE
Use the single goal for maven-assembly-plugin to create uberjars

### DIFF
--- a/blueflood-all/pom.xml
+++ b/blueflood-all/pom.xml
@@ -27,7 +27,7 @@
             <id>make-assembly</id>
             <phase>package</phase>
             <goals>
-              <goal>assembly</goal>
+              <goal>single</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
The `assembly` goal for maven-assembly-plugin is depreciated and is
causing odd behavior in maven. Use the `single` goal instead as the
documentation suggests.
