### PR TITLE
print the retrieve command with the option at the end of the ingestion

### DIFF
--- a/demo/ingest.py
+++ b/demo/ingest.py
@@ -84,9 +84,15 @@ def main():
         print('Writing metrics for tenant: %s, metric name: %s,\
             start: %d, end: %d' % (tenantId, metricName, start, end))
         r = requests.post(url, data=json.dumps(payload))
-        print(r)
+        print('Response from server %s' % (r))
+        print('To retrive the generated data with retrieve.py script, use the following command (assuming port number 20000):')
+        print('')
+        print('./retrieve.py --host %s --port 20000 --metric %s --tenant %s --from %s --to %s --points 100' \
+            % (options.host, metricName, tenantId, start - 100000000, end + 100000000))
+        print('')
     except Exception, ex:
         print(ex)
         raise Exception('Cannot ingest metrics into bluflood')
 
 main()
+


### PR DESCRIPTION
This prints an additional line like the following so that the user can copy and paste easily.

To retrive the generated data with retrieve.py script, use the following command (assuming port number 20000):

./retrieve.py --host localhost --port 20000 --metric met.53c632b6-0ed2-11e3-bf0c-bc764e10e18e --tenant ac53c5196c-0ed2-11e3-bf0c-bc764e10e18e --from 1377474026267 --to 1377674026267 --points 100
