### PR TITLE
Log rollup exception stacktraces

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -112,12 +112,12 @@ public class RollupRunnable implements Runnable {
                             AstyanaxReader.getUnitString(singleRollupReadContext.getLocator()),
                             singleRollupReadContext.getRollupGranularity().name(),
                             singleRollupReadContext.getRange().getStart()));
-        } catch (Throwable th) {
+        } catch (Exception e) {
             log.error("Rollup failed; Locator: {}, Source Granularity: {}, For period: {}", new Object[] {
                     singleRollupReadContext.getLocator(),
                     singleRollupReadContext.getRange().toString(),
                     srcGran.name(),
-                    th});
+                    e});
         } finally {
             executionContext.decrementReadCounter();
             timerContext.stop();


### PR DESCRIPTION
Rollups are failing in prod, and we need to find out exactly where they are failing. This isn't helpful:

```
2014-07-18 00:00:21,074 87975613 [pool-8-thread-66] ERROR com.rackspacecloud.blueflood.service.RollupRunnable  - Rollup failed; Locator: XXX, Source Granularity: metrics_full, Exception: java.lang.ClassCastExceptio
```

We need to do an audit of all our try{}catch{} and error logging statements to make sure we log the full stack trace when an exception occurs.

Changes:

Do not include exception in log template

```
Do not include exception in log string template or the stacktrace will
be lost.
```

Include the range that rollup failed on

```
Include the range that rollup failed on so one can find the data in the
db for debugging purposes.
```

Catch on Exception instead of Throwable

```
`Throwable` has 2 subclasses: `Exception` and `Error`. According to the
java docs, quote:

    An Error is a subclass of Throwable that indicates serious problems
    that a reasonable application should not try to catch.

http://docs.oracle.com/javase/7/docs/api/java/lang/Error.html
```
