### PR TITLE
Associate TTLs with Column Families instead of Granularity.

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/internal/InternalAPIFactory.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/internal/InternalAPIFactory.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.internal;
 
+import com.rackspacecloud.blueflood.io.AstyanaxIO;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import org.apache.http.conn.ClientConnectionManager;
@@ -33,8 +34,10 @@ public class InternalAPIFactory {
     private static int PAGINATION_RETRY_COUNT = 3;
 
     static final Map<Granularity, TimeValue> SAFETY_TTLS = new HashMap<Granularity, TimeValue>() {{
-        for (Granularity gran : Granularity.granularities())
-            put(gran, new TimeValue(gran.getTTL().getValue() * 5, gran.getTTL().getUnit()));
+        for (Granularity gran : Granularity.granularities()) {
+            TimeValue defaultTTL = AstyanaxIO.getColumnFamilyMapper().get(gran).getDefaultTTL(); 
+            put(gran, new TimeValue(defaultTTL.getValue() * 5, defaultTTL.getUnit()));
+        }
     }};
 
     private static final Account DEFAULT_ACCOUNT = new Account() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/rollup/Granularity.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/rollup/Granularity.java
@@ -40,12 +40,12 @@ public class Granularity {
     public static final int MILLISECONDS_IN_SLOT = 300000;
     private static final int SECS_PER_DAY = 86400;
     
-    public static final Granularity FULL = new Granularity("metrics_full", 300000, BASE_SLOTS_PER_GRANULARITY, new TimeValue(1, TimeUnit.DAYS), "full");
-    public static final Granularity MIN_5 = new Granularity("metrics_5m", 300000, BASE_SLOTS_PER_GRANULARITY, new TimeValue(2, TimeUnit.DAYS), "5m");
-    public static final Granularity MIN_20 = new Granularity("metrics_20m", 1200000, (BASE_SLOTS_PER_GRANULARITY / 4), new TimeValue(3, TimeUnit.DAYS), "20m");
-    public static final Granularity MIN_60 = new Granularity("metrics_60m", 3600000, (BASE_SLOTS_PER_GRANULARITY / 12), new TimeValue(31, TimeUnit.DAYS), "60m");
-    public static final Granularity MIN_240 = new Granularity("metrics_240m", 14400000, (BASE_SLOTS_PER_GRANULARITY / 48), new TimeValue(60, TimeUnit.DAYS), "240m");
-    public static final Granularity MIN_1440 = new Granularity("metrics_1440m", 86400000, (BASE_SLOTS_PER_GRANULARITY / 288), new TimeValue(365, TimeUnit.DAYS), "1440m");
+    public static final Granularity FULL = new Granularity("metrics_full", 300000, BASE_SLOTS_PER_GRANULARITY, "full");
+    public static final Granularity MIN_5 = new Granularity("metrics_5m", 300000, BASE_SLOTS_PER_GRANULARITY, "5m");
+    public static final Granularity MIN_20 = new Granularity("metrics_20m", 1200000, (BASE_SLOTS_PER_GRANULARITY / 4), "20m");
+    public static final Granularity MIN_60 = new Granularity("metrics_60m", 3600000, (BASE_SLOTS_PER_GRANULARITY / 12), "60m");
+    public static final Granularity MIN_240 = new Granularity("metrics_240m", 14400000, (BASE_SLOTS_PER_GRANULARITY / 48), "240m");
+    public static final Granularity MIN_1440 = new Granularity("metrics_1440m", 86400000, (BASE_SLOTS_PER_GRANULARITY / 288), "1440m");
     
     private static final Granularity LAST = MIN_1440;
     
@@ -69,16 +69,12 @@ public class Granularity {
     // number of slots for this granularity.  This number decreases as granularity is more coarse.  Also, the number of
     // minutes indicated by a single slot increases as the number of slots goes down.
     private final int numSlots;
-
-    // Default TTL to use if not provided
-    private TimeValue defaultTTL = null;
     
-    private Granularity(String cf, int milliseconds, int numSlots, TimeValue ttl, String shortName) {
+    private Granularity(String cf, int milliseconds, int numSlots, String shortName) {
         index = INDEX_COUNTER++;
         this.cf = cf;
         this.milliseconds = milliseconds;
         this.numSlots = numSlots;
-        this.defaultTTL = ttl;
         this.shortName = shortName;
     }
     
@@ -279,12 +275,8 @@ public class Granularity {
         return Integer.parseInt(s.split(",")[1]);
     }
 
-    public TimeValue getTTL() {
-        return this.defaultTTL;
+    @Override
+    public String toString() {
+        return name();
     }
-
-  @Override
-  public String toString() {
-    return name();
-  }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/cache/TtlCacheTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/cache/TtlCacheTest.java
@@ -92,9 +92,9 @@ public class TtlCacheTest {
     
     private void warmCache() {
         for (int i = 0; i < 100; i++) {
-            for (Granularity gran : Granularity.granularities()) {
-                twoSecondCache.getTtl("ackVCKg1rk", AstyanaxIO.getColumnFamilyMapper().get(gran));
-                twoSecondCache.getTtl("acAAAAAAAA", AstyanaxIO.getColumnFamilyMapper().get(gran));
+            for (AstyanaxIO.MetricColumnFamily cf : AstyanaxIO.getMetricColumnFamilies()) {
+                twoSecondCache.getTtl("ackVCKg1rk", cf);
+                twoSecondCache.getTtl("acAAAAAAAA", cf);
             }
         }
     }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/rollup/GranularityTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/rollup/GranularityTest.java
@@ -271,16 +271,6 @@ public class GranularityTest {
     }
 
     @Test
-    public void testGetTTL() {
-        Granularity gran = Granularity.FULL;
-
-        TimeValue tv = gran.getTTL();
-        TimeValue tv2 = new TimeValue(1, TimeUnit.DAYS);
-        
-        Assert.assertEquals(tv2.toDays(), tv.toDays());
-    }
-
-    @Test
     public void testBadGranularityFromPointsInterval() {
         try {
             Granularity.granularityFromPointsInInterval(2, 1, 3);


### PR DESCRIPTION
- This only caused a problem with the Account interface in TtlCache, which probably needs to be rethought anyway.
- Introduce MetricColumnFamily that contains a default TTL.
- Get all the TTL stuff out of Granularity.  woo.
