### PR TITLE
upgrade elasticsearch to 1.1.0

### DIFF
--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>0.90.6</version>
+      <version>1.1.0</version>
     </dependency>
 
     <dependency>
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>com.github.tlrx</groupId>
       <artifactId>elasticsearch-test</artifactId>
-      <version>0.90.6</version>
+      <version>1.1.0</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
We should keep current with ES. Luckily the features we are using are so basic no code changes were required.
