### PR TITLE
Shutoff maven-javadoc-plugin's noisy logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <quiet>true</quiet>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
Logs which get generated by the maven javadoc plugin are noisy. They make it difficult to track the actual error which occurs in case of travis build failure. Adding a configuration flag of `<quiet>` to the plugin, will stop this redundant logging.
