### PR TITLE
Fix failing rollups

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/MaxValue.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/MaxValue.java
@@ -74,7 +74,7 @@ public class MaxValue extends AbstractRollupStat {
             if (this.isFloatingPoint()) {
                 double doubleValOther = val.doubleValue();
                 if (this.toDouble()< doubleValOther) {
-                    this.setLongValue((Long)o);
+                    this.setLongValue(val);
                 }
             } else {
                 this.setLongValue(Math.max(this.toLong(), val));


### PR DESCRIPTION
This is the same thing that was happening in the MinValue class:

Rollups are occasionally failing in prod because sometimes the var `o`
is an `Integer`, and we try to cast it to be a `Long`. Which fails
of course with a `ClassCastException` exception.

Same fix as in MinValue class: use `val` instead of `o`.
