### PR TITLE
Remove abort rejection handler from ingest pipeline

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -139,7 +139,6 @@ public class HttpMetricsIngestionServer {
                         .withCorePoolSize(WRITE_THREADS)
                         .withMaxPoolSize(WRITE_THREADS)
                         .withUnboundedQueue()
-                        .withRejectedHandler(new ThreadPoolExecutor.AbortPolicy())
                         .build(),
                 writer,
                 timeout,


### PR DESCRIPTION
We do not want to use the abort rejection handler on the batch writer.
This will discard writes if the incoming data starts to overwhelm the
batch writers, and we won't even be aware of it unless we look at the
logs.

We should use the default rejection handler which will still process the
data.
