### PR TITLE
Making AsyncChain typesafe

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/concurrent/AsyncChain.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/concurrent/AsyncChain.java
@@ -16,6 +16,8 @@
 
 package com.rackspacecloud.blueflood.concurrent;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -27,31 +29,64 @@ import java.util.List;
 /**
  * A light-weight abstraction that allows you to link AsyncFunction objects together.  apply() will end up invoking the
  * entire chain.  It is possible to create entire trees of functions with both synchronous and asynchronous parts.
- * 
- * todo: we need a way to validate that the first parameterized type on the first AsyncFunction is I and the last
- * parameterized type on the last AsyncFunction is O.
+ *
+ * <p>
+ *     Sample usage:
+ * <pre>
+ * <code>func = AsyncChain.withFunction(aToB).withFunction(bToC).withFunction(cToD).build();
+ * func.apply(a) // returns a future of D.
+ * </code>
+ * </p>
  */
 public class AsyncChain<I, O> implements AsyncFunction<I, O> {
-    private List<AsyncFunction> functions = new ArrayList<AsyncFunction>();
-    
-    public AsyncChain<I, O> withFunction(AsyncFunction func) {
-        functions.add(func);
-        return this;
+    private final ImmutableList<AsyncFunction<?, ?>> functions;
+
+    public AsyncChain(List<AsyncFunction<?, ?>> functions) {
+        this.functions = ImmutableList.copyOf(functions);
     }
-    
+
     public ListenableFuture<O> apply(I input) throws Exception {
-        List<AsyncFunction> copy = new ArrayList<AsyncFunction>(functions);
-        AsyncFunction func;
         ListenableFuture nextInput = new NoOpFuture<I>(input);
-        
-        while (copy.size() > 0) {
-            func = copy.remove(0);
+        for (AsyncFunction func : functions) {
             if (func instanceof AsyncFunctionWithThreadPool) {
-                nextInput = Futures.transform(nextInput, func, ((AsyncFunctionWithThreadPool)func).getThreadPool());    
+                nextInput = Futures.transform(nextInput, func, ((AsyncFunctionWithThreadPool)func).getThreadPool());
             } else {
                 nextInput = Futures.transform(nextInput, func, MoreExecutors.sameThreadExecutor());
             }
         }
         return nextInput;
+    }
+
+    /**
+     * Start the builder for a chain of async functions.
+     */
+    public static <A, B> Builder<A, B> withFunction(AsyncFunction<A, B> function) {
+        return new Builder<A, B>(function);
+    }
+
+    public static class Builder <A, B> {
+        private final List<AsyncFunction<?, ?>> functions;
+
+        private Builder(AsyncFunction<A, B> function) {
+            Preconditions.checkNotNull(function);
+            functions = new ArrayList<AsyncFunction<?, ?>>();;
+            functions.add(function);
+        }
+
+        private Builder(List<AsyncFunction<?, ?>> functions) {
+            Preconditions.checkNotNull(functions);
+            this.functions = functions;
+        }
+
+        public <C> Builder<A, C> withFunction(AsyncFunction<B, C> function) {
+            Preconditions.checkNotNull(function);
+            ArrayList<AsyncFunction<?, ?>> copy = new ArrayList<AsyncFunction<?, ?>>(this.functions);
+            copy.add(function);
+            return new Builder<A, C>(copy);
+        }
+
+        public AsyncChain<A, B> build() {
+            return new AsyncChain<A, B>(functions);
+        }
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/processors/DiscoveryWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/processors/DiscoveryWriter.java
@@ -26,15 +26,14 @@ import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.utils.Metrics;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadPoolExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DiscoveryWriter extends AsyncFunctionWithThreadPool<List<List<IMetric>>, List<List<IMetric>>> {
 
@@ -80,9 +79,9 @@ public class DiscoveryWriter extends AsyncFunctionWithThreadPool<List<List<IMetr
             }
         }
     }
-    
-    private static List<Object> condense(List<List<IMetric>> input) {
-        List<Object> willIndex = new ArrayList<Object>();
+
+    private static List<IMetric> condense(List<List<IMetric>> input) {
+        List<IMetric> willIndex = new ArrayList<IMetric>();
         for (List<IMetric> list : input) {
             // make mockito happy.
             if (list.size() == 0) {
@@ -101,8 +100,8 @@ public class DiscoveryWriter extends AsyncFunctionWithThreadPool<List<List<IMetr
     
     public ListenableFuture<Boolean> processMetrics(List<List<IMetric>> input) {
         // filter out the metrics that are current.
-        final List<Object> willIndex = DiscoveryWriter.condense(input);
-        
+        final List<IMetric> willIndex = DiscoveryWriter.condense(input);
+
         // process en masse.
         return getThreadPool().submit(new Callable<Boolean>() {
             @Override

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
@@ -1,8 +1,9 @@
 package com.rackspacecloud.blueflood.io;
 
+import com.rackspacecloud.blueflood.types.IMetric;
 import java.util.List;
 
 public interface DiscoveryIO {
-    public void insertDiscovery(List<Object> metrics) throws Exception;
+    public void insertDiscovery(List<IMetric> metrics) throws Exception;
     public List<SearchResult> search(String tenant, String query) throws Exception;
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/DiscoveryWriterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/DiscoveryWriterTest.java
@@ -4,6 +4,11 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.rackspacecloud.blueflood.concurrent.ThreadPoolBuilder;
 import com.rackspacecloud.blueflood.io.DiscoveryIO;
 import com.rackspacecloud.blueflood.types.IMetric;
+import com.rackspacecloud.blueflood.types.Metric;
+
+import com.rackspacecloud.blueflood.types.IMetric;
+import com.rackspacecloud.blueflood.types.Metric;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -39,7 +44,7 @@ public class DiscoveryWriterTest {
         testdata.add(mock(List.class));
         testdata.add(mock(List.class));
         
-        List<Object> flatTestData = new ArrayList<Object>();
+        List<IMetric> flatTestData = new ArrayList<IMetric>();
         for (List<IMetric> list : testdata) {
             if (list.size() == 0) continue;
             for (IMetric m : list) {

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.slf4j.Logger;
@@ -89,7 +90,7 @@ public class ElasticIO implements DiscoveryIO {
         return result;
     }
 
-    public void insertDiscovery(List<Object> batch) throws IOException {
+    public void insertDiscovery(List<IMetric> batch) throws IOException {
         batchHistogram.update(batch.size());
         if (batch.size() == 0) {
             return;
@@ -106,7 +107,6 @@ public class ElasticIO implements DiscoveryIO {
                 }
 
                 IMetric metric = (IMetric)obj;
-
                 Locator locator = metric.getLocator();
                 Discovery md = new Discovery(locator.getTenantId(), locator.getMetricName());
 

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
@@ -75,9 +75,9 @@ public class ElasticIOTest {
         return locators;
     }
 
-    private static List<Object> createTestMetrics(String tenantId) {
+    private static List<IMetric> createTestMetrics(String tenantId) {
         Metric metric;
-        List<Object> metrics = new ArrayList<Object>();
+        List<IMetric> metrics = new ArrayList<IMetric>();
         List<Locator> locators = createComplexTestLocators(tenantId);
         for (Locator locator : locators) {
             metric = new Metric(locator, "blarg", 0, new TimeValue(1, TimeUnit.DAYS), UNIT);
@@ -86,9 +86,9 @@ public class ElasticIOTest {
         return metrics;
     }
 
-    private static List<Object> createTestMetricsFromInterface(String tenantId) {
+    private static List<IMetric> createTestMetricsFromInterface(String tenantId) {
         IMetric metric;
-        List<Object> metrics = new ArrayList<Object>();
+        List<IMetric> metrics = new ArrayList<IMetric>();
         CounterRollup counter = new CounterRollup();
 
         List<Locator> locators = createComplexTestLocators(tenantId);

--- a/blueflood-udp/src/main/java/com/rackspacecloud/blueflood/service/udp/MainIngestor.java
+++ b/blueflood-udp/src/main/java/com/rackspacecloud/blueflood/service/udp/MainIngestor.java
@@ -61,18 +61,19 @@ public class MainIngestor {
     private static AsyncChain<DatagramPacket, ?> buildProcessor(ScheduleContext context) {
 
         // this will eventually take a UDP packet, deserialize it and put it to the database. Each w
-        AsyncChain<DatagramPacket, Object> processor = new AsyncChain<DatagramPacket, Object>()
+        AsyncChain<DatagramPacket, ?> processor =
 
                 // this stage deserializes the UDP datagrams. since the serialization is at our discretion (and
                 // your's too), it just matters that you are able to end up with a collection of
                 // com.rackspacecloud.blueflood.types.Metric.
-                .withFunction(new DeserializeAndReleaseFunc(new ThreadPoolBuilder().withName("Packet Deserializer").build()))
+                AsyncChain.withFunction(new DeserializeAndReleaseFunc(new ThreadPoolBuilder().withName("Packet Deserializer").build()))
 
                 // this this stage writes a single metrics to the database.
                 .withFunction(new SimpleMetricWriter(new ThreadPoolBuilder().withName("Database Writer").build()))
 
                 // this stage updates the context, which eventually gets push to the database.
-                .withFunction(new ContextUpdater(new ThreadPoolBuilder().withName("Context Updater").build(), context));
+                .withFunction(new ContextUpdater(new ThreadPoolBuilder().withName("Context Updater").build(), context))
+                .build();
 
         return processor;
     }

--- a/blueflood-udp/src/main/java/com/rackspacecloud/blueflood/service/udp/functions/ContextUpdater.java
+++ b/blueflood-udp/src/main/java/com/rackspacecloud/blueflood/service/udp/functions/ContextUpdater.java
@@ -7,13 +7,14 @@ import com.rackspacecloud.blueflood.service.ScheduleContext;
 import com.rackspacecloud.blueflood.types.Metric;
 import com.rackspacecloud.blueflood.utils.Util;
 
+import java.util.Collection;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * Simple demonstratin of a AsyncFunctionWithThreadPool that does not use its threadpool.  It does things on
  * whichever thread AsyncChain.apply() was called on.
  */
-public class ContextUpdater extends AsyncFunctionWithThreadPool<Metric, Metric> {
+public class ContextUpdater extends AsyncFunctionWithThreadPool<Collection<Metric>, Collection<Metric>> {
     
     private final ScheduleContext context;
     
@@ -23,9 +24,11 @@ public class ContextUpdater extends AsyncFunctionWithThreadPool<Metric, Metric> 
     }
 
     @Override
-    public ListenableFuture<Metric> apply(Metric input) throws Exception {
+    public ListenableFuture<Collection<Metric>> apply(Collection<Metric> input) throws Exception {
         // this is a quick operation, so do not use the threadpool.  Just do the work and return a NoOpFuture.
-        context.update(input.getCollectionTime(), Util.computeShard(input.getLocator().toString()));
-        return new NoOpFuture<Metric>(input);
+        for (Metric metric : input) {
+            context.update(metric.getCollectionTime(), Util.computeShard(metric.getLocator().toString()));
+        }
+        return new NoOpFuture<Collection<Metric>>(input);
     }
 }


### PR DESCRIPTION
Another no-op ish commit to clean up the code.

Made `AsyncChain` into a builder, that tracks the type of the function per addition so that the final composed result is indeed typesafe (Metric -> IMetric mostly).

I had to go around and plumb through the code to sprinkle the type parameter everywhere.

also use the iterator instead of copying the array - more idiomatic java, and this should make things a bit more efficient.
