### PR TITLE
Implement Comparable inteface on Locator

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Locator.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Locator.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Locator {
+public class Locator implements Comparable<Locator> {
     private static final String metricTokenSeparator;
     private static final String metricTokenSeparatorRegex;
     private static final Logger log = LoggerFactory.getLogger(Locator.class);
@@ -75,7 +75,7 @@ public class Locator {
     public String getTenantId() {
         return this.tenantId;
     }
-    
+
     public String getMetricName() {
         return this.metricName;
     }
@@ -90,5 +90,10 @@ public class Locator {
 
     public static Locator createLocatorFromDbKey(String fullyQualifiedMetricName) throws IllegalArgumentException {
         return new Locator(fullyQualifiedMetricName);
+    }
+
+    @Override
+    public int compareTo(Locator o) {
+        return stringRep.compareTo(o.toString());
     }
 }


### PR DESCRIPTION
Implemented the Comparable inteface on Locator to fix a
ClassCastException error. Here's the full error:

```
java.lang.ClassCastException: com.rackspacecloud.blueflood.types.Locator cannot be cast to java.lang.Comparable
```

This occurred when using the contains method on some Set class to see if
the Locator was already present in the container.

Fixes batched reads in my dev environment. :)

7 little lines of code code to fix a problem that had all of us stumped all day. :)
