### PR TITLE
It's unsafe to mutate defaultResponse concurrently.

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/HttpResponder.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/HttpResponder.java
@@ -29,13 +29,8 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.setContentLength;
 import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 public class HttpResponder {
-    private static final DefaultHttpResponse defaultResponse = new DefaultHttpResponse(HTTP_1_1,
-            HttpResponseStatus.OK);
-
-
     public static void respond(ChannelHandlerContext ctx, HttpRequest req, HttpResponseStatus status) {
-        defaultResponse.setStatus(status);
-        respond(ctx, req, defaultResponse);
+        respond(ctx, req, new DefaultHttpResponse(HTTP_1_1, status));
     }
 
     public static void respond(ChannelHandlerContext ctx, HttpRequest req, HttpResponse res) {


### PR DESCRIPTION
I've replaced the unsafe mutation with a new instance for every call to respond.

There are no existing unit tests for any of this HTTP framework stuff, but there is an existing integration test that covers the changed code path.

Of course it doesn't actually test anything in a way that would help with a thread run order bug such as this.  I suspect findbugs would correctly identify it but I haven't tried configuring findbugs yet.

There are only 4 usages of this method though, 
 * DefaultHandler
 * NoRouteHandler
 * QueryStringDecoderAndRouter
 * UnsupportedVerbsHandler

So the impact of these changes is probably pretty minimal.
