### PR TITLE
Use JaCoCo to get combined unit and integration test coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - mvn verify -Pcassandra-2.0 -Dmaven.javadoc.skip --quiet
 
 after_success:
-  - mvn clean cobertura:cobertura coveralls:report
+  - mvn clean jacoco:report coveralls:report
 
 notifications:
   irc: "irc.freenode.net#blueflood"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - mvn verify -Pcassandra-2.0 -Dmaven.javadoc.skip --quiet
 
 after_success:
-  - mvn clean jacoco:report coveralls:report
+  - mvn clean jacoco:report jacoco:report-integration coveralls:report
 
 notifications:
   irc: "irc.freenode.net#blueflood"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - mvn verify -Pcassandra-2.0 -Dmaven.javadoc.skip --quiet
 
 after_success:
-  - mvn clean jacoco:report jacoco:report-integration coveralls:report
+  - mvn jacoco:report jacoco:report-integration coveralls:report
 
 notifications:
   irc: "irc.freenode.net#blueflood"

--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -101,6 +101,7 @@
               <!-- do not require zookeeper for these tests. -->
               <argLine>-DZOOKEEPER_CLUSTER=NONE</argLine>
               <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties</argLine>
+              <argLine>${jacoco.agent.it.argLine}</argLine>
               <!-- Skips integration tests if the value of skip.integration.tests property is true -->
               <skipTests>${skip.integration.tests}</skipTests>
               <includes>

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -41,6 +41,7 @@
       </testResource>
     </testResources>
 
+
     <plugins>
       <!-- Used to add source directories to our build. -->
       <plugin>
@@ -81,7 +82,7 @@
           <threadCount>5</threadCount>
         </configuration>
       </plugin>
-
+      
       <!-- Used for integration tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -103,6 +104,7 @@
               <!-- do not require zookeeper for these tests. -->
               <argLine>-DZOOKEEPER_CLUSTER=NONE</argLine>
               <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties</argLine>
+              <argLine>${jacoco.agent.it.argLine}</argLine>
               <!-- Skips integration tests if the value of skip.integration.tests property is true -->
               <skipTests>${skip.integration.tests}</skipTests>
               <includes>
@@ -118,7 +120,6 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,12 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>3.0.1</version>
+        <configuration>
+          <jacocoReports>
+            <jacocoReport>blueflood-core/target/site/jacoco-it/jacoco.xml</jacocoReport>
+            <jacocoReport>blueflood-http/target/site/jacoco-it/jacoco.xml</jacocoReport>
+          </jacocoReports>
+        </configuration>
       </plugin>
 
       <!-- Spin up Cassandra -->

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,21 @@
       </plugin>
 
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.3-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>2.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.3-SNAPSHOT</version>
+        <version>0.7.2.201409121644</version>
         <executions>
           <execution>
             <id>prepare-agent</id>
@@ -156,32 +156,19 @@
               <goal>prepare-agent</goal>
             </goals>
           </execution>
-        </executions>
-      </plugin>
-
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <aggregate>true</aggregate>
-          <check />
-          <formats>
-            <format>xml</format>
-            <format>html</format>
-          </formats>
-        </configuration>
-        <executions>
           <execution>
-            <phase>verify</phase>
+            <id>prepare-it-agent</id>
+            <phase>pre-integration-test</phase>
             <goals>
-              <goal>cobertura</goal>
+              <goal>prepare-agent-integration</goal>
             </goals>
+            <configuration>
+              <propertyName>jacoco.agent.it.argLine</propertyName>
+            </configuration>
           </execution>
         </executions>
       </plugin>
-
+      
       <plugin>
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
@@ -364,5 +351,4 @@
       <url>file://${basedir}/../maven/repo</url>
     </repository>
   </repositories>
-
 </project>


### PR DESCRIPTION
This tries to use jacoco to enable combined coverage reports of integration and unit tests across all modules.

It doesn't address cross-module coverage, so code that is uncovered in blueflood-core, but is executed when blueflood-http tests are run, is counted as uncovered.

This is strictly speaking correct as the coverage provided is accidental and illusory. However there is an issue to provide that functionality in https://github.com/jacoco/jacoco/pull/97

Since we're nowhere near enforcing 100% coverage it's probably fine to just wait until that is addressed.