### PR TITLE
Move cobertura to the top-level pom and configure it to generate aggregate results.

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -135,28 +135,6 @@
           </descriptorRefs>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.5.2</version>
-        <configuration>
-          <check />
-          <formats>
-            <format>xml</format>
-            <format>html</format>
-          </formats>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>cobertura</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
 
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,28 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <aggregate>true</aggregate>
+          <check />
+          <formats>
+            <format>xml</format>
+            <format>html</format>
+          </formats>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>cobertura</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Spin up Cassandra -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This makes

```console
$ mvn cobertura:cobertura -P all-modules
```

generate an aggregate coverage report at `target/site/cobertura/index.html`.