### PR TITLE
Update ES metric document mapping

### DIFF
--- a/blueflood-elasticsearch/src/main/resources/metrics_mapping.json
+++ b/blueflood-elasticsearch/src/main/resources/metrics_mapping.json
@@ -4,30 +4,17 @@
             "required": true
         },
         "properties": {
-            "TENANT_ID": {
+            "tenantId": {
                 "type": "string",
                 "index": "not_analyzed"
             },
-            "TYPE": {
+            "unit": {
                 "type": "string",
                 "index": "not_analyzed"
             },
-            "UNIT": {
+            "metric_name": {
                 "type": "string",
                 "index": "not_analyzed"
-            },
-            "METRIC_NAME": {
-                "type": "multi_field",
-                "fields": {
-                    "RAW_METRIC_NAME": {
-                        "type": "string",
-                        "index": "not_analyzed"
-                    },
-                    "METRIC_NAME": {
-                        "type": "string",
-                        "index": "analyzed"
-                    }
-                }
             }
         }
     }


### PR DESCRIPTION
Update ES metric document mapping to match the layout we discussed
during metrics week:
- Use 'human' names - no all-upper case names.
- Ditch type - it is going away, and is only a single letter.
