### PR TITLE
Allow filtering of different stats via HTTP requests

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
@@ -21,6 +21,7 @@ import com.rackspacecloud.blueflood.http.HttpClientVendor;
 import com.rackspacecloud.blueflood.io.AstyanaxReader;
 import com.rackspacecloud.blueflood.io.AstyanaxWriter;
 import com.rackspacecloud.blueflood.io.IntegrationTestBase;
+import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.IncomingMetricMetadataAnalyzer;
@@ -30,7 +31,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.json.simple.JSONArray;
 import org.junit.*;
 
 import java.net.URI;
@@ -149,13 +149,13 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
                                                    long from, long to) throws Exception {
         for (Locator locator : locators) {
             for (Granularity g2 : Granularity.granularities()) {
-                JSONArray data = (JSONArray) httpHandler.GetDataByPoints(
+                MetricData data = httpHandler.GetDataByPoints(
                         locator.getTenantId(),
                         locator.getMetricName(),
                         baseMillis,
                         baseMillis + 86400000,
-                        points.get(g2)).get("values");
-                Assert.assertEquals((int) answers.get(locator).get(g2), data.size());
+                        points.get(g2));
+                Assert.assertEquals((int) answers.get(locator).get(g2), data.getData().getPoints().size());
             }
         }
     }
@@ -169,9 +169,9 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
     private int getNumberOfPointsViaHTTPHandler(HttpRollupsQueryHandler handler,
                                                Locator locator, long from, long to, Resolution resolution)
             throws Exception {
-        final JSONArray values =  (JSONArray) handler.GetDataByResolution(locator.getTenantId(),
-                locator.getMetricName(), from, to, resolution).get("values");
-        return values.size();
+        final MetricData values = handler.GetDataByResolution(locator.getTenantId(),
+                locator.getMetricName(), from, to, resolution);
+        return values.getData().getPoints().size();
     }
 
     private void testHttpRequestForPoints() throws Exception {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/JSONOutputSerializer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/JSONOutputSerializer.java
@@ -63,20 +63,23 @@ public class JSONOutputSerializer implements OutputSerializer<JSONObject> {
         object.put("unit", unit);
 
         JSONObject filterStatsObject;
+        long numPoints;
         if (point.getData() instanceof Rollup) {
-            object.put("numPoints", ((Rollup) point.getData()).getCount());
+            numPoints = ((Rollup) point.getData()).getCount();
             filterStatsObject = getFilteredStatsForRollup((Rollup) point.getData(), filterStats);
         } else {
-            object.put("numPoints", 1L);
+            numPoints = 1;
             filterStatsObject = getFilteredStatsForFullRes(point.getData(), filterStats);
         }
 
         // Set all filtered stats to null if numPoints is 0
-        if ((Long) object.get("numPoints") == 0) {
+        if (numPoints == 0) {
             final Set<Map.Entry<String, Object>> statsSet = filterStatsObject.entrySet();
 
             for (Map.Entry<String, Object> stat : statsSet) {
-                stat.setValue(null);
+                if (!stat.getKey().equals("numPoints")) {
+                    stat.setValue(null);
+                }
             }
         }
 
@@ -94,13 +97,15 @@ public class JSONOutputSerializer implements OutputSerializer<JSONObject> {
             for (String stat : filterStats) {
             String lowerCaseStat = stat.toLowerCase();
             if (lowerCaseStat.equals("average")) {
-                filteredObject.put(lowerCaseStat, rollup.getAverage());
+                filteredObject.put("average", rollup.getAverage());
             } else if (lowerCaseStat.equals("min")) {
-                filteredObject.put(lowerCaseStat, rollup.getMinValue());
+                filteredObject.put("min", rollup.getMinValue());
             } else if (lowerCaseStat.equals("max")) {
-                filteredObject.put(lowerCaseStat, rollup.getMaxValue());
+                filteredObject.put("max", rollup.getMaxValue());
             } else if (lowerCaseStat.equals("variance")) {
-                filteredObject.put(lowerCaseStat, rollup.getVariance());
+                filteredObject.put("variance", rollup.getVariance());
+            } else if (lowerCaseStat.equals("numpoints")) {
+                filteredObject.put("numPoints", rollup.getCount());
             }
         }
 
@@ -115,13 +120,15 @@ public class JSONOutputSerializer implements OutputSerializer<JSONObject> {
             for (String stat : filterStats) {
                 String lowerCaseStat = stat.toLowerCase();
                 if (lowerCaseStat.equals("average")) {
-                    filteredObject.put(lowerCaseStat, rawSample);
+                    filteredObject.put("average", rawSample);
                 } else if (lowerCaseStat.equals("min")) {
-                    filteredObject.put(lowerCaseStat, rawSample);
+                    filteredObject.put("min", rawSample);
                 } else if (lowerCaseStat.equals("max")) {
-                    filteredObject.put(lowerCaseStat, rawSample);
+                    filteredObject.put("max", rawSample);
                 } else if (lowerCaseStat.equals("variance")) {
-                    filteredObject.put(lowerCaseStat, 0);
+                    filteredObject.put("variance", 0);
+                } else if (lowerCaseStat.equals("numpoints")) {
+                    filteredObject.put("numPoints", 1);
                 }
             }
         }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/serializers/JSONOutputSerializerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/serializers/JSONOutputSerializerTest.java
@@ -53,13 +53,15 @@ public class JSONOutputSerializerTest {
             Assert.assertEquals(point.getData(), dataJSON.get("average"));
             Assert.assertEquals(point.getData(), dataJSON.get("min"));
             Assert.assertEquals(point.getData(), dataJSON.get("max"));
-            Assert.assertEquals(1L, dataJSON.get("numPoints"));
 
             // Assert unit is same
             Assert.assertEquals(metricData.getUnit(), dataJSON.get("unit"));
 
             // Assert that variance isn't present
             Assert.assertNull(dataJSON.get("variance"));
+
+            // Assert numPoints isn't present
+            Assert.assertNull(dataJSON.get("numPoints"));
         }
     }
 
@@ -68,8 +70,13 @@ public class JSONOutputSerializerTest {
     public void testTransformRollupDataForCoarserGran() throws Exception {
         final JSONOutputSerializer serializer = new JSONOutputSerializer();
         final MetricData metricData = new MetricData(FakeMetricDataGenerator.generateFakeRollupPoints(), "unknown");
+        Set<String> filters = new HashSet<String>();
+        filters.add("average");
+        filters.add("min");
+        filters.add("max");
+        filters.add("numPoints");
 
-        JSONObject metricDataJSON = serializer.transformRollupData(metricData, filterStats);
+        JSONObject metricDataJSON = serializer.transformRollupData(metricData, filters);
 
         final JSONArray data = (JSONArray) metricDataJSON.get("values");
         for (int i = 0; i < data.size(); i++) {


### PR DESCRIPTION
By default, "average" and "numPoints" are the stats that would be sent out as responses. 

If user specifies a select query parameter like

GET /v1.0/:tenantId/experimental/views/metric_data/:metricName?from= 1378235503000&to= 1378335503000&points=100&select=average&select=variance

we'd send out both average and variance as part of JSON response. 

Note that numPoints is also a 'selectable' stat. 'timestamp' key is always returned. 

You can also specify stats like select=average,min,max but such a notation is not recommended. 
