### PR TITLE
Handle long frames by return 400.

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/HttpResponder.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/HttpResponder.java
@@ -45,7 +45,7 @@ public class HttpResponder {
 
         // Send the response and close the connection if necessary.
         ChannelFuture f = ctx.getChannel().write(res);
-        if (!isKeepAlive(req)) {
+        if (req == null || !isKeepAlive(req)) {
             f.addListener(ChannelFutureListener.CLOSE);
         }
     }


### PR DESCRIPTION
Netty is weird in that in tries to create a message out of whatever is left in the buffer after I return the 400. Likely this is a problem of me not knowing how to do something right within netty, but I couldn't figure it out after a little searching.

We just squelch the empty message errors for now.
