### PR TITLE
Return 400 for decoding exceptions

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/QueryStringDecoderAndRouter.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/QueryStringDecoderAndRouter.java
@@ -16,13 +16,8 @@
 
 package com.rackspacecloud.blueflood.http;
 
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.ExceptionEvent;
-import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
-import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
-import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.QueryStringDecoder;
+import org.jboss.netty.channel.*;
+import org.jboss.netty.handler.codec.http.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,5 +44,9 @@ public class QueryStringDecoderAndRouter extends SimpleChannelUpstreamHandler {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) {
         log.warn("Exception event received: ", e.getCause());
+        // Exception received here is due to decoding errors, mostly due to bad requests
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST);
+        ChannelFuture f = ctx.getChannel().write(response);
+        f.addListener(ChannelFutureListener.CLOSE);
     }
 }


### PR DESCRIPTION
Netty does not send any response for exceptions occurred while decoding HTTP Query requests. https://gist.github.com/chinmay-gupte/c871758bdc24833136e3.
Fixed this and made it to send `400` for decoding exceptions and close the connection.
https://gist.github.com/chinmay-gupte/33c5a539357a20b0a914
