### PR TITLE
fix default value for elasticsearch_hosts to match expected format

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/ElasticIOConfig.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/ElasticIOConfig.java
@@ -17,7 +17,7 @@
 package com.rackspacecloud.blueflood.service;
 
 public enum ElasticIOConfig implements ConfigDefaults {
-    ELASTICSEARCH_HOSTS("127.0.0.1,9300"),
+    ELASTICSEARCH_HOSTS("127.0.0.1:9300"),
     ELASTICSEARCH_CLUSTERNAME("elasticsearch"),
     ELASTICSEARCH_NUM_INDICES("1");
 


### PR DESCRIPTION
blueflood-elasticsearch expects servers given in the ELASTICSEARCH_HOSTS list to be $ip:$port. Fix the default value.
