### PR TITLE
Maven3

### DIFF
--- a/blueflood-all/pom.xml
+++ b/blueflood-all/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>${blueflood.version}</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -50,43 +50,43 @@
     <dependency>
       <artifactId>blueflood-core</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <artifactId>blueflood-http</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <artifactId>blueflood-udp</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <artifactId>blueflood-elasticsearch</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <artifactId>blueflood-statsd</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <artifactId>blueflood-kafka</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <artifactId>blueflood-cloudfiles</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/blueflood-cloudfiles/pom.xml
+++ b/blueflood-cloudfiles/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>${blueflood.version}</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@
     <dependency>
       <artifactId>blueflood-core</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>${blueflood.version}</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>${blueflood.version}</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -42,7 +42,7 @@
     <dependency>
       <artifactId>blueflood-core</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>${blueflood.version}</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -127,7 +127,7 @@
     <dependency>
       <artifactId>blueflood-core</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/blueflood-kafka/pom.xml
+++ b/blueflood-kafka/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>${blueflood.version}</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -54,7 +54,7 @@
     <dependency>
       <artifactId>blueflood-core</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/blueflood-statsd/pom.xml
+++ b/blueflood-statsd/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>${blueflood.version}</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -26,7 +26,7 @@
     <dependency>
       <artifactId>blueflood-core</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
     
     <dependency>

--- a/blueflood-udp/pom.xml
+++ b/blueflood-udp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>${blueflood.version}</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -26,7 +26,7 @@
     <dependency>
       <artifactId>blueflood-core</artifactId>
       <groupId>com.rackspacecloud</groupId>
-      <version>${blueflood.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <artifactId>blueflood</artifactId>
   <name>Blueflood</name>
   <packaging>pom</packaging>
-  <version>${blueflood.version}</version>
+  <version>2.0.0-SNAPSHOT</version>
   <modules>
     <module>blueflood-core</module>
     <module>blueflood-udp</module>
@@ -41,7 +41,6 @@
   <url>http://blueflood.io</url>
 
   <properties>
-    <blueflood.version>2.0.0-SNAPSHOT</blueflood.version>
     <!-- Used to locate the profile specific configuration file. -->
     <build.profile.id>dev</build.profile.id>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Update our poms to fix all the warnings that maven3 gives off.

Changes made:
- Remove the blueflood-udp dependency from blueflood-all
- Add version to maven-javadoc-plugin
- Added MainClass config to manifest in uberjar. (allows you to start blueflod like: java -jar blueflood-uberjar.jar) (not a requirement for maven3, but I thought it was neat and probably useful to java newbies).
- Marked testing dependencies in blueflood-http as optional. (also not necessary for maven3, but should help make the uberjar a bit smaller).
- Got rid of blueflood.version.

About blueflood.version:
maven3 gave warnings about this, and said that support for the version being an expression may be dropped in future versions of maven. So to shut maven up, I used the same pattern that dropwizard uses: https://github.com/dropwizard/dropwizard/blob/master/dropwizard-configuration/pom.xml

We can use the `versions` maven plugin to update the versions in all our poms. Used like so: `mvn versions:set -DnewVersion=2.0.1-SNAPSHOT`.  That updates the parent pom and all child poms as well.
