### PR TITLE
Configure RiemannReporter prefix

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Metrics.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Metrics.java
@@ -83,6 +83,9 @@ public class Metrics {
                 if (!config.getStringProperty(CoreConfig.RIEMANN_LOCALHOST).isEmpty()) {
                     builder.localHost(config.getStringProperty(CoreConfig.RIEMANN_LOCALHOST));
                 }
+                if (!config.getStringProperty(CoreConfig.RIEMANN_PREFIX).isEmpty()) {
+                    builder.prefixedWith(config.getStringProperty(CoreConfig.RIEMANN_PREFIX));
+                }
                 if (!config.getStringProperty(CoreConfig.RIEMANN_TAGS).isEmpty()) {
                     builder.tags(config.getListProperty(CoreConfig.RIEMANN_TAGS));
                 }


### PR DESCRIPTION
We have a configuration option in BF to configure the RiemannReporter
prefix, but don't use it. Correcting that oversight...
