### PR TITLE
drop empty index batches.

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -82,6 +82,9 @@ public class ElasticIO implements DiscoveryIO {
     }
 
     public void insertDiscovery(List<Metric> batch) throws IOException {
+        if (batch.size() == 0) {
+            return;
+        }
         // TODO: check bulk insert result and retry
         BulkRequestBuilder bulk = client.prepareBulk();
         for (Metric metric : batch) {


### PR DESCRIPTION
ES did not like them being empty.
