### PR TITLE
Fix (another) intermittent test failure

### DIFF
--- a/blueflood-kafka/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/KafkaServiceTest.java
+++ b/blueflood-kafka/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/KafkaServiceTest.java
@@ -55,7 +55,7 @@ public class KafkaServiceTest {
         //Test whether executor got the task
         Assert.assertEquals(kafkaServiceSpy.getKafkaExecutorsUnsafe().getTaskCount(), 1);
         //Verify that there were interactions with the mock producer
-        verify(mockProducer).send(anyListOf(KeyedMessage.class));
+        verify(mockProducer, timeout(1000)).send(anyListOf(KeyedMessage.class));
 
         //Stop Kafka Production and test whether the listener object was removed
         kafkaServiceSpy.stopService();


### PR DESCRIPTION
We are testing, if the `send` method of the mock producer, gets called by submitting a RollupEvent to `KafkaService`. This happens in a `ThreadPoolExecutor`, so there is no guarantee, that the `send` method will be executed instantaneously.
Adding a timeout for verification, **might** solve this problem.
If it does not, I will increase the timeout OR remove this (over) test.
