### PR TITLE
Dominic/no more linked blocking queue

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/concurrent/ThreadPoolBuilder.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/concurrent/ThreadPoolBuilder.java
@@ -104,8 +104,8 @@ public class ThreadPoolBuilder {
         }
         String metricName = name.subSequence(0, name.length() - 3) + " work queue size"; // don't need the '-%d'
         final BlockingQueue<Runnable> workQueue = this.queueSize > 0 ? new ArrayBlockingQueue<Runnable>(queueSize) :
-                    new LinkedBlockingQueue<Runnable>();
-        
+                    new SynchronousQueue<Runnable>();
+
         return new InstrumentedThreadPoolExecutor(
                 metricName,
                 corePoolSize,


### PR DESCRIPTION
Use `SynchronousQueue` instead of `LinkedBlockingQueue` in `ThreadPoolExecutor`. Discovered that `LinkedBlockingQueue` can't handle that many concurrent `get()`s.

So far `SynchronousQueue` has had better performance in my testing.
