### PR TITLE
variable name indicates 'seconds' but is treated as 'millis' when used.

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -130,7 +130,7 @@ class LocatorFetchRunnable implements Runnable {
                 rollupBatchWriter.drainBatch(); // gets any remaining rollups enqueued for put. should be no-op after being called once
             }
             try {
-                Thread.currentThread().sleep(LOCATOR_WAIT_FOR_ALL_SECS);
+                Thread.currentThread().sleep(LOCATOR_WAIT_FOR_ALL_SECS * 1000);
             } catch (InterruptedException ex) {
                 if (log.isTraceEnabled())
                     log.trace("Woken wile waiting for rollups to coalesce for {} {}", parentSlotKey);


### PR DESCRIPTION
Fix by multiplying \* 1000 during sleep.
