### PR TITLE
Push CF resolution into `RollupRunnable`

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/RollupRunnableIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/RollupRunnableIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.rackspacecloud.blueflood.service;
+
+import com.rackspacecloud.blueflood.io.AstyanaxIO;
+import com.rackspacecloud.blueflood.io.AstyanaxReader;
+import com.rackspacecloud.blueflood.io.AstyanaxWriter;
+import com.rackspacecloud.blueflood.io.IntegrationTestBase;
+import com.rackspacecloud.blueflood.rollup.Granularity;
+import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.types.Metric;
+import com.rackspacecloud.blueflood.types.Range;
+import com.rackspacecloud.blueflood.utils.TimeValue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+public class RollupRunnableIntegrationTest extends IntegrationTestBase {
+    
+    // gentle reader: remember, all column families are truncated between tests.
+    
+    private AstyanaxWriter writer = AstyanaxWriter.getInstance();
+    private AstyanaxReader reader = AstyanaxReader.getInstance();
+    
+    private final Locator normalLocator = Locator.createLocatorFromPathComponents("runnabletest", "just_some_data");
+    private final Range range = new Range(0, 5 * 60 * 1000);
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        
+        final TimeValue ttl = new TimeValue(24, TimeUnit.HOURS);
+        
+        ArrayList<Metric> normalMetrics = new ArrayList<Metric>(5);
+        
+        for (int i = 0; i < 5; i++) {
+            long time = i * 30000;
+            Metric metric = new Metric(normalLocator, i, time, ttl, "horses");
+            normalMetrics.add(metric);
+        }
+        
+        writer.insertFull(normalMetrics);
+    }
+    
+    @Test
+    public void testNormalMetrics() throws IOException {
+        // full res has 5 samples.
+        Assert.assertEquals(5, reader.getSimpleDataToRoll(normalLocator, range).getPoints().size());
+        
+        // assert nothing in 5m for this locator.
+        Assert.assertEquals(0, reader.getBasicRollupDataToRoll(normalLocator, range, AstyanaxIO.CF_METRICS_5M).getPoints().size());
+        
+        RollupExecutionContext rec = new RollupExecutionContext(Thread.currentThread());
+        RollupContext rc = new RollupContext(normalLocator, range, Granularity.FULL);
+        RollupRunnable rr = new RollupRunnable(rec, rc);
+        rr.run();
+        
+        // assert something in 5m for this locator.
+        Assert.assertEquals(1, reader.getBasicRollupDataToRoll(normalLocator, range, AstyanaxIO.CF_METRICS_5M).getPoints().size());
+    }
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
@@ -36,34 +36,34 @@ import java.util.*;
 public class AstyanaxIO {
     private static final AstyanaxContext<Keyspace> context;
     private static final Keyspace keyspace;
-    protected static final ColumnFamily<Locator, Long> CF_METRICS_FULL = new ColumnFamily<Locator, Long>("metrics_full",
+    public static final ColumnFamily<Locator, Long> CF_METRICS_FULL = new ColumnFamily<Locator, Long>("metrics_full",
             LocatorSerializer.get(),
             LongSerializer.get());
-    protected static final ColumnFamily<Locator, Long> CF_METRICS_5M = new ColumnFamily<Locator, Long>("metrics_5m",
+    public static final ColumnFamily<Locator, Long> CF_METRICS_5M = new ColumnFamily<Locator, Long>("metrics_5m",
             LocatorSerializer.get(),
             LongSerializer.get());
-    protected static final ColumnFamily<Locator, Long> CF_METRICS_20M = new ColumnFamily<Locator, Long>("metrics_20m",
+    public static final ColumnFamily<Locator, Long> CF_METRICS_20M = new ColumnFamily<Locator, Long>("metrics_20m",
             LocatorSerializer.get(),
             LongSerializer.get());
-    protected static final ColumnFamily<Locator, Long> CF_METRICS_60M = new ColumnFamily<Locator, Long>("metrics_60m",
+    public static final ColumnFamily<Locator, Long> CF_METRICS_60M = new ColumnFamily<Locator, Long>("metrics_60m",
             LocatorSerializer.get(),
             LongSerializer.get());
-    protected static final ColumnFamily<Locator, Long> CF_METRICS_240M = new ColumnFamily<Locator, Long>("metrics_240m",
+    public static final ColumnFamily<Locator, Long> CF_METRICS_240M = new ColumnFamily<Locator, Long>("metrics_240m",
             LocatorSerializer.get(),
             LongSerializer.get());
-    protected static final ColumnFamily<Locator, Long> CF_METRICS_1440M = new ColumnFamily<Locator, Long>("metrics_1440m",
+    public static final ColumnFamily<Locator, Long> CF_METRICS_1440M = new ColumnFamily<Locator, Long>("metrics_1440m",
             LocatorSerializer.get(),
             LongSerializer.get());
-    protected static final ColumnFamily<Locator, String> CF_METRIC_METADATA = new ColumnFamily<Locator, String>("metrics_metadata",
+    public static final ColumnFamily<Locator, String> CF_METRIC_METADATA = new ColumnFamily<Locator, String>("metrics_metadata",
             LocatorSerializer.get(),
             StringSerializer.get());
-    protected static final ColumnFamily<Locator, Long> CF_METRICS_STRING = new ColumnFamily<Locator, Long>("metrics_string",
+    public static final ColumnFamily<Locator, Long> CF_METRICS_STRING = new ColumnFamily<Locator, Long>("metrics_string",
             LocatorSerializer.get(),
             LongSerializer.get());
-    protected static final ColumnFamily<Long, Locator> CF_METRICS_LOCATOR = new ColumnFamily<Long, Locator>("metrics_locator",
+    public static final ColumnFamily<Long, Locator> CF_METRICS_LOCATOR = new ColumnFamily<Long, Locator>("metrics_locator",
             LongSerializer.get(),
             LocatorSerializer.get());
-    protected static final ColumnFamily<Long, String> CF_METRICS_STATE = new ColumnFamily<Long, String>("metrics_state",
+    public static final ColumnFamily<Long, String> CF_METRICS_STATE = new ColumnFamily<Long, String>("metrics_state",
             LongSerializer.get(),
             StringSerializer.get());
     protected static final Map<String, ColumnFamily<Locator, Long>> CF_NAME_TO_CF;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -16,8 +16,6 @@
 
 package com.rackspacecloud.blueflood.service;
 
-import com.netflix.astyanax.model.ColumnFamily;
-import com.rackspacecloud.blueflood.io.AstyanaxIO;
 import com.rackspacecloud.blueflood.io.AstyanaxReader;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.Locator;
@@ -79,14 +77,12 @@ class LocatorFetchRunnable implements Runnable {
         final RollupExecutionContext executionContext = new RollupExecutionContext(Thread.currentThread());
         for (Column<Locator> locatorCol : AstyanaxReader.getInstance().getAllLocators(shard)) {
             final Locator locator = locatorCol.getName();
-            final ColumnFamily<Locator, Long> srcCF = AstyanaxIO.getColumnFamilyMapper().get(finerGran.name());
-            final ColumnFamily<Locator, Long> destCF = AstyanaxIO.getColumnFamilyMapper().get(gran.name());
 
             if (log.isTraceEnabled())
                 log.trace("Rolling up (check,metric,dimension) {} for (gran,slot,shard) {}", locatorCol.getName(), parentSlotKey);
             try {
                 executionContext.increment();
-                final RollupContext rollupContext = new RollupContext(locator, parentRange, srcCF, destCF);
+                final RollupContext rollupContext = new RollupContext(locator, parentRange, finerGran);
                 rollupExecutor.execute(new RollupRunnable(executionContext, rollupContext));
                 rollCount += 1;
             } catch (Throwable any) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupContext.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupContext.java
@@ -16,10 +16,9 @@
 
 package com.rackspacecloud.blueflood.service;
 
-import com.netflix.astyanax.model.ColumnFamily;
+import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Range;
-import com.rackspacecloud.blueflood.types.Rollup;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Histogram;
 import com.yammer.metrics.core.Timer;
@@ -27,24 +26,20 @@ import com.yammer.metrics.core.Timer;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Will eventually become RollupContext as soon as the existing RollupContext is renamed to ScheduleContext.
- * This class keeps track of what is happening in an rollup for a specific metric.  Rollups for a single metric are run 
- * in parallel, as indicated by the counter.  The counter signals a thread that is waiting for all rollups for that
- * metric is finished so that the metric service can be signaled/
+ * This class keeps track of what is happening in a rollup for a specific metric.
  */
 class RollupContext {
-    private final Locator locator;
-    private final Range range;
-    private final ColumnFamily<Locator, Long> srcCF; // this is the source column family to read from.
-    private final ColumnFamily<Locator, Long> destCF; // this is the dest column family to write to.
     private static final Timer executeTimer = Metrics.newTimer(RollupService.class, "Rollup Execution Timer", TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
     private static final Histogram waitHist = Metrics.newHistogram(RollupService.class, "Rollup Wait Histogram", true);
-
-    RollupContext(Locator locator, Range rangeToRead, ColumnFamily srcColumnFamily, ColumnFamily destColumnFamily) {
+    
+    private final Locator locator;
+    private final Range range;
+    private final Granularity sourceGranularity;
+    
+    RollupContext(Locator locator, Range rangeToRead, Granularity sourceGranularity) {
         this.locator = locator;
         this.range = rangeToRead;
-        this.srcCF = srcColumnFamily;
-        this.destCF = destColumnFamily;
+        this.sourceGranularity = sourceGranularity;
     }
     
     Timer getExecuteTimer() {
@@ -55,12 +50,8 @@ class RollupContext {
         return waitHist;
     }
 
-    public ColumnFamily<Locator, Long> getSourceColumnFamily() {
-        return this.srcCF;
-    }
-
-    public ColumnFamily<Locator, Long> getDestinationColumnFamily() {
-        return this.destCF;
+    Granularity getSourceGranularity() {
+        return sourceGranularity;
     }
 
     Range getRange() {


### PR DESCRIPTION
This matters because histogram and preaggreated metrics will be stored in different column families.  Column families no longer will map so easily from granularities.
- Create a test along the way
- Expose the Astyanax ColumnFamily objects.
