### PR TITLE
Fixing the step to run the install.  It should be install instead of before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ jdk:
   - oraclejdk6
   - openjdk6
 
-before_script:
-  - mvn install -Pskip-unit-tests,skip-integration-tests
+install:
+  - mvn install -Dmaven.test.skip
 
 script: 
   - mvn verify # runs integration tests against cassandra 1.0.8


### PR DESCRIPTION
Per documentation here. 

http://about.travis-ci.org/docs/user/build-configuration/#install

Our last job with the current travis configuration still calling the old install

https://travis-ci.org/rackerlabs/blueflood/jobs/10694592

skip test is done through maven.test.skip that is honored by both surefire and failsafe

http://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-test.html
