### PR TITLE
Speed up Travis Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - openjdk7
 
 install:
-  - mvn install -Dmaven.test.skip -Dmaven.javadoc.skip
+  - mvn install dependency:resolve -Dmaven.test.skip -Dmaven.javadoc.skip
 
 script: 
   - mvn verify -Pcassandra-2.0 -Dmaven.javadoc.skip --quiet


### PR DESCRIPTION
- As a part of speeding up Blueflood open source tests, we are sticking to Cassandra 2.0 and giving up running tests on 1.1 and 1.2
- Fixing the Maven dependency resolution plugin
