### PR TITLE
WIP: Metadata cache optimization

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/cache/MetadataCacheIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/cache/MetadataCacheIntegrationTest.java
@@ -33,6 +33,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import com.rackspacecloud.blueflood.utils.InMemoryMetadataIO;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -269,52 +270,7 @@ public class MetadataCacheIntegrationTest extends IntegrationTestBase {
         Assert.assertEquals("zzzzz", cache1.get(l1, "zee"));
     }
     
-    private static class InMemoryMetadataIO implements MetadataIO {
-        private final Table<Locator, String, String> backingTable = Tables.newCustomTable(
-            Maps.<Locator, Map<String, String>>newHashMap(),
-            new Supplier<Map<String, String>>() {
-                @Override
-                public Map<String, String> get() {
-                    return Maps.newHashMap();
-                }
-            }
-        );
-        
-        @Override
-        public void put(Locator locator, String key, String value) throws IOException {
-            backingTable.put(locator, key, value);
-        }
 
-        @Override
-        public Map<String, String> getAllValues(Locator locator) throws IOException {
-            return backingTable.row(locator);
-        }
-
-        @Override
-        public Table<Locator, String, String> getAllValues(Set<Locator> locators) throws IOException {
-            Table<Locator, String, String> results = HashBasedTable.create();
-
-            for (Locator locator : locators) {
-                Map<String, String> metaForLoc = backingTable.row(locator);
-                for (Map.Entry<String, String> meta : metaForLoc.entrySet()) {
-                    results.put(locator, meta.getKey(), meta.getValue());
-                }
-            }
-
-            return results;
-        }
-
-        @Override
-        public void putAll(Table<Locator, String, String> meta) throws IOException {
-            backingTable.putAll(meta);
-        }
-
-        @Override
-        public int getNumberOfRowsTest() throws IOException {
-            return backingTable.rowKeySet().size();
-        }
-    }
-    
     @Parameterized.Parameters
     public static Collection<Object[]> getIOs() {
         List<Object[]> ios = new ArrayList<Object[]>();

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxReaderIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxReaderIntegrationTest.java
@@ -22,12 +22,10 @@ import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.*;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public class AstyanaxReaderIntegrationTest extends IntegrationTestBase {
     

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxReaderIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxReaderIntegrationTest.java
@@ -127,7 +127,7 @@ public class AstyanaxReaderIntegrationTest extends IntegrationTestBase {
     @Test
     public void test_StringMetrics_WithoutMetadata_NotRetrieved() throws Exception {
         List<Locator> locatorList = new ArrayList<Locator>();
-        Metric metric = writeMetric("string_metric", "version 1.0.43342346");
+        Metric metric = writeMetric("string_metric_1", "version 1.0.43342346");
         locatorList.add(metric.getLocator());
 
         // Test batch reads

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
@@ -108,12 +108,16 @@ public class AstyanaxIO {
     }
 
     protected AbstractSerializer serializerFor(RollupType rollupType, DataType dataType, Granularity gran) {
-        if (dataType.equals(DataType.STRING)) {
-            return StringSerializer.get();
-        } else if (dataType.equals(DataType.BOOLEAN)) {
-            return BooleanSerializer.get();
-        } else {
+       try {
+           if (dataType.equals(DataType.STRING)) {
+               return StringSerializer.get();
+           } else if (dataType.equals(DataType.BOOLEAN)) {
+               return BooleanSerializer.get();
+           } else {
+               return NumericSerializer.serializerFor(RollupType.classOf(rollupType, gran));
+           }
+       } catch (Exception ex) {
            return NumericSerializer.serializerFor(RollupType.classOf(rollupType, gran));
-        }
+       }
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
@@ -108,16 +108,16 @@ public class AstyanaxIO {
     }
 
     protected AbstractSerializer serializerFor(RollupType rollupType, DataType dataType, Granularity gran) {
-       try {
-           if (dataType.equals(DataType.STRING)) {
-               return StringSerializer.get();
-           } else if (dataType.equals(DataType.BOOLEAN)) {
-               return BooleanSerializer.get();
-           } else {
-               return NumericSerializer.serializerFor(RollupType.classOf(rollupType, gran));
-           }
-       } catch (Exception ex) {
-           return NumericSerializer.serializerFor(RollupType.classOf(rollupType, gran));
-       }
+        if (dataType == null) {
+            return NumericSerializer.serializerFor(RollupType.classOf(rollupType, gran));
+        }
+
+        if (dataType.equals(DataType.STRING)) {
+            return StringSerializer.get();
+        } else if (dataType.equals(DataType.BOOLEAN)) {
+            return BooleanSerializer.get();
+        } else {
+            return NumericSerializer.serializerFor(RollupType.classOf(rollupType, gran));
+        }
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -43,7 +43,6 @@ import com.rackspacecloud.blueflood.types.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.crypto.Data;
 import java.io.IOException;
 import java.util.*;
 
@@ -335,7 +334,6 @@ public class AstyanaxReader extends AstyanaxIO {
             if (rollupType == null) {
                 rollupType = RollupType.BF_BASIC;
             }
-
             if (type == null) {
                 return getNumericOrStringRollupDataForRange(locator, range, gran, rollupType);
             }
@@ -372,11 +370,9 @@ public class AstyanaxReader extends AstyanaxIO {
             try {
                 RollupType rollupType = RollupType.fromString((String)
                             metaCache.get(locator, MetricMetadata.ROLLUP_TYPE.name().toLowerCase()));
-
                 if (rollupType == null) {
                     rollupType = RollupType.BF_BASIC;
                 }
-
                 //TODO: If we stop processing string and boolean, we can always hardcode this to numeric
                 DataType dataType = getDataType(locator, MetricMetadata.TYPE.name().toLowerCase());
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -222,7 +222,7 @@ public class AstyanaxReader extends AstyanaxIO {
         return columns == null ? new EmptyColumnList<Long>() : columns;
     }
 
-    private Map<Locator, ColumnList<Long>>  getColumnsFromDB(List<Locator> locators, ColumnFamily<Locator, Long> CF,
+    private Map<Locator, ColumnList<Long>> getColumnsFromDB(List<Locator> locators, ColumnFamily<Locator, Long> CF,
                                                             Range range) {
         if (range.getStart() > range.getStop()) {
             throw new RuntimeException(String.format("Invalid rollup range: ", range.toString()));

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -298,19 +298,6 @@ public class AstyanaxReader extends AstyanaxIO {
         return points;
     }
 
-    public static String getUnitString(Locator locator) {
-        String unitString = null;
-        try {
-            unitString = metaCache.get(locator, MetricMetadata.UNIT.name().toLowerCase(), String.class);
-        } catch (CacheException ex) {
-            log.warn("Cache exception reading unitString from MetadataCache: ", ex);
-        }
-        if (unitString == null) {
-            unitString = UNKNOWN;
-        }
-        return unitString;
-    }
-
     public static String getType(Locator locator) {
         String type = null;
         try {
@@ -411,7 +398,7 @@ public class AstyanaxReader extends AstyanaxIO {
 
         ColumnFamily cf = CassandraModel.getColumnFamily(HistogramRollup.class, granularity);
         Points<HistogramRollup> histogramRollupPoints = getDataToRoll(HistogramRollup.class, locator, range, cf);
-        return new MetricData(histogramRollupPoints, getUnitString(locator), MetricData.Type.HISTOGRAM);
+        return new MetricData(histogramRollupPoints, null, MetricData.Type.HISTOGRAM);
     }
 
     // Used for string metrics
@@ -428,7 +415,7 @@ public class AstyanaxReader extends AstyanaxIO {
             }
         }
 
-        return new MetricData(points, getUnitString(locator), MetricData.Type.STRING);
+        return new MetricData(points, null, MetricData.Type.STRING);
     }
 
     private MetricData getBooleanMetricDataForRange(Locator locator, Range range, Granularity gran) {
@@ -444,7 +431,7 @@ public class AstyanaxReader extends AstyanaxIO {
             }
         }
 
-        return new MetricData(points, getUnitString(locator), MetricData.Type.BOOLEAN);
+        return new MetricData(points, null, MetricData.Type.BOOLEAN);
     }
 
     // todo: replace this with methods that pertain to type (which can be used to derive a serializer).
@@ -466,7 +453,7 @@ public class AstyanaxReader extends AstyanaxIO {
             }
         }
 
-        return new MetricData(points, getUnitString(locator), MetricData.Type.NUMBER);
+        return new MetricData(points, null, MetricData.Type.NUMBER);
     }
 
     // gets called when we DO NOT know what the data type is (numeric, string, etc.)
@@ -489,7 +476,7 @@ public class AstyanaxReader extends AstyanaxIO {
             //TODO: if we stop processing string metrics, can we get this info from somewhere else?
             //Just return type numeric by default for now
             DataType dataType = getDataType(locator, dataTypeCacheKey);
-            String unit = getUnitString(locator);
+            String unit = null;
             MetricData.Type outputType = MetricData.Type.from(rollupType, dataType);
             Points points = getPointsFromColumns(columns, rollupType, dataType, gran);
             MetricData data = new MetricData(points, unit, outputType);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/CassandraModel.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/CassandraModel.java
@@ -12,6 +12,7 @@ import com.rackspacecloud.blueflood.service.SlotState;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 
+import javax.xml.crypto.Data;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -163,14 +164,12 @@ public class CassandraModel {
     }
 
     public static ColumnFamily getColumnFamily(RollupType type, DataType dataType, Granularity gran) {
+        if (dataType == null) {
+            dataType = DataType.INT;
+        }
 
-        try {
-            if (type == RollupType.BF_BASIC &&
-                    (dataType.equals(DataType.BOOLEAN) || dataType.equals(DataType.STRING))) {
-                return CF_METRICS_STRING;
-            }
-        } catch (Exception ex) {
-            return getColumnFamily(RollupType.classOf(type, gran), gran);
+        if (type == RollupType.BF_BASIC && (dataType.equals(DataType.BOOLEAN) || dataType.equals(DataType.STRING))) {
+            return CF_METRICS_STRING;
         }
 
         return getColumnFamily(RollupType.classOf(type, gran), gran);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/CassandraModel.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/CassandraModel.java
@@ -12,7 +12,6 @@ import com.rackspacecloud.blueflood.service.SlotState;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 
-import javax.xml.crypto.Data;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/CassandraModel.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/CassandraModel.java
@@ -163,9 +163,14 @@ public class CassandraModel {
     }
 
     public static ColumnFamily getColumnFamily(RollupType type, DataType dataType, Granularity gran) {
-        if (type == RollupType.BF_BASIC &&
-                (dataType.equals(DataType.BOOLEAN) || dataType.equals(DataType.STRING))) {
-            return CF_METRICS_STRING;
+
+        try {
+            if (type == RollupType.BF_BASIC &&
+                    (dataType.equals(DataType.BOOLEAN) || dataType.equals(DataType.STRING))) {
+                return CF_METRICS_STRING;
+            }
+        } catch (Exception ex) {
+            return getColumnFamily(RollupType.classOf(type, gran), gran);
         }
 
         return getColumnFamily(RollupType.classOf(type, gran), gran);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/MetricData.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/MetricData.java
@@ -61,19 +61,20 @@ public class MetricData {
         }
 
         public static Type from(RollupType rollupType, DataType dataType) {
-            try {
-                if (dataType.equals(DataType.STRING)) {
-                    return STRING;
-                } else if (dataType.equals(DataType.BOOLEAN)) {
-                    return BOOLEAN;
-                } else {
-                    if (rollupType == RollupType.BF_HISTOGRAMS) {
-                        return HISTOGRAM;
-                    }
+            // We no longer store datatype metadata for Numeric datatypes
+            if (dataType == null) {
+                return  NUMBER;
+            }
 
-                    return NUMBER;
+            if (dataType.equals(DataType.STRING)) {
+                return STRING;
+            } else if (dataType.equals(DataType.BOOLEAN)) {
+                return BOOLEAN;
+            } else {
+                if (rollupType == RollupType.BF_HISTOGRAMS) {
+                    return HISTOGRAM;
                 }
-            } catch (Exception ex) {
+
                 return NUMBER;
             }
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/MetricData.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/MetricData.java
@@ -61,15 +61,19 @@ public class MetricData {
         }
 
         public static Type from(RollupType rollupType, DataType dataType) {
-            if (dataType.equals(DataType.STRING)) {
-                return STRING;
-            } else if (dataType.equals(DataType.BOOLEAN)) {
-                return BOOLEAN;
-            } else {
-                if (rollupType == RollupType.BF_HISTOGRAMS) {
-                    return HISTOGRAM;
-                }
+            try {
+                if (dataType.equals(DataType.STRING)) {
+                    return STRING;
+                } else if (dataType.equals(DataType.BOOLEAN)) {
+                    return BOOLEAN;
+                } else {
+                    if (rollupType == RollupType.BF_HISTOGRAMS) {
+                        return HISTOGRAM;
+                    }
 
+                    return NUMBER;
+                }
+            } catch (Exception ex) {
                 return NUMBER;
             }
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/MetricData.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/MetricData.java
@@ -22,7 +22,7 @@ import com.rackspacecloud.blueflood.types.RollupType;
 
 public class MetricData {
     private final Points data;
-    private final String unit;
+    private String unit;
     private final Type type;
 
     public MetricData(Points points, String unit, Type type) {
@@ -35,8 +35,12 @@ public class MetricData {
         return data;
     }
 
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
     public String getUnit() {
-        return unit;
+        return this.unit;
     }
 
     public String getType() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
@@ -72,7 +72,6 @@ public class IncomingMetricMetadataAnalyzer {
             String existing = cache.get(locator, key, String.class);
 
             // always update the cache. it is smart enough to avoid needless writes.
-            //if (dataType.equals(DataType.STRING) }})
             cache.put(locator, key, incoming);
 
             boolean differs = existing != null && !incoming.equals(existing);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
@@ -22,10 +22,7 @@ import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.exceptions.IncomingMetricException;
 import com.rackspacecloud.blueflood.exceptions.IncomingTypeException;
 import com.rackspacecloud.blueflood.exceptions.IncomingUnitException;
-import com.rackspacecloud.blueflood.types.IMetric;
-import com.rackspacecloud.blueflood.types.Metric;
-import com.rackspacecloud.blueflood.types.MetricMetadata;
-import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,9 +49,12 @@ public class IncomingMetricMetadataAnalyzer {
         for (IMetric metric : metrics) {
             try {
                 if (metric instanceof Metric) {
-                    Collection<IncomingMetricException> metricProblems = checkMetric((Metric)metric);
-                    if (metricProblems != null) {
-                        problems.addAll(metricProblems);
+                    DataType datatype = ((Metric) metric).getDataType();
+                    if (datatype.equals(DataType.STRING) || datatype.equals(DataType.BOOLEAN)) {
+                        Collection<IncomingMetricException> metricProblems = checkMetric((Metric) metric);
+                        if (metricProblems != null) {
+                            problems.addAll(metricProblems);
+                        }
                     }
                 }
             } catch (CacheException ex) {
@@ -72,6 +72,7 @@ public class IncomingMetricMetadataAnalyzer {
             String existing = cache.get(locator, key, String.class);
 
             // always update the cache. it is smart enough to avoid needless writes.
+            //if (dataType.equals(DataType.STRING) }})
             cache.put(locator, key, incoming);
 
             boolean differs = existing != null && !incoming.equals(existing);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -23,6 +23,8 @@ import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.exceptions.GranularityException;
 import com.rackspacecloud.blueflood.io.AstyanaxReader;
 import com.rackspacecloud.blueflood.io.CassandraModel;
+import com.rackspacecloud.blueflood.io.DiscoveryIO;
+import com.rackspacecloud.blueflood.io.SearchResult;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.Metrics;
@@ -33,6 +35,7 @@ import com.rackspacecloud.blueflood.eventemitter.RollupEventEmitter;
 import com.rackspacecloud.blueflood.eventemitter.RollupEvent;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /** rolls up data into one data point, inserts that data point. */
@@ -52,6 +55,7 @@ public class RollupRunnable implements Runnable {
     private static final Timer calcTimer = Metrics.timer(RollupRunnable.class, "Read And Calculate Rollup");
     private static final Meter noPointsToCalculateRollup = Metrics.meter(RollupRunnable.class, "No points to calculate rollup");
     private static HashMap<Granularity, Meter> granToMeters = new HashMap<Granularity, Meter>();
+    public DiscoveryIO discoveryHandler = loadDiscoveryModule();
 
     static {
         for (Granularity rollupGranularity : Granularity.rollupGranularities()) {
@@ -65,7 +69,38 @@ public class RollupRunnable implements Runnable {
         this.rollupBatchWriter = rollupBatchWriter;
         startWait = System.currentTimeMillis();
     }
-    
+
+    private static DiscoveryIO loadDiscoveryModule() {
+        List<String> modules = Configuration.getInstance().getListProperty(CoreConfig.DISCOVERY_MODULES);
+
+        if (!modules.isEmpty() && modules.size() != 1) {
+            throw new RuntimeException("Cannot load query service with more than one discovery module");
+        }
+
+        ClassLoader classLoader = DiscoveryIO.class.getClassLoader();
+        for (String module : modules) {
+            log.info("Loading metric discovery module " + module);
+            try {
+                Class discoveryClass = classLoader.loadClass(module);
+                log.info("Registering metric discovery module " + module);
+                return (DiscoveryIO) discoveryClass.newInstance();
+            } catch (InstantiationException e) {
+                log.error("Unable to create instance of metric discovery class for: " + module, e);
+            } catch (IllegalAccessException e) {
+                log.error("Error starting metric discovery module: " + module, e);
+            } catch (ClassNotFoundException e) {
+                log.error("Unable to locate metric discovery module: " + module, e);
+            } catch (RuntimeException e) {
+                log.error("Error starting metric discovery module: " + module, e);
+            } catch (Throwable e) {
+                log.error("Error starting metric discovery module: " + module, e);
+            }
+        }
+
+        return null;
+    }
+
+
     public void run() {
         // done waiting.
         singleRollupReadContext.getWaitHist().update(System.currentTimeMillis() - startWait);
@@ -98,6 +133,11 @@ public class RollupRunnable implements Runnable {
             Rollup rollup = null;
             RollupType rollupType = RollupType.fromString((String) rollupTypeCache.get(
                     singleRollupReadContext.getLocator(), MetricMetadata.ROLLUP_TYPE.name().toLowerCase()));
+
+            if (rollupType == null) {
+                rollupType = RollupType.BF_BASIC;
+            }
+
             Class<? extends Rollup> rollupClass = RollupType.classOf(rollupType, srcGran.coarser());
             ColumnFamily<Locator, Long> srcCF = CassandraModel.getColumnFamily(rollupClass, srcGran);
             ColumnFamily<Locator, Long> dstCF = CassandraModel.getColumnFamily(rollupClass, srcGran.coarser());
@@ -121,11 +161,18 @@ public class RollupRunnable implements Runnable {
             rollupBatchWriter.enqueueRollupForWrite(new SingleRollupWriteContext(rollup, singleRollupReadContext, dstCF));
 
             RollupService.lastRollupTime.set(System.currentTimeMillis());
+
+            RollupEventEmitter ree = RollupEventEmitter.getInstance();
+
+            String unit = null;
+            if (ree.hasListeners(RollupEventEmitter.ROLLUP_EVENT_NAME)) {
+                unit = getUnits(singleRollupReadContext.getLocator().getTenantId(), singleRollupReadContext.getLocator().getMetricName());
+            }
+
             //Emit a rollup event to eventemitter
             RollupEventEmitter.getInstance().emit(RollupEventEmitter.ROLLUP_EVENT_NAME,
                     new RollupEvent(singleRollupReadContext.getLocator(), rollup,
-                            //TODO: Add units here
-                            null,
+                            unit,
                             singleRollupReadContext.getRollupGranularity().name(),
                             singleRollupReadContext.getRange().getStart()));
         } catch (Exception e) {
@@ -138,6 +185,21 @@ public class RollupRunnable implements Runnable {
             executionContext.decrementReadCounter();
             timerContext.stop();
         }
+    }
+
+    private String getUnits(String tenantId, String metricName) {
+        String unit = null;
+        try {
+            List<SearchResult> results = discoveryHandler.search(tenantId, metricName);
+            for (SearchResult res : results) {
+                unit = res.getUnit();
+                break;
+            }
+        } catch (Exception ex) {
+            log.info(ex.getMessage());
+        }
+
+        return unit;
     }
 
     // dertmine which DataType to use for serialization.

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -124,7 +124,8 @@ public class RollupRunnable implements Runnable {
             //Emit a rollup event to eventemitter
             RollupEventEmitter.getInstance().emit(RollupEventEmitter.ROLLUP_EVENT_NAME,
                     new RollupEvent(singleRollupReadContext.getLocator(), rollup,
-                            AstyanaxReader.getUnitString(singleRollupReadContext.getLocator()),
+                            //TODO: Add units here
+                            null,
                             singleRollupReadContext.getRollupGranularity().name(),
                             singleRollupReadContext.getRange().getStart()));
         } catch (Exception e) {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/IncomingMetricMetadataAnalyzerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/IncomingMetricMetadataAnalyzerTest.java
@@ -4,10 +4,7 @@ import com.rackspacecloud.blueflood.cache.MetadataCache;
 
 import com.rackspacecloud.blueflood.io.MetadataIO;
 import com.rackspacecloud.blueflood.service.IncomingMetricMetadataAnalyzer;
-import com.rackspacecloud.blueflood.types.IMetric;
-import com.rackspacecloud.blueflood.types.Locator;
-import com.rackspacecloud.blueflood.types.Metric;
-import com.rackspacecloud.blueflood.types.MetricMetadata;
+import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.InMemoryMetadataIO;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import junit.framework.Assert;
@@ -59,5 +56,24 @@ public class IncomingMetricMetadataAnalyzerTest {
 
         String unit = cache.get(locator, MetricMetadata.UNIT.name().toLowerCase());
         Assert.assertEquals("somethings", unit);
+    }
+
+    @Test
+    public void test_ScanMetricS_DoesNotStoreTypeAndUnit_ForPreaggregatedMetrics() throws  Exception {
+        MetadataCache cache = MetadataCache.createLoadingCacheInstance(new TimeValue(5, TimeUnit.MINUTES), 1);
+        cache.setIO(this.metadataIO);
+        IncomingMetricMetadataAnalyzer analyzer = new IncomingMetricMetadataAnalyzer(cache);
+
+        ArrayList<IMetric> metricsList = new ArrayList<IMetric>();
+
+        Locator locator = Locator.createLocatorFromDbKey("preag_counter");
+        metricsList.add(new PreaggregatedMetric(12300000, locator, new TimeValue(1, TimeUnit.DAYS), new CounterRollup()));
+
+        analyzer.scanMetrics(metricsList);
+        String type = cache.get(locator, MetricMetadata.TYPE.name().toLowerCase());
+        Assert.assertEquals(null, type);
+
+        String unit = cache.get(locator, MetricMetadata.UNIT.name().toLowerCase());
+        Assert.assertEquals(null, unit);
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/IncomingMetricMetadataAnalyzerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/IncomingMetricMetadataAnalyzerTest.java
@@ -19,7 +19,7 @@ public class IncomingMetricMetadataAnalyzerTest extends IntegrationTestBase{
 
     @Test
     public void test_ScanMetrics_DoesNotStoreTypeAndUnit_ForNumericMetrics() throws Exception {
-        MetadataCache cache = MetadataCache.getInstance();
+        MetadataCache cache = MetadataCache.createLoadingCacheInstance(new TimeValue(5, TimeUnit.MINUTES), 1);
         IncomingMetricMetadataAnalyzer analyzer = new IncomingMetricMetadataAnalyzer(cache);
 
         ArrayList<IMetric> metricsList = new ArrayList<IMetric>();
@@ -37,7 +37,7 @@ public class IncomingMetricMetadataAnalyzerTest extends IntegrationTestBase{
 
     @Test
     public void test_ScanMetricS_StoresTypeAndUnit_ForStringMetrics() throws  Exception {
-        MetadataCache cache = MetadataCache.getInstance();
+        MetadataCache cache = MetadataCache.createLoadingCacheInstance(new TimeValue(5, TimeUnit.MINUTES), 1);
         IncomingMetricMetadataAnalyzer analyzer = new IncomingMetricMetadataAnalyzer(cache);
 
         ArrayList<IMetric> metricsList = new ArrayList<IMetric>();

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/IncomingMetricMetadataAnalyzerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/IncomingMetricMetadataAnalyzerTest.java
@@ -1,0 +1,55 @@
+package com.rackspacecloud.blueflood.inputs.processors;
+
+import com.rackspacecloud.blueflood.cache.MetadataCache;
+import com.rackspacecloud.blueflood.exceptions.CacheException;
+import com.rackspacecloud.blueflood.io.IntegrationTestBase;
+import com.rackspacecloud.blueflood.service.IncomingMetricMetadataAnalyzer;
+import com.rackspacecloud.blueflood.types.IMetric;
+import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.types.Metric;
+import com.rackspacecloud.blueflood.types.MetricMetadata;
+import com.rackspacecloud.blueflood.utils.TimeValue;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+public class IncomingMetricMetadataAnalyzerTest extends IntegrationTestBase{
+
+    @Test
+    public void test_ScanMetrics_DoesNotStoreTypeAndUnit_ForNumericMetrics() throws Exception {
+        MetadataCache cache = MetadataCache.getInstance();
+        IncomingMetricMetadataAnalyzer analyzer = new IncomingMetricMetadataAnalyzer(cache);
+
+        ArrayList<IMetric> metricsList = new ArrayList<IMetric>();
+
+        Locator locator = Locator.createLocatorFromDbKey("integer_metric");
+        metricsList.add(getRandomIntMetric(locator, 1));
+
+        analyzer.scanMetrics(metricsList);
+        String type = cache.get(locator, MetricMetadata.TYPE.name().toLowerCase());
+        Assert.assertEquals(null, type);
+
+        String unit = cache.get(locator, MetricMetadata.UNIT.name().toLowerCase());
+        Assert.assertEquals(null, unit);
+    }
+
+    @Test
+    public void test_ScanMetricS_StoresTypeAndUnit_ForStringMetrics() throws  Exception {
+        MetadataCache cache = MetadataCache.getInstance();
+        IncomingMetricMetadataAnalyzer analyzer = new IncomingMetricMetadataAnalyzer(cache);
+
+        ArrayList<IMetric> metricsList = new ArrayList<IMetric>();
+
+        Locator locator = Locator.createLocatorFromDbKey("string_metric");
+        metricsList.add(getRandomStringmetric(locator, 1));
+
+        analyzer.scanMetrics(metricsList);
+        String type = cache.get(locator, MetricMetadata.TYPE.name().toLowerCase());
+        Assert.assertEquals("S", type);
+
+        String unit = cache.get(locator, MetricMetadata.UNIT.name().toLowerCase());
+        Assert.assertEquals("unknown", unit);
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/InMemoryMetadataIO.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/InMemoryMetadataIO.java
@@ -1,0 +1,60 @@
+package com.rackspacecloud.blueflood.utils;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
+import com.rackspacecloud.blueflood.io.MetadataIO;
+import com.rackspacecloud.blueflood.types.Locator;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+public class InMemoryMetadataIO implements MetadataIO {
+    public final Table<Locator, String, String> backingTable = Tables.newCustomTable(
+            Maps.<Locator, Map<String, String>>newHashMap(),
+            new Supplier<Map<String, String>>() {
+                @Override
+                public Map<String, String> get() {
+                    return Maps.newHashMap();
+                }
+            }
+    );
+
+    @Override
+    public void put(Locator locator, String key, String value) throws IOException {
+        backingTable.put(locator, key, value);
+    }
+
+    @Override
+    public Map<String, String> getAllValues(Locator locator) throws IOException {
+        return backingTable.row(locator);
+    }
+
+    @Override
+    public Table<Locator, String, String> getAllValues(Set<Locator> locators) throws IOException {
+        Table<Locator, String, String> results = HashBasedTable.create();
+
+        for (Locator locator : locators) {
+            Map<String, String> metaForLoc = backingTable.row(locator);
+            for (Map.Entry<String, String> meta : metaForLoc.entrySet()) {
+                results.put(locator, meta.getKey(), meta.getValue());
+            }
+        }
+
+        return results;
+    }
+
+    @Override
+    public void putAll(Table<Locator, String, String> meta) throws IOException {
+        backingTable.putAll(meta);
+    }
+
+    @Override
+    public int getNumberOfRowsTest() throws IOException {
+        return backingTable.rowKeySet().size();
+    }
+}
+

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -172,7 +172,7 @@ public class HttpMetricsIngestionServer {
 
         this.defaultProcessorChain = AsyncChain
                 .withFunction(typeAndUnitProcessor)
-                .withFunction(rollupTypeCacher)
+                //.withFunction(rollupTypeCacher)
                 .withFunction(batchSplitter)
                 .withFunction(discoveryWriter)
                 .withFunction(batchWriter)


### PR DESCRIPTION
Currently, Blueflood stores the following metadata for numeric and string metrics:
1. Type
2. Unit
3.  RollupType

However for numeric metrics, which is our most common use case, we do not want to store metadata information in the metadata cache and infer it automatically ie if type and rollup type are null, we assume a numeric type, Basic rollup type respectively. Units will be obtained from ElasticSearch. 
