### PR TITLE
Tiny: Fix logging

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/TtlCache.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/TtlCache.java
@@ -55,7 +55,7 @@ public class TtlCache extends AbstractJmxCache implements TtlCacheMBean {
     // allowable errors per minute.
     private double safetyThreshold = 10d;
     
-    private volatile long lastFetchError = System.currentTimeMillis();
+    private volatile long lastFetchError = 0;
 
     public TtlCache(String label, TimeValue expiration, int cacheConcurrency, final InternalAPI internalAPI) {
         try {


### PR DESCRIPTION
These would fix the spurious ERROR messages emitted during cobertura test coverage.

Changed log.error to log.warn when we receive 404 against a request to get account info for tenantId.
