### PR TITLE
Change the Cloud Files rollup exporter file name format

### DIFF
--- a/blueflood-cloudfiles/src/main/java/com/rackspacecloud/blueflood/outputs/cloudfiles/RollupFile.java
+++ b/blueflood-cloudfiles/src/main/java/com/rackspacecloud/blueflood/outputs/cloudfiles/RollupFile.java
@@ -18,6 +18,8 @@ package com.rackspacecloud.blueflood.outputs.cloudfiles;
 
 import com.rackspacecloud.blueflood.eventemitter.RollupEvent;
 import com.rackspacecloud.blueflood.outputs.serializers.RollupEventSerializer;
+import com.rackspacecloud.blueflood.service.CloudfilesConfig;
+import com.rackspacecloud.blueflood.service.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +68,7 @@ public class RollupFile implements Comparable {
     public String getRemoteName() {
         Date time = new Date(timestamp);
         String formattedTime = new SimpleDateFormat("yyyyMMdd_").format(time);
-        return formattedTime + System.currentTimeMillis() + "_" + System.getenv("HOSTNAME");
+        return formattedTime + System.currentTimeMillis() + "_" + Configuration.getInstance().getStringProperty(CloudfilesConfig.CLOUDFILES_HOST_UNIQUE_IDENTIFIER);
     }
 
     /**

--- a/blueflood-cloudfiles/src/main/java/com/rackspacecloud/blueflood/service/CloudfilesConfig.java
+++ b/blueflood-cloudfiles/src/main/java/com/rackspacecloud/blueflood/service/CloudfilesConfig.java
@@ -23,7 +23,8 @@ public enum CloudfilesConfig implements ConfigDefaults {
     CLOUDFILES_ZONE("IAD"),
     CLOUDFILES_MAX_BUFFER_AGE("3600000"), // 1000*60*60 = 60 minutes
     CLOUDFILES_MAX_BUFFER_SIZE("104857600"), // 1024*1024*100 = 100MB
-    CLOUDFILES_BUFFER_DIR("./CLOUDFILES_BUFFER");
+    CLOUDFILES_BUFFER_DIR("./CLOUDFILES_BUFFER"),
+    CLOUDFILES_HOST_UNIQUE_IDENTIFIER("bf-host");
 
     static {
         Configuration.getInstance().loadDefaults(CloudfilesConfig.values());


### PR DESCRIPTION
There might be some issues with the current export file format to Cloud Files leading to some files never being read. This is mainly because Cloud Files reads files lexicographically, so if a file falling later in the order gets written and read first, updating the last marker which the Cloud Files downloader maintains, files belonging before this file getting written later, might be completely ignored and never being read. Prepending the timestamp at which the file starts getting uploaded will solve this to the precision of 1 ms.
