### PR TITLE
Update docker file to also spin up blueflood

### DIFF
--- a/demo/docker/Dockerfile
+++ b/demo/docker/Dockerfile
@@ -3,8 +3,14 @@ FROM ubuntu:12.04
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
 RUN apt-get update
 
-# install tools
+# install net tools
 RUN apt-get -y -f install curl net-tools
+
+# install git
+RUN apt-get -y install git
+
+# install maven (building blueflood jar)
+RUN apt-get -y install maven
 
 # add cassandra PPA
 RUN curl -L http://debian.datastax.com/debian/repo_key | apt-key add -
@@ -24,6 +30,9 @@ RUN update-java-alternatives -s java-7-oracle
 
 # install cassandra
 RUN apt-get install cassandra -y
+
+# git clone blueflood repo
+RUN git clone http://github.com/rackerlabs/blueflood.git /src/blueflood
 
 # start Cassandra
 ADD . /src

--- a/demo/docker/config/blueflood-log4j.properties
+++ b/demo/docker/config/blueflood-log4j.properties
@@ -1,0 +1,10 @@
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %-20.20c{1}:%-3L - %m%n
+log4j.logger.httpclient.wire.header=WARN
+log4j.logger.httpclient.wire.content=WARN
+log4j.logger.org.apache.http.client.protocol=INFO
+log4j.logger.org.apache.http.wire=INFO
+log4j.logger.org.apache.http.impl=INFO
+log4j.logger.org.apache.http.headers=INFO
+log4j.rootLogger=INFO, console

--- a/demo/docker/config/blueflood.conf
+++ b/demo/docker/config/blueflood.conf
@@ -1,0 +1,42 @@
+NAME=localhost
+# comma-delimited list of host:port tuples.
+CASSANDRA_HOSTS=%listen_ip%:9160
+DEFAULT_CASSANDRA_PORT=9160
+ROLLUP_KEYSPACE=DATA
+CLUSTER_NAME=TEST\u0020CLUSTER
+
+#comma-delimited list of host:port tuples.
+ZOOKEEPER_CLUSTER=NONE
+
+# limits the maximum number of concurrent rollups that can be taking place. This number will vary, but should be
+# kept reasonable. (values as high as 200 are not unreasonable, given suitable hardware.)
+MAX_ROLLUP_THREADS=100
+MAX_CASSANDRA_CONNECTIONS=128
+MAX_TIMEOUT_WHEN_EXHAUSTED=1
+
+# indicates how often the scheduler will scavenge for (shard,slots) that need to be rolled up.
+SCHEDULE_POLL_PERIOD=5000
+
+# if you find your system getting behind, but cores are not being fully utilized, follow this procedure:
+# 1. if RollupServiceMBean.getQueuedRollupCount() is big, you need to increase MAX_ROLLUP_THREADS.
+
+# identifies which data shards this node is responsible for. Value values are:
+# 1. "ALL" indicates this node is responsible for rolling up all shards.
+# 2. "NONE" indicates this node will not perform rollups. It is a read/write slave.
+# 3. a comma-delimited list of integers (0-127). E.g.: "0,1,2,3,4,5,6,7"
+SHARDS=All
+
+# frequency at which shard state push/pull happens in milliseconds.
+# pushes happen relatively quickly and should not be delayed.
+SHARD_PUSH_PERIOD=2000
+
+# since pulls take an order of magnitude longer than pushes, they should be spaced out.  The longer the period, the
+# higher the probability that occasional extra 5m rollups will be scheduled.  Plan on at least 50ms per shard.  So if
+# your node is managing 10 shards, it will take about 500ms to do a pull.
+SHARD_PULL_PERIOD=10000
+
+# each node can run one or more of INGEST, ROLLUP or QUERY services. This
+# setting makes that obvious and explicit.
+INGEST_MODE=true
+ROLLUP_MODE=true
+QUERY_MODE=true

--- a/demo/docker/start.sh
+++ b/demo/docker/start.sh
@@ -8,11 +8,15 @@ else
   SEED_IP=$1
 fi
 
+# Set addresses in cassandra config files
 sed -i "s/%seed_ip%/$SEED_IP/g" /src/config/cassandra.yaml
 sed -i "s/%listen_ip%/$IP/g" /src/config/cassandra.yaml
 sed -i "s/%listen_ip%/$IP/g" /src/config/cassandra-env.sh
+sed -i "s/%listen_ip%/$IP/g" /src/config/blueflood.conf
 
-cp /src/config/* /etc/cassandra/
+# Copy cassandra configs to /etc/cassandra
+cp /src/config/cassandra-env.sh /etc/cassandra/
+cp /src/config/cassandra.yaml /etc/cassandra/
 
 export MAX_HEAP_SIZE="512M"
 export HEAP_NEWSIZE="256M"
@@ -20,8 +24,29 @@ export HEAP_NEWSIZE="256M"
 cassandra
 sleep 5;
 
+# Setup cassandra schema
 if [ -z $1 ]; then
   cassandra-cli -h ${IP} -f /src/init.cql
 fi
+
+# Copy blueflood configs to /src/blueflood
+cp /src/config/blueflood.conf /src/blueflood/
+cp /src/config/blueflood-log4j.properties /src/blueflood/
+
+# Build blueflood
+cd /src/blueflood/
+mvn package
+cp /src/blueflood/blueflood-all/target/blueflood-all-1.0.0-SNAPSHOT-jar-with-dependencies.jar /src/blueflood/
+
+/usr/bin/java \
+        -Dblueflood.config=file:blueflood.conf \
+        -Dlog4j.configuration=file:blueflood-log4j.properties \
+        -Xms1G \
+        -Xmx1G \
+        -Dcom.sun.management.jmxremote.authenticate=false \
+        -Dcom.sun.management.jmxremote.ssl=false \
+        -Djava.rmi.server.hostname=${IP} \
+        -Dcom.sun.management.jmxremote.port=9180 \
+        -classpath blueflood-all-1.0.0-SNAPSHOT-jar-with-dependencies.jar com.rackspacecloud.blueflood.service.BluefloodServiceStarter 2>&1 >  /src/blueflood/blueflood.log &
 
 /bin/bash


### PR DESCRIPTION
This PR would git clone blueflood repo, build the jar using maven and spin up blueflood server in background. 

People would just have to use curl or ingest/retrieve scripts to play around with blueflood.
