### PR TITLE
add a coarse rate-limiting feature to migrations

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/tools/ops/Migration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/tools/ops/Migration.java
@@ -1,7 +1,5 @@
 package com.rackspacecloud.blueflood.tools.ops;
 
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Sets;
 import com.netflix.astyanax.AstyanaxContext;
 import com.netflix.astyanax.ColumnListMutation;


### PR DESCRIPTION
-rate columns_per_second

If you set it too small, the 30 second idle timer may shut things down. Just be aware of that.
