### PR TITLE
memoize computeShard

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/processors/BatchWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/processors/BatchWriter.java
@@ -97,7 +97,7 @@ public class BatchWriter extends AsyncFunctionWithThreadPool<List<List<IMetric>>
                         
                         // marks this shard dirty, so rollup nodes know to pick up the work.
                         for (IMetric metric : batch) {
-                            context.update(metric.getCollectionTime(), Util.computeShard(metric.getLocator().toString()));
+                            context.update(metric.getCollectionTime(), Util.getShard(metric.getLocator().toString()));
                         }
                         
                         return true;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
@@ -132,7 +132,7 @@ public class AstyanaxWriter extends AstyanaxIO {
 
     // numeric only!
     private final void insertLocator(Locator locator, MutationBatch mutationBatch) {
-        mutationBatch.withRow(CassandraModel.CF_METRICS_LOCATOR, (long) Util.computeShard(locator.toString()))
+        mutationBatch.withRow(CassandraModel.CF_METRICS_LOCATOR, (long) Util.getShard(locator.toString()))
                 .putEmptyColumn(locator, LOCATOR_TTL);
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Util.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Util.java
@@ -16,6 +16,8 @@
 
 package com.rackspacecloud.blueflood.utils;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.rackspacecloud.blueflood.io.Constants;
 import org.apache.commons.codec.digest.DigestUtils;
 
@@ -23,10 +25,22 @@ import java.text.DecimalFormat;
 import java.text.Format;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
 public class Util {
     public static final String DEFAULT_DIMENSION = "default";
     public static final Format DECIMAL_FORMAT = new DecimalFormat("0.00");
+    private static final Cache<String, Integer> shardCache = CacheBuilder.newBuilder().expireAfterAccess(10,
+            TimeUnit.MINUTES).concurrencyLevel(30).build();
+
+    public static Integer getShard(String s) {
+        Integer shard = shardCache.getIfPresent(s);
+        if (shard == null) {
+            shard = computeShard(s);
+            shardCache.put(s, shard);
+        }
+        return shard;
+    }
 
     public static int computeShard(String s) {
         return (int)Long.parseLong(DigestUtils.md5Hex(s).substring(30), 16) % Constants.NUMBER_OF_SHARDS;


### PR DESCRIPTION
Part of calculating the md5sum is `MessageDigest.getInstance()`, which
is a blocking operation. Memoizing computeShard stops us from calling
this too often and is a massive speed up.
