### PR TITLE
NOT FOR MASTER: Add backwards compatible v1.0 endpoints 

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -99,9 +99,9 @@ public class HttpMetricsIngestionServer {
         
         RouteMatcher router = new RouteMatcher();
         router.get("/v1.0", new DefaultHandler());
-        router.post("/v1.0/:tenantId/ingest/multi", new HttpMultitenantMetricsIngestionHandler(defaultProcessorChain, timeout));
-        router.post("/v1.0/:tenantId/ingest", new HttpMetricsIngestionHandler(defaultProcessorChain, timeout));
-        router.post("/v1.0/:tenantId/ingest/aggregated", new HttpStatsDIngestionHandler(statsdProcessorChain, timeout));
+        router.post("/v1.0/multitenant/experimental/metrics", new HttpMultitenantMetricsIngestionHandler(defaultProcessorChain, timeout));
+        router.post("/v1.0/:tenantId/experimental/metrics", new HttpMetricsIngestionHandler(defaultProcessorChain, timeout));
+        router.post("/v1.0/:tenantId/experimental/metrics/statsd", new HttpStatsDIngestionHandler(statsdProcessorChain, timeout));
 
         router.get("/v2.0", new DefaultHandler());
         router.post("/v2.0/:tenantId/ingest/multi", new HttpMultitenantMetricsIngestionHandler(defaultProcessorChain, timeout));

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
@@ -48,9 +48,9 @@ public class HttpMetricDataQueryServer {
 
         RouteMatcher router = new RouteMatcher();
         router.get("/v1.0", new DefaultHandler());
-        router.get("/v1.0/:tenantId/views/:metricName", new HttpRollupsQueryHandler());
-        router.post("/v1.0/:tenantId/views", new HttpMultiRollupsQueryHandler());
-        router.get("/v1.0/:tenantId/views/histograms/:metricName", new HttpHistogramQueryHandler());
+        router.get("/v1.0/:tenantId/experimental/views/metric_data/:metricName", new HttpRollupsQueryHandler());
+        router.post("/v1.0/:tenantId/experimental/views/metric_data", new HttpMultiRollupsQueryHandler());
+        router.get("/v1.0/:tenantId/experimental/views/histograms/:metricName", new HttpHistogramQueryHandler());
 
         router.get("/v2.0", new DefaultHandler());
         router.get("/v2.0/:tenantId/views/:metricName", new HttpRollupsQueryHandler());


### PR DESCRIPTION
Though the request handlers will be same for v1.0 and v2.0, we need to support both the endpoints for an interim period of time.
