### PR TITLE
Change the cache expiration policy to reduce GC

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
@@ -68,7 +68,7 @@ public class AstyanaxWriter extends AstyanaxIO {
     
 
     // this collection is used to reduce the number of locators that get written.  Simply, if a locator has been
-    // written in the last 10 minutes, don't bother.
+    // seen within the last 10 minutes, don't bother.
     private static final Cache<String, Boolean> insertedLocators = CacheBuilder.newBuilder().expireAfterAccess(10,
             TimeUnit.MINUTES).concurrencyLevel(16).build();
 


### PR DESCRIPTION
The 'expireAfterWrite' expiration policy is causing excessive GC during
high load. Since we're going to be seeing the same things over and over
again, it is better to expire things from the cache when we stop seeing
it. This will reduce the amount of GC.
