### PR TITLE
Fix intermittent test failure

### DIFF
--- a/blueflood-kafka/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/KafkaServiceTest.java
+++ b/blueflood-kafka/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/KafkaServiceTest.java
@@ -52,7 +52,7 @@ public class KafkaServiceTest {
         //Verify that the call method was called atleast once
         verify(kafkaServiceSpy, timeout(1000).atLeastOnce()).call(rollupEvent);
 
-        //Test whether executor actually executed a task
+        //Test whether executor got the task
         Assert.assertEquals(kafkaServiceSpy.getKafkaExecutorsUnsafe().getTaskCount(), 1);
         //Verify that there were interactions with the mock producer
         verify(mockProducer).send(anyListOf(KeyedMessage.class));


### PR DESCRIPTION
Submitting a task to the executor does not guarantee that it would be executed immediately. Sometimes the task might be still pending and the assert to check the completed task count might fail. Using the count of all the tasks ever scheduled will stop these intermittent failures.
