### PR TITLE
Increase the number of results returned in the search results. 

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -161,7 +161,7 @@ public class ElasticIO implements DiscoveryIO {
                 );
         SearchResponse response = client.prepareSearch(INDEX_NAME)
                 .setRouting(tenant)
-                .setSize(500)
+                .setSize(100000)
                 .setVersion(true)
                 .setQuery(qb)
                 .execute()


### PR DESCRIPTION
It was 500. Make it 100000. For now.

We should consider changing the API signature to support paging. This would shake down all the way to the search endpoint.
