### PR TITLE
Rename TimerRollup.count_ps to TimerRollup.rate.

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/serializers/NumericSerializer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/serializers/NumericSerializer.java
@@ -242,7 +242,7 @@ public class NumericSerializer {
                 TimerRollup rollup = (TimerRollup)o;
                 sz += CodedOutputStream.computeRawVarint64Size(rollup.getSum());
                 sz += CodedOutputStream.computeRawVarint64Size(rollup.getCount());
-                sz += CodedOutputStream.computeDoubleSizeNoTag(rollup.getCountPS());
+                sz += CodedOutputStream.computeDoubleSizeNoTag(rollup.getRate());
                 sz += CodedOutputStream.computeRawVarint32Size(rollup.getSampleCount());
                 sz += sizeOf(rollup.getAverage(), Type.B_ROLLUP_STAT);
                 sz += sizeOf(rollup.getMaxValue(), Type.B_ROLLUP_STAT);
@@ -341,7 +341,7 @@ public class NumericSerializer {
         // sum, count, countps, avg, max, min, var
         out.writeRawVarint64(rollup.getSum());
         out.writeRawVarint64(rollup.getCount());
-        out.writeDoubleNoTag(rollup.getCountPS());
+        out.writeDoubleNoTag(rollup.getRate());
         out.writeRawVarint32(rollup.getSampleCount());
         putRollupStat(rollup.getAverage(), out);
         putRollupStat(rollup.getMaxValue(), out);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/TimerRollup.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/TimerRollup.java
@@ -13,7 +13,7 @@ import java.util.*;
 public class TimerRollup implements Rollup, IBasicRollup {
     private long sum = 0;
     private long count = 0;
-    private double count_ps = 0;
+    private double rate = 0;
 
     /**
      * Number of pre-aggregated timers received by Blueflood
@@ -45,7 +45,7 @@ public class TimerRollup implements Rollup, IBasicRollup {
     }
 
     public TimerRollup withCountPS(double count_ps) {
-        this.count_ps = count_ps;
+        this.rate = count_ps;
         return this;
     }
 
@@ -141,14 +141,15 @@ public class TimerRollup implements Rollup, IBasicRollup {
         
     }
     
-    public double getCountPS() { return count_ps; }
+    // per second rate.
+    public double getRate() { return rate; }
     public long getSum() { return sum; }
     public long getCount() { return count; };
     public int getSampleCount() { return sampleCount; }
     
     public String toString() {
-        return String.format("sum:%s, count_ps:%s, count:%s, min:%s, max:%s, avg:%s, var:%s, sample_cnt:%s, %s",
-                sum, count_ps, count, min, max, average, variance, sampleCount,
+        return String.format("sum:%s, rate:%s, count:%s, min:%s, max:%s, avg:%s, var:%s, sample_cnt:%s, %s",
+                sum, rate, count, min, max, average, variance, sampleCount,
                 Joiner.on(", ").withKeyValueSeparator(": ").join(percentiles.entrySet()));
     }
     
@@ -158,7 +159,7 @@ public class TimerRollup implements Rollup, IBasicRollup {
 
         if (other.sum != this.sum) return false;
         if (other.sampleCount != this.sampleCount) return false;
-        if (other.count_ps != this.count_ps) return false;
+        if (other.rate != this.rate) return false;
         if (!other.average.equals(this.average)) return false;
         if (!other.variance.equals(this.variance)) return false;
         if (!other.min.equals(this.min)) return false;
@@ -193,8 +194,8 @@ public class TimerRollup implements Rollup, IBasicRollup {
             
             // todo: put this calculation in a static method and write tests for it.
             long count = this.getCount() + rollup.getCount();
-            double time = Util.safeDiv((double) getCount(), this.count_ps) + Util.safeDiv((double) rollup.getCount(), rollup.count_ps);
-            this.count_ps = Util.safeDiv((double) count, time);
+            double time = Util.safeDiv((double) getCount(), this.rate) + Util.safeDiv((double) rollup.getCount(), rollup.rate);
+            this.rate = Util.safeDiv((double) count, time);
             
             // update fields.
             this.count += rollup.getCount();

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/TimerRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/TimerRollupTest.java
@@ -79,7 +79,7 @@ public class TimerRollupTest {
         assertRollupsAreClose(cumulativeBasicFromRaw, cumulativeTimer);
         assertRollupsAreClose(cumulativeBasicFromRollups, cumulativeTimer);
         
-        Assert.assertEquals(4.5d, cumulativeTimer.getCountPS());
+        Assert.assertEquals(4.5d, cumulativeTimer.getRate());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class TimerRollupTest {
             add(new Point<TimerRollup>(200, tr1));
         }});
         
-        Assert.assertEquals(4d/3d, cumulative.getCountPS());
+        Assert.assertEquals(4d/3d, cumulative.getRate());
     }
     
     private static final Collection<Number> longs = new ArrayList<Number>() {{


### PR DESCRIPTION
This distances us from statsD conventions, and makes more sense if for those who come upon the codebase without statsD exposure.
