### PR TITLE
Adding the foundation for classifying TTLs into bins

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/ConfigTtlProvider.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/ConfigTtlProvider.java
@@ -166,7 +166,6 @@ public class ConfigTtlProvider implements TenantTtlProvider {
     }
 
     public TimeValue getConfigTTLForUserTTL(TimeValue userTTL) {
-
         for(TtlBin ttlBin : this.ttl_bins) {
             if(ttlBin.isTtlWithinBounds(userTTL))
             {
@@ -178,15 +177,40 @@ public class ConfigTtlProvider implements TenantTtlProvider {
     }
 
     private void initializeTtlBinsList() {
+        final Configuration config = Configuration.getInstance();
+
         this.ttl_bins = new ArrayList<TtlBin>();
 
-        ttl_bins.add(new TtlBin(new TimeValue(0,TimeUnit.SECONDS), new TimeValue(5,TimeUnit.SECONDS), new TimeValue(2,TimeUnit.DAYS)));
-        ttl_bins.add(new TtlBin(new TimeValue(5,TimeUnit.SECONDS), new TimeValue(15,TimeUnit.SECONDS),new TimeValue(7,TimeUnit.DAYS)));
-        ttl_bins.add(new TtlBin(new TimeValue(15,TimeUnit.SECONDS), new TimeValue(30,TimeUnit.SECONDS),new TimeValue(14,TimeUnit.DAYS)));
-        ttl_bins.add(new TtlBin(new TimeValue(30,TimeUnit.SECONDS), new TimeValue(5,TimeUnit.MINUTES), new TimeValue(31,TimeUnit.DAYS)));
-        ttl_bins.add(new TtlBin(new TimeValue(5,TimeUnit.MINUTES), new TimeValue(20,TimeUnit.MINUTES), new TimeValue(62,TimeUnit.DAYS)));
-        ttl_bins.add(new TtlBin(new TimeValue(20,TimeUnit.MINUTES), new TimeValue(1,TimeUnit.HOURS), new TimeValue(93,TimeUnit.DAYS)));
-        ttl_bins.add(new TtlBin(new TimeValue(1,TimeUnit.HOURS), new TimeValue(1,TimeUnit.DAYS),new TimeValue(186,TimeUnit.DAYS)));
-        ttl_bins.add(new TtlBin(new TimeValue(1,TimeUnit.DAYS), new TimeValue(Integer.MAX_VALUE,TimeUnit.DAYS),new TimeValue(Integer.MAX_VALUE,TimeUnit.DAYS)));
+        ttl_bins.add(new TtlBin(new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_LOWER_BOUND0),TimeUnit.SECONDS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_UPPER_BOUND0),TimeUnit.SECONDS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_0),TimeUnit.DAYS)));
+
+        ttl_bins.add(new TtlBin(new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_LOWER_BOUND1),TimeUnit.SECONDS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_UPPER_BOUND1),TimeUnit.SECONDS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_1),TimeUnit.DAYS)));
+
+        ttl_bins.add(new TtlBin(new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_LOWER_BOUND2),TimeUnit.SECONDS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_UPPER_BOUND2),TimeUnit.SECONDS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_2),TimeUnit.DAYS)));
+
+        ttl_bins.add(new TtlBin(new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_LOWER_BOUND3),TimeUnit.SECONDS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_UPPER_BOUND3),TimeUnit.MINUTES),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_3),TimeUnit.DAYS)));
+
+        ttl_bins.add(new TtlBin(new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_LOWER_BOUND4),TimeUnit.MINUTES),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_UPPER_BOUND4),TimeUnit.MINUTES),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_4),TimeUnit.DAYS)));
+
+        ttl_bins.add(new TtlBin(new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_LOWER_BOUND5),TimeUnit.MINUTES),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_UPPER_BOUND5),TimeUnit.HOURS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_5),TimeUnit.DAYS)));
+
+        ttl_bins.add(new TtlBin(new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_LOWER_BOUND6),TimeUnit.HOURS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_UPPER_BOUND6),TimeUnit.DAYS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_6),TimeUnit.DAYS)));
+
+        ttl_bins.add(new TtlBin(new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_LOWER_BOUND7),TimeUnit.DAYS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_BIN_UPPER_BOUND7),TimeUnit.DAYS),
+                new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_7),TimeUnit.DAYS)));
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/TtlConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/TtlConfig.java
@@ -52,7 +52,39 @@ public enum TtlConfig implements ConfigDefaults {
     TIMER_ROLLUPS_MIN20("60"), // 2 months
     TIMER_ROLLUPS_MIN60("90"), // 3 months
     TIMER_ROLLUPS_MIN240("180"), // 6 months
-    TIMER_ROLLUPS_MIN1440("365"); // 1 year
+    TIMER_ROLLUPS_MIN1440("365"), // 1 year
+
+    TTL_BIN_LOWER_BOUND0("0"), // 0 seconds
+    TTL_BIN_UPPER_BOUND0("5"), // 5 seconds
+    TTL_CONFIG_0("2"),  // 2 days
+
+    TTL_BIN_LOWER_BOUND1("5"), // 5 seconds
+    TTL_BIN_UPPER_BOUND1("15"), // 15 seconds
+    TTL_CONFIG_1("7"), //7 days
+
+    TTL_BIN_LOWER_BOUND2("15"), //15 seconds
+    TTL_BIN_UPPER_BOUND2("30"), //30 seconds
+    TTL_CONFIG_2("14"), //14 days
+
+    TTL_BIN_LOWER_BOUND3("30"), //30 seconds
+    TTL_BIN_UPPER_BOUND3("5"), //5 minutes
+    TTL_CONFIG_3("31"), //31 days
+
+    TTL_BIN_LOWER_BOUND4("5"), //5 min
+    TTL_BIN_UPPER_BOUND4("20"), //20 min
+    TTL_CONFIG_4("62"), //62 days
+
+    TTL_BIN_LOWER_BOUND5("20"), //20 min
+    TTL_BIN_UPPER_BOUND5("1"), //1 hr
+    TTL_CONFIG_5("93"), //93 days
+
+    TTL_BIN_LOWER_BOUND6("1"), // 1 hour
+    TTL_BIN_UPPER_BOUND6("1"), //1 day
+    TTL_CONFIG_6("186"), //186 days
+
+    TTL_BIN_LOWER_BOUND7("1"), //1 day
+    TTL_BIN_UPPER_BOUND7(Integer.toString(Integer.MAX_VALUE)), //max days
+    TTL_CONFIG_7(Integer.toString(Integer.MAX_VALUE)); //max days
 
     static {
         Configuration.getInstance().loadDefaults(TtlConfig.values());

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/cache/ConfigTtlProviderTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/cache/ConfigTtlProviderTest.java
@@ -63,44 +63,42 @@ public class ConfigTtlProviderTest {
 
     @Test
     public void configTTLForUserTTLReturnsExpectedValues() throws Exception {
-        //Bucket #1
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(0,TimeUnit.SECONDS),new TimeValue(2, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(4,TimeUnit.SECONDS),new TimeValue(2, TimeUnit.DAYS)));
+        final Configuration config = Configuration.getInstance();
 
+        //Bucket #1
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(0,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_0), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(4,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_0), TimeUnit.DAYS)));
 
         //Bucket #2
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(5,TimeUnit.SECONDS),new TimeValue(7, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(14,TimeUnit.SECONDS),new TimeValue(7, TimeUnit.DAYS)));
-
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(5,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_1), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(14,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_1), TimeUnit.DAYS)));
 
         //Bucket #3
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(15,TimeUnit.SECONDS),new TimeValue(14, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(29,TimeUnit.SECONDS),new TimeValue(14, TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(15,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_2), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(29,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_2), TimeUnit.DAYS)));
 
         //Bucket #4
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(30,TimeUnit.SECONDS),new TimeValue(31, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(270,TimeUnit.SECONDS),new TimeValue(31, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(299,TimeUnit.SECONDS),new TimeValue(31, TimeUnit.DAYS)));
-
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(30,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_3), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(270,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_3), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(299,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_3), TimeUnit.DAYS)));
 
         //Bucket #5
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(5,TimeUnit.MINUTES),new TimeValue(62, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(1100,TimeUnit.SECONDS),new TimeValue(62, TimeUnit.DAYS)));
-
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(5,TimeUnit.MINUTES),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_4), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(1100,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_4), TimeUnit.DAYS)));
 
         //Bucket #6
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(20,TimeUnit.MINUTES),new TimeValue(93, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(1700,TimeUnit.SECONDS),new TimeValue(93, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(59,TimeUnit.MINUTES),new TimeValue(93, TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(20,TimeUnit.MINUTES),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_5), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(1700,TimeUnit.SECONDS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_5), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(59,TimeUnit.MINUTES),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_5), TimeUnit.DAYS)));
 
         //Bucket #7
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(1,TimeUnit.HOURS),new TimeValue(186, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(14,TimeUnit.HOURS),new TimeValue(186, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(23,TimeUnit.HOURS),new TimeValue(186, TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(1,TimeUnit.HOURS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_6), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(14,TimeUnit.HOURS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_6), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(23,TimeUnit.HOURS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_6), TimeUnit.DAYS)));
 
         //Bucket #8
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(1,TimeUnit.DAYS),new TimeValue(Integer.MAX_VALUE, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(1000,TimeUnit.DAYS),new TimeValue(Integer.MAX_VALUE, TimeUnit.DAYS)));
-        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(999999,TimeUnit.HOURS),new TimeValue(Integer.MAX_VALUE, TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(1,TimeUnit.DAYS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_7), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(1000,TimeUnit.DAYS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_7), TimeUnit.DAYS)));
+        Assert.assertTrue(compareConfigTtlWithExpectedTtl(new TimeValue(999999,TimeUnit.HOURS),new TimeValue(config.getIntegerProperty(TtlConfig.TTL_CONFIG_7), TimeUnit.DAYS)));
     }
 }


### PR DESCRIPTION
https://gist.github.com/lakshmi-kannan/cfa272facce11c9dd26f
https://gist.github.com/tilogaat/44a4006f1750b4c92ecf

Based on the above gists, we want the ability to classify TTLs in separate bins. This PR adds code to ConfigTTLProvider to provide the infrastructure for binning. This infrastructure will be used by Ingestion and Rollups to bin the TTLs

2 points I'd like to get feedback about - 
- Check to see if the class TTLBins is in the appropriate place 
-  Check to see if the test adequately covers most of the cases 
