### PR TITLE
update travis-ci java builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
-  - oraclejdk6
+  - oraclejdk7
+  - openjdk7
   - openjdk6
 
 install:


### PR DESCRIPTION
drop oraclejdk6 as they no longer support it.
add oraclejdk7 and openjdk7.
