### PR TITLE
First pass at fixing NPEs while ingesting statsd metrics

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
@@ -101,12 +101,12 @@ public class PreaggregateConversions {
             TimerRollup rollup = new TimerRollup()
                     .withCount(timer.getCount().longValue())
                     .withSampleCount(1)
-                    .withAverage(resolveNumber(timer.getAvg()))
-                    .withMaxValue(resolveNumber(timer.getMax()))
-                    .withMinValue(resolveNumber(timer.getMin()))
-                    .withCountPS(timer.getRate().doubleValue())
-                    .withSum(timer.getSum().longValue()) // I wonder now if assuming sum instanceof Long is wrong.
-                    .withVariance(Math.pow(timer.getStd().doubleValue(), 2d));
+                    .withAverage(resolveNumber(timer.getAvg() == null ? 0.0d : timer.getAvg()))
+                    .withMaxValue(resolveNumber(timer.getMax() == null ? 0.0d : timer.getMax()))
+                    .withMinValue(resolveNumber(timer.getMin() == null ? 0.0d : timer.getMin()))
+                    .withCountPS(timer.getRate() == null ? 0.0d : timer.getRate().doubleValue())
+                    .withSum(timer.getSum() == null ? 0L : timer.getSum().longValue()) // I wonder now if assuming sum instanceof Long is wrong.
+                    .withVariance(Math.pow(timer.getStd() == null ? 0.0d : timer.getStd().doubleValue(), 2d));
             for (Map.Entry<String, Bundle.Percentile> entry : timer.getPercentiles().entrySet()) {
                 // throw away max and sum.
                 if (entry.getValue().getAvg() != null) {


### PR DESCRIPTION
Currently, we make an assumption that all the sub-metrics within a pre-aggregated statsd metric always exist. We are seeing data right now which makes us believe that this assumption is wrong. It might cause NPEs if some of sub-metrics are missing.
This is a quick fix, which will set the sub-metrics to 0s if they do not exist. I completely understand that this is not a permanent fix, but making changes to support non-existence of sub-metrics is a bit contrived and I will start working on it. Just getting this out there, so that we can continue ingesting statsd metrics without interruption.
