### PR TITLE
hotfix null data

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -75,6 +75,9 @@ public class RollupHandler {
                     try {
                         MetricData data = AstyanaxReader.getInstance().getDatapointsForRange(locator, r, Granularity.FULL);
                         Points dataToRoll = data.getData();
+                        if (dataToRoll.isEmpty()) {
+                            continue;
+                        }
                         Rollup rollup = RollupHandler.rollupFromPoints(dataToRoll);
                         
                         if (rollup.hasData()) {


### PR DESCRIPTION
We need to figure out a better longterm solution, but this will work for now. When we call rollupFromPoints where points.isEmpty(), it throws an IllegalStateException. We should be able to build a Rollup object that represents that no data exists, not throw.
