### PR TITLE
Make Locator hashable

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Locator.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Locator.java
@@ -64,7 +64,7 @@ public class Locator {
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof Locator && obj.hashCode() == this.hashCode();
+        return obj != null && obj instanceof Locator && obj.hashCode() == this.hashCode();
     }
 
     public String toString() {


### PR DESCRIPTION
implements `hashCode` and `equals` so that it can be used in hash tables and guava collections.
