### PR TITLE
Http rollup type persistence threads

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -144,7 +144,11 @@ public class HttpMetricsIngestionServer {
                 new TimeValue(48, TimeUnit.HOURS),
                 Configuration.getInstance().getIntegerProperty(CoreConfig.MAX_ROLLUP_READ_THREADS));
         rollupTypeCacher = new RollupTypeCacher(
-                new ThreadPoolBuilder().withName("Rollup type persistence").build(),
+                new ThreadPoolBuilder()
+                        .withName("Rollup type persistence")
+                        .withCorePoolSize(Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_ROLLUP_TYPE_PERSISTENCE_THREADS))
+                        .withMaxPoolSize(Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_ROLLUP_TYPE_PERSISTENCE_THREADS))
+                        .build(),
                 rollupTypeCache,
                 true
         ).withLogger(log);

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpConfig.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpConfig.java
@@ -54,6 +54,7 @@ public enum HttpConfig implements ConfigDefaults {
     // metric and max metrics allowed per batch query.
     BATCH_QUERY_TIMEOUT("20"),  // 20s
 
+    HTTP_ROLLUP_TYPE_PERSISTENCE_THREADS("10"),
     TYPE_UNIT_PROCESSING_THREADS("10");
 
     static {


### PR DESCRIPTION
The rollup type persistence processor is a bottleneck. We need to be able to increase the number of threads given to that processor to be able to eliminate it.
