### PR TITLE
WIP : Load HTTP ingestion and query modules by default

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -28,8 +28,8 @@ public enum CoreConfig implements ConfigDefaults {
     ROLLUP_KEYSPACE("DATA"),
     CLUSTER_NAME("Test Cluster"),
 
-    INGESTION_MODULES(""),
-    QUERY_MODULES(""),
+    INGESTION_MODULES("com.rackspacecloud.blueflood.service.HttpIngestionService"),
+    QUERY_MODULES("com.rackspacecloud.blueflood.service.HttpQueryService"),
     DISCOVERY_MODULES(""),
     EVENT_LISTENER_MODULES(""),
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -58,8 +58,9 @@ public class ConfigurationTest {
     @Test
     public void testGetListProperty() {
         Configuration config = Configuration.getInstance();
-        Assert.assertEquals(config.getStringProperty(CoreConfig.QUERY_MODULES), "");
-        Assert.assertTrue(config.getListProperty(CoreConfig.QUERY_MODULES).isEmpty());
+        //Test the default query module
+        Assert.assertEquals(config.getStringProperty(CoreConfig.QUERY_MODULES), "com.rackspacecloud.blueflood.service.HttpQueryService");
+        //Override the default
         System.setProperty("QUERY_MODULES", "a");
         Assert.assertEquals(config.getListProperty(CoreConfig.QUERY_MODULES).size(), 1);
         System.setProperty("QUERY_MODULES", "a,b , c");


### PR DESCRIPTION
While I know the consequences of loading default ingestion and query services, IMO having them will lead to faster and easier way to play around with BF. In current setting, the user will supply the ingestion and query modules only when he wants to override these defaults. **This PR is up for discussion, whether this is really needed.**
