### PR TITLE
make concurrency gettable on TtlCache

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/TtlCache.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/TtlCache.java
@@ -61,6 +61,7 @@ public class TtlCache extends AbstractJmxCache implements TtlCacheMBean {
     private double safetyThreshold = 10d;
     
     private volatile long lastFetchError = 0;
+    private final int concurrency;
 
     public TtlCache(String label, TimeValue expiration, int cacheConcurrency, final InternalAPI internalAPI) {
         try {
@@ -111,11 +112,16 @@ public class TtlCache extends AbstractJmxCache implements TtlCacheMBean {
 
                     }
                 };
+        this.concurrency = cacheConcurrency;
         cache = CacheBuilder.newBuilder()
                 .expireAfterWrite(expiration.getValue(), expiration.getUnit())
-                .concurrencyLevel(cacheConcurrency)
+                .concurrencyLevel(concurrency)
                 .recordStats()
                 .build(loader);
+    }
+
+    public int getConcurrency() {
+        return concurrency;
     }
     
     // override this if you're not interested in caching the entire ttl map.


### PR DESCRIPTION
Makes concurrency exposed on TtlCache. Makes it easier to create threadpools that use it with a fixed number of threads equal to the cache concurrency.
