### PR TITLE
Use bounded queue for metadata batch threadpool

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/MetadataCache.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/MetadataCache.java
@@ -141,7 +141,9 @@ public class MetadataCache extends AbstractJmxCache implements MetadataCacheMBea
         this.metaReads = new ConcurrentLinkedQueue<Locator>();
         this.readThreadPoolExecutor = new ThreadPoolBuilder().withCorePoolSize(batchedReadsPipelineLimit)
                 .withMaxPoolSize(batchedReadsPipelineLimit)
-                .withUnboundedQueue().withName("MetaBatchedReadsThreadPool").build();
+                .withBoundedQueue(Configuration.getInstance()
+                        .getIntegerProperty(CoreConfig.META_CACHE_BATCHED_READS_QUEUE_SIZE))
+                .withName("MetaBatchedReadsThreadPool").build();
 
         this.batchedReads = Configuration.getInstance().getBooleanProperty(
                 CoreConfig.META_CACHE_BATCHED_READS);
@@ -158,7 +160,9 @@ public class MetadataCache extends AbstractJmxCache implements MetadataCacheMBea
         this.outstandingMetaWrites = new ConcurrentSkipListSet<CacheKey>();
         this.writeThreadPoolExecutor = new ThreadPoolBuilder().withCorePoolSize(batchedWritesPipelineLimit)
                 .withMaxPoolSize(batchedWritesPipelineLimit)
-                .withUnboundedQueue().withName("MetaBatchedWritesThreadPool").build();
+                .withBoundedQueue(Configuration.getInstance()
+                        .getIntegerProperty(CoreConfig.META_CACHE_BATCHED_WRITES_QUEUE_SIZE))
+                .withName("MetaBatchedWritesThreadPool").build();
         this.metaWrites = new ConcurrentLinkedQueue<CacheKey>();
 
         if (batchedWrites) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/concurrent/ThreadPoolBuilder.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/concurrent/ThreadPoolBuilder.java
@@ -58,8 +58,13 @@ public class ThreadPoolBuilder {
         return this;
     }
 
-    public ThreadPoolBuilder withUnboundedQueue() {
+    public ThreadPoolBuilder withSynchronousQueue() {
         this.queueSize = 0;
+        return this;
+    }
+
+    public ThreadPoolBuilder withUnboundedQueue() {
+        this.queueSize = -1;
         return this;
     }
 
@@ -103,8 +108,15 @@ public class ThreadPoolBuilder {
     }
 
     public ThreadPoolExecutor build() {
-        final BlockingQueue<Runnable> workQueue = this.queueSize > 0 ? new ArrayBlockingQueue<Runnable>(queueSize) :
-                    new SynchronousQueue<Runnable>();
+        BlockingQueue<Runnable> workQueue;
+        switch (this.queueSize) {
+            case 0: workQueue = new SynchronousQueue<Runnable>();
+                break;
+            case -1: workQueue = new LinkedBlockingQueue<Runnable>();
+                break;
+            default: workQueue = new ArrayBlockingQueue<Runnable>(queueSize);
+                break;
+        };
 
         ThreadPoolExecutor executor = new ThreadPoolExecutor(
                 corePoolSize, maxPoolSize,

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -50,10 +50,12 @@ public enum CoreConfig implements ConfigDefaults {
     META_CACHE_BATCHED_READS_THRESHOLD("100"), // how many rows to read at a time? (batch size)
     META_CACHE_BATCHED_READS_TIMER_MS("10"),  // how often to read? (batch timer) (read faster than writes)
     META_CACHE_BATCHED_READS_PIPELINE_DEPTH("10"), // how many outstanding batches? (1 thread per batch).
+    META_CACHE_BATCHED_READS_QUEUE_SIZE("1000"),
 
     META_CACHE_BATCHED_WRITES_THRESHOLD("100"),  // how many meta columns to write at a time? (batch size)
     META_CACHE_BATCHED_WRITES_TIMER_MS("20"),   // how often to write? (batch timer)
     META_CACHE_BATCHED_WRITES_PIPELINE_DEPTH("10"), // how many outstanding batches? (1 thread per batch).
+    META_CACHE_BATCHED_WRITES_QUEUE_SIZE("1000"),
 
     // Maximum timeout waiting on exhausted connection pools in milliseconds.
     // Maps directly to Astyanax's ConnectionPoolConfiguration.setMaxTimeoutWhenExhausted

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/concurrent/ThreadPoolBuilderTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/concurrent/ThreadPoolBuilderTest.java
@@ -1,0 +1,34 @@
+package com.rackspacecloud.blueflood.concurrent;
+
+import junit.framework.TestCase;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class ThreadPoolBuilderTest extends TestCase {
+
+    public void testWithSynchronousQueue() throws Exception {
+        ThreadPoolExecutor tpe = new ThreadPoolBuilder()
+                .withSynchronousQueue()
+                .build();
+        assertEquals(SynchronousQueue.class, tpe.getQueue().getClass());
+    }
+
+    public void testWithUnboundedQueue() throws Exception {
+        ThreadPoolExecutor tpe = new ThreadPoolBuilder()
+                .withUnboundedQueue()
+                .build();
+        assertEquals(LinkedBlockingQueue.class, tpe.getQueue().getClass());
+    }
+
+    public void testWithBoundedQueue() throws Exception {
+        int queueSize = 70;
+        ThreadPoolExecutor tpe = new ThreadPoolBuilder()
+                .withBoundedQueue(queueSize)
+                .build();
+        assertEquals(ArrayBlockingQueue.class, tpe.getQueue().getClass());
+        assertEquals(queueSize, tpe.getQueue().remainingCapacity());
+    }
+}

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -143,7 +143,7 @@ public class HttpMetricsIngestionServer {
                         .withName("Metric Batch Writing")
                         .withCorePoolSize(WRITE_THREADS)
                         .withMaxPoolSize(WRITE_THREADS)
-                        .withUnboundedQueue()
+                        .withSynchronousQueue()
                         .build(),
                 writer,
                 timeout,


### PR DESCRIPTION
When `unboundedQueue` became an alias for `SynchronousQueue`, it
improved performance in asyncChain, and almost everywhere in blueflood.
Except for the metadata batch threadpool. This is one of those areas
where a large queue is required in order for work to build up. The more
work that builds up, the bigger the batches, the more efficient the meta
cache batch operations get.

This should speed up blueflood ramp up during cache loads.