### PR TITLE
Minor writer optimizations

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
@@ -16,6 +16,12 @@
 
 package com.rackspacecloud.blueflood.io;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.netflix.astyanax.ColumnListMutation;
+import com.netflix.astyanax.Keyspace;
+import com.netflix.astyanax.MutationBatch;
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.netflix.astyanax.model.ColumnFamily;
 import com.rackspacecloud.blueflood.cache.TtlCache;
 import com.rackspacecloud.blueflood.internal.Account;
@@ -25,18 +31,11 @@ import com.rackspacecloud.blueflood.rollup.MetricsPersistenceOptimizer;
 import com.rackspacecloud.blueflood.rollup.MetricsPersistenceOptimizerFactory;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.UpdateStamp;
-import com.rackspacecloud.blueflood.types.BasicRollup;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Metric;
 import com.rackspacecloud.blueflood.types.Rollup;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import com.rackspacecloud.blueflood.utils.Util;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.netflix.astyanax.ColumnListMutation;
-import com.netflix.astyanax.Keyspace;
-import com.netflix.astyanax.MutationBatch;
-import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.yammer.metrics.core.TimerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +82,7 @@ public class AstyanaxWriter extends AstyanaxIO {
 
     // this collection is used to reduce the number of locators that get written.  Simply, if a locator has been
     // written in the last 10 minutes, don't bother.
-    private static final Cache<String, String> insertedLocators = CacheBuilder.newBuilder().expireAfterWrite(10,
+    private static final Cache<String, Boolean> insertedLocators = CacheBuilder.newBuilder().expireAfterWrite(10,
             TimeUnit.MINUTES).concurrencyLevel(16).build();
 
 
@@ -148,7 +147,7 @@ public class AstyanaxWriter extends AstyanaxIO {
     // numeric only!
     private final void insertLocator(Locator locator, MutationBatch mutationBatch) {
         mutationBatch.withRow(CF_METRICS_LOCATOR, (long) Util.computeShard(locator.toString()))
-                .putColumn(locator, "", LOCATOR_TTL);
+                .putEmptyColumn(locator, LOCATOR_TTL);
     }
 
     private void insertMetric(Metric metric, MutationBatch mutationBatch) {
@@ -268,7 +267,7 @@ public class AstyanaxWriter extends AstyanaxIO {
     }
 
     private static void setLocatorCurrent(Locator loc) {
-        insertedLocators.put(loc.toString(), "");
+        insertedLocators.put(loc.toString(), Boolean.TRUE);
     }
 
 }


### PR DESCRIPTION
This will make us write an empty column instead of the empty string for metrics_locator.

It will also use a singleton boolean instead of creating lots of strings for the insertedLocators cache.
