### PR TITLE
Make rolling for granularities configurable

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -93,7 +93,14 @@ public enum CoreConfig implements ConfigDefaults {
     // Assume, for calculating granularity for GetByPoints queries, that data is sent at this interval.
     GET_BY_POINTS_ASSUME_INTERVAL("30000"),
     // valid options are: GEOMETRIC, LINEAR, and LESSTHANEQUAL
-    GET_BY_POINTS_GRANULARITY_SELECTION("GEOMETRIC");
+    GET_BY_POINTS_GRANULARITY_SELECTION("GEOMETRIC"),
+
+    //Granularities to rollup when rollup mode is enabled
+    METRICS_5M("true"),
+    METRICS_20M("true"),
+    METRICS_60M("true"),
+    METRICS_240M("true"),
+    METRICS_1440M("true");
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());


### PR DESCRIPTION
Adds configuration option for every metric granularity that we currently support, to make the rolling up for a particular granularity optional.
