### PR TITLE
Stop rolling up slots for which shard ownership has changed

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupService.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupService.java
@@ -200,6 +200,7 @@ public class RollupService implements Runnable, RollupServiceMBean {
             boolean rejected = false;
             while (context.hasScheduled() && !rejected && active) {
                 final String slotKey = context.getNextScheduled();
+                if (slotKey == null) { continue; }
                 try {
                     log.debug("Scheduling slotKey {} @ {}", slotKey, context.getCurrentTimeMillis());
                     locatorFetchExecutors.execute(new LocatorFetchRunnable(context, slotKey, rollupReadExecutors, rollupWriteExecutors));

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ScheduleContext.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ScheduleContext.java
@@ -188,8 +188,8 @@ public class ScheduleContext implements IngestionContext {
                     return key;
                 } else {
                     shardOwnershipChanged.mark();
+                    return null;
                 }
-                return null;
             }
         }
     }


### PR DESCRIPTION
If shard ownership has changed, trust that the node that owns the shard will roll it up.

If there is a delay between scheduling of a slot and running rollups for that slow, there is a potential for multiple nodes to be duplicating work.
