### PR TITLE
Instrumenting threadpool more systematically

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/concurrent/AsyncFunctionWithThreadPool.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/concurrent/AsyncFunctionWithThreadPool.java
@@ -20,32 +20,30 @@ import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * Does asynchronous work using a specified threadpool.
- * @param <I>
- * @param <O>
+ * @param <I> function input type.
+ * @param <O> function output type.
  */
 public abstract class AsyncFunctionWithThreadPool<I, O> implements AsyncFunction<I, O> {
-    
     private final ThreadPoolExecutor executor;
-    // listieningExecutor wraps the above executor.
+    /** Wraps {@link #executor}.*/
     private final ListeningExecutorService listeningExecutor;
-    
     private Logger log = LoggerFactory.getLogger(getClass());
-    
+
     public AsyncFunctionWithThreadPool(ThreadPoolExecutor executor) {
         this.executor = executor;
         this.listeningExecutor = MoreExecutors.listeningDecorator(executor);
     }
     
-    public <I, O> AsyncFunctionWithThreadPool<I, O> withLogger(Logger log) {
+    public AsyncFunctionWithThreadPool<I, O> withLogger(Logger log) {
         this.log = log;
-        return (AsyncFunctionWithThreadPool<I,O>) this;
+        return this;
     }
     
     public ListeningExecutorService getThreadPool() { return listeningExecutor; }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupService.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupService.java
@@ -132,8 +132,7 @@ public class RollupService implements Runnable, RollupServiceMBean {
         // higher.
         Configuration config = Configuration.getInstance();
         final int locatorFetchConcurrency = config.getIntegerProperty(CoreConfig.MAX_LOCATOR_FETCH_THREADS);
-        locatorFetchExecutors = new InstrumentedThreadPoolExecutor(
-            "LocatorFetchThreadPool",
+        locatorFetchExecutors = new ThreadPoolExecutor(
             locatorFetchConcurrency, locatorFetchConcurrency,
             30, TimeUnit.SECONDS,
             new ArrayBlockingQueue<Runnable>(locatorFetchConcurrency * 5),
@@ -152,12 +151,13 @@ public class RollupService implements Runnable, RollupServiceMBean {
                 super.afterExecute(r, t);
             }
         };
+        InstrumentedThreadPoolExecutor.instrument(locatorFetchExecutors, "LocatorFetchThreadPool");
 
         // unbounded work queue.
         final BlockingQueue<Runnable> rollupReadQueue = new LinkedBlockingQueue<Runnable>();
 
-        rollupReadExecutors = new InstrumentedThreadPoolExecutor(
-            "RollupReadsThreadpool",
+        rollupReadExecutors = new ThreadPoolExecutor(
+            // "RollupReadsThreadpool",
             config.getIntegerProperty(CoreConfig.MAX_ROLLUP_READ_THREADS),
             config.getIntegerProperty(CoreConfig.MAX_ROLLUP_READ_THREADS),
             30, TimeUnit.SECONDS,
@@ -166,8 +166,8 @@ public class RollupService implements Runnable, RollupServiceMBean {
             new ThreadPoolExecutor.AbortPolicy()
         );
         final BlockingQueue<Runnable> rollupWriteQueue = new LinkedBlockingQueue<Runnable>();
-        rollupWriteExecutors = new InstrumentedThreadPoolExecutor(
-                "RollupWritesThreadpool",
+        rollupWriteExecutors = new ThreadPoolExecutor(
+                // "RollupWritesThreadpool",
                 config.getIntegerProperty(CoreConfig.MAX_ROLLUP_WRITE_THREADS),
                 config.getIntegerProperty(CoreConfig.MAX_ROLLUP_WRITE_THREADS),
                 30, TimeUnit.SECONDS,
@@ -175,6 +175,8 @@ public class RollupService implements Runnable, RollupServiceMBean {
                 Executors.defaultThreadFactory(),
                 new ThreadPoolExecutor.AbortPolicy()
         );
+        InstrumentedThreadPoolExecutor.instrument(rollupReadExecutors, "RollupReadsThreadpool");
+        InstrumentedThreadPoolExecutor.instrument(rollupWriteExecutors, "RollupWritesThreadpool");
     }
 
     public void forcePoll() {


### PR DESCRIPTION
This branches off https://github.com/rackerlabs/blueflood/pull/383 so it should be merged afterwards.

This PR changes `InstrumentedThreadPoolExecutor` dramatically. Instead of making it a subclass of `ThreadPoolExecutor`, the instrumentation is done via static method. this allows us to instrument any `ThreadPoolExecutor` free of class hierarchy pollution, and specifically allows us to use `ThreadPoolBuilder` more often.

I added default instrumentation to the `ThreadPoolBuilder`. this means that the all the threadpools within blueflood are instrumented by default, and exports coda hale metrics to whichever system it is exporting the metrics to.
