### PR TITLE
Fix failing rollups

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/MinValue.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/MinValue.java
@@ -74,7 +74,7 @@ public class MinValue extends AbstractRollupStat {
             if (this.isFloatingPoint()) {
                 double doubleValOther = val.doubleValue();
                 if (this.toDouble()> doubleValOther) {
-                    this.setLongValue((Long)o);
+                    this.setLongValue(val);
                 }
             } else {
                 this.setLongValue(Math.min(this.toLong(), val));


### PR DESCRIPTION
Rollups are occasionally failing in prod because sometimes the var `o`
is an `Integer`, and we try to cast it to be a `Long`. Which fails
of course with a `ClassCastException` exception.

As just a couple lines above this bug `(Long) val` is created by turning
`o` into `Long` the correct way, I surmise this was a (freudian) typo.

NEEDS MORE LINT!
