### PR TITLE
Add stats to filter if its specified as a single item without commas

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
@@ -207,6 +207,8 @@ public class HttpRollupsQueryHandler extends RollupHandler
                 if (stat.contains(",")) {
                     List<String> nestedStats = Arrays.asList(stat.split(","));
                     filters.addAll(MetricStat.fromStringList(nestedStats));
+                } else {
+                    filters.add(MetricStat.fromString(stat));
                 }
             }
             return filters;


### PR DESCRIPTION
It looks like I forgot to address the base case of query parameters being individually called out like
select=average&select=min 

while I tried to address non-standard case of allowing people to specify
select=average,min.
