### PR TITLE
Refactor QueryStringDecoderAndRouter.

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/HTTPRequestWithDecodedQueryParams.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/HTTPRequestWithDecodedQueryParams.java
@@ -34,7 +34,6 @@ public class HTTPRequestWithDecodedQueryParams implements HttpRequest {
     }
 
     public static HTTPRequestWithDecodedQueryParams createHttpRequestWithDecodedQueryParams(DefaultHttpRequest request) {
-        final String uri = request.getUri();
         final QueryStringDecoder decoder = new QueryStringDecoder(request.getUri());
         request.setUri(decoder.getPath());
         return new HTTPRequestWithDecodedQueryParams(request, decoder.getParameters());

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/QueryStringDecoderAndRouter.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/QueryStringDecoderAndRouter.java
@@ -39,16 +39,7 @@ public class QueryStringDecoderAndRouter extends SimpleChannelUpstreamHandler {
         Object msg = e.getMessage();
         if (msg instanceof DefaultHttpRequest) {
             final DefaultHttpRequest request = (DefaultHttpRequest) msg;
-            final QueryStringDecoder decoder = new QueryStringDecoder(((HttpRequest) msg).getUri());
-
-            // Modify the original request headers with query parameters
-            if (decoder != null && !decoder.getParameters().isEmpty()) {
-                final HttpRequest requestWithParams =
-                        HTTPRequestWithDecodedQueryParams.createHttpRequestWithDecodedQueryParams(request);
-                router.route(ctx, requestWithParams);
-            } else {
-                router.route(ctx, request);
-            }
+            router.route(ctx, HTTPRequestWithDecodedQueryParams.createHttpRequestWithDecodedQueryParams(request));
         } else {
             log.error("Ignoring non HTTP message {}, from {}", e.getMessage(), e.getRemoteAddress());
             throw new Exception("Non-HTTP message from " + e.getRemoteAddress());


### PR DESCRIPTION
There were some unnecessary condition statements to check if decoder is null (which can never be null, as we are instantiating it in previous line of code) and redundant use of `QueryStringDecoder` in multiple places in both `QueryStringDecoderAndRouter` and `HTTPRequestWithDecodedQueryParams`. Refactored it to what i think will be optimized code.
