### PR TITLE
Add type to Elastic search result

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -16,9 +16,7 @@
 
 package com.rackspacecloud.blueflood.io;
 
-import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.ElasticClientManager;
-import com.rackspacecloud.blueflood.service.ElasticIOConfig;
 import com.rackspacecloud.blueflood.service.RemoteElasticSearchServer;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Metric;
@@ -43,7 +41,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static com.rackspacecloud.blueflood.io.ElasticIO.ESFieldLabel.*;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
@@ -85,7 +82,8 @@ public class ElasticIO implements DiscoveryIO {
         String metricName = (String)source.get(METRIC_NAME.toString());
         String tenantId = (String)source.get(TENANT_ID.toString());
         String unit = (String)source.get(UNIT.toString());
-        Result result = new Result(tenantId, metricName, unit);
+        String type = (String)source.get(TYPE.toString());
+        Result result = new Result(tenantId, metricName, unit, type);
 
         return result;
     }
@@ -208,26 +206,36 @@ public class ElasticIO implements DiscoveryIO {
     public static class Result {
         private final String metricName;
         private final String unit;
+        private final String type;
         private final String tenantId;
 
-        public Result(String tenantId, String name, String unit) {
+        public Result(String tenantId, String name, String unit, String type) {
             this.tenantId = tenantId;
             this.metricName = name;
             this.unit = unit;
+            this.type = type;
         }
 
         public String getTenantId() {
             return tenantId;
         }
+
         public String getMetricName() {
             return metricName;
         }
+
         public String getUnit() {
             return unit;
         }
+
+        public String getType() {
+            return type;
+        }
+
         @Override
         public String toString() {
-            return "Result [tenantId=" + tenantId + ", metricName=" + metricName + ", unit=" + unit + "]";
+            return "Result [tenantId=" + tenantId + ", metricName=" + metricName
+                    + ", unit=" + unit + ", type=" + type + "]";
         }
 
         @Override
@@ -236,7 +244,7 @@ public class ElasticIO implements DiscoveryIO {
             int result = 1;
             result = prime * result
                     + ((metricName == null) ? 0 : metricName.hashCode());
-            result = prime * result + ((unit == null) ? 0 : unit.hashCode());
+            result = prime * result + ((unit == null) ? 0 : unit.hashCode()) + ((type == null) ? 0 : type.hashCode());
             return result;
         }
 
@@ -250,11 +258,13 @@ public class ElasticIO implements DiscoveryIO {
             }
             return equals((Result) obj);
         }
+
         public boolean equals(Result other) {
             if (this == other) {
                 return true;
             }
-            return metricName.equals(other.metricName) && unit.equals(other.unit) && tenantId.equals(other.tenantId);
+            return metricName.equals(other.metricName) && unit.equals(other.unit) && tenantId.equals(other.tenantId)
+                    && type.equals(other.type);
         }
     }
 }

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
@@ -43,13 +43,14 @@ public class ElasticIOTest {
     private static final String TENANT_A = "ratanasv";
     private static final String TENANT_B = "someotherguy";
     private static final String UNIT = "horse length";
+    private static final String TYPE = "number";
     private static final Map<String, List<Locator>> locatorMap = new HashMap<String, List<Locator>>();
     private ElasticIO elasticIO;
     private EsSetup esSetup;
 
     private static ElasticIO.Result createExpectedResult(String tenantId, int x, String y, int z) {
         Locator locator = createTestLocator(tenantId, x, y, z);
-        return new ElasticIO.Result(tenantId, locator.getMetricName(), UNIT);
+        return new ElasticIO.Result(tenantId, locator.getMetricName(), UNIT, TYPE);
     }
     private static Locator createTestLocator(String tenantId, int x, String y, int z) {
         String xs = (x < 10 ? "0" : "") + String.valueOf(x);
@@ -126,7 +127,7 @@ public class ElasticIOTest {
         List<Locator> locators = locatorMap.get(TENANT_A);
         Assert.assertEquals(locators.size(), results.size());
         for (Locator locator : locators) {
-            entry =  new ElasticIO.Result(TENANT_A, locator.getMetricName(), UNIT);
+            entry = new ElasticIO.Result(TENANT_A, locator.getMetricName(), UNIT, TYPE);
             Assert.assertTrue((results.contains(entry)));
         }
 


### PR DESCRIPTION
Looks like we index the metric type but we don't expose it in results. We need the type to be exposed. 
