### PR TITLE
Lazy load half the connections

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
@@ -129,6 +129,7 @@ class AstyanaxIO {
                 .setMaxConnsPerHost(connsPerHost)
                 .setMaxBlockedThreadsPerHost(5)
                 .setMaxTimeoutWhenExhausted(timeoutWhenExhausted)
+                .setInitConnsPerHost(connsPerHost / 2)
                 .setSeeds(Configuration.getStringProperty("CASSANDRA_HOSTS"));
         return connectionPoolConfiguration;
     }


### PR DESCRIPTION
This should mitigate some of the issues we've seen with cluster restarts flooding cassandra with connection attempts.
