### PR TITLE
Wait for ES response in insertDiscovery

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -103,7 +103,7 @@ public class ElasticIO implements DiscoveryIO {
             md.withAnnotation(info);
             bulk.add(createSingleRequest(md));
         }
-        bulk.execute();
+        bulk.execute().actionGet();
     }
 
     private IndexRequestBuilder createSingleRequest(Discovery md) throws IOException {

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
@@ -129,7 +129,6 @@ public class ElasticIOTest {
         elasticIO.insertDiscovery(createTestMetrics(TENANT_A));
         elasticIO.insertDiscovery(createTestMetrics(TENANT_B));
 
-        TimeUnit.SECONDS.sleep(1);
         iac.prepareRefresh().execute().actionGet();
     }
 


### PR DESCRIPTION
This fixes intermittent test failures caused by running tests before all
metric names have finished being indexed.
