### PR TITLE
Use the same version of metrics as the rest of BF

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandler.java
@@ -35,9 +35,8 @@ import com.rackspacecloud.blueflood.types.BatchMetricsQuery;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.outputs.utils.RollupsQueryParams;
 import com.rackspacecloud.blueflood.utils.TimeValue;
-import com.yammer.metrics.Metrics;
-import com.yammer.metrics.core.Timer;
-import com.yammer.metrics.core.TimerContext;
+import com.rackspacecloud.blueflood.utils.Metrics;
+import com.codahale.metrics.Timer;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.http.*;
@@ -54,8 +53,8 @@ public class HttpMultiRollupsQueryHandler implements HttpRequestHandler {
     private final BatchedMetricsOutputSerializer<JSONObject> serializer;
     private final Gson gson;           // thread-safe
     private final JsonParser parser;   // thread-safe
-    private final Timer httpBatchMetricsFetchTimer = Metrics.newTimer(HttpMultiRollupsQueryHandler.class,
-            "Handle HTTP batch request for metrics", TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+    private final Timer httpBatchMetricsFetchTimer = Metrics.timer(HttpMultiRollupsQueryHandler.class,
+            "Handle HTTP batch request for metrics");
     private final ThreadPoolExecutor executor;
     private final TimeValue queryTimeout;
     private final int maxMetricsPerRequest;
@@ -110,7 +109,7 @@ public class HttpMultiRollupsQueryHandler implements HttpRequestHandler {
 
         HTTPRequestWithDecodedQueryParams requestWithParams = (HTTPRequestWithDecodedQueryParams) request;
 
-        final TimerContext httpBatchMetricsFetchTimerContext = httpBatchMetricsFetchTimer.time();
+        final Timer.Context httpBatchMetricsFetchTimerContext = httpBatchMetricsFetchTimer.time();
         try {
             RollupsQueryParams params = PlotRequestParser.parseParams(requestWithParams.getQueryParams());
             BatchMetricsQuery query = new BatchMetricsQuery(locators, params.getRange(), params.getGranularity());

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
@@ -34,9 +34,8 @@ import com.rackspacecloud.blueflood.outputs.utils.PlotRequestParser;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.Resolution;
 import com.rackspacecloud.blueflood.outputs.utils.RollupsQueryParams;
-import com.yammer.metrics.Metrics;
-import com.yammer.metrics.core.Timer;
-import com.yammer.metrics.core.TimerContext;
+import com.rackspacecloud.blueflood.utils.Metrics;
+import com.codahale.metrics.Timer;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.http.*;
@@ -54,8 +53,8 @@ public class HttpRollupsQueryHandler extends RollupHandler
     private final BasicRollupsOutputSerializer<JSONObject> serializer;
     private final Gson gson;           // thread-safe
     private final JsonParser parser;   // thread-safe
-    private final Timer httpMetricsFetchTimer = Metrics.newTimer(HttpRollupsQueryHandler.class,
-            "Handle HTTP request for metrics", TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+    private final Timer httpMetricsFetchTimer = Metrics.timer(HttpRollupsQueryHandler.class,
+            "Handle HTTP request for metrics");
 
     public HttpRollupsQueryHandler() {
         this.serializer = new JSONBasicRollupsOutputSerializer();
@@ -119,7 +118,7 @@ public class HttpRollupsQueryHandler extends RollupHandler
 
         HTTPRequestWithDecodedQueryParams requestWithParams = (HTTPRequestWithDecodedQueryParams) request;
 
-        final TimerContext httpMetricsFetchTimerContext = httpMetricsFetchTimer.time();
+        final Timer.Context httpMetricsFetchTimerContext = httpMetricsFetchTimer.time();
         try {
             RollupsQueryParams params = PlotRequestParser.parseParams(requestWithParams.getQueryParams());
 


### PR DESCRIPTION
Discovered some classes metrics that were still using yammer metrics.

I upgraded these to codahale metrics 3. The file left that is still using yammer metrics is: blueflood-kafka/src/main/java/com/rackspacecloud/blueflood/utils/KafkaGraphiteReporter.java, though I understand that is intentional.
