### PR TITLE
Consolidating all DataTypes of all numeric metrics into a single NUMERIC datatype

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxReaderIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxReaderIntegrationTest.java
@@ -75,11 +75,11 @@ public class AstyanaxReaderIntegrationTest extends IntegrationTestBase {
         locatorList.add(metric.getLocator());
 
         metric = writeMetric("int_metric", 45);
-        MetadataCache.getInstance().put(metric.getLocator(), MetricMetadata.TYPE.name().toLowerCase(), DataType.INT.toString());
+        MetadataCache.getInstance().put(metric.getLocator(), MetricMetadata.TYPE.name().toLowerCase(), DataType.NUMERIC.toString());
         locatorList.add(metric.getLocator());
 
         metric = writeMetric("long_metric", 67L);
-        MetadataCache.getInstance().put(metric.getLocator(), MetricMetadata.TYPE.name().toLowerCase(), DataType.LONG.toString());
+        MetadataCache.getInstance().put(metric.getLocator(), MetricMetadata.TYPE.name().toLowerCase(), DataType.NUMERIC.toString());
         locatorList.add(metric.getLocator());
 
         // Test batch reads

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -460,7 +460,7 @@ public class AstyanaxReader extends AstyanaxIO {
     private MetricData getNumericOrStringRollupDataForRange(Locator locator, Range range, Granularity gran, RollupType rollupType) {
         Instrumentation.markScanAllColumnFamilies();
 
-        final MetricData metricData = getNumericMetricDataForRange(locator, range, gran, rollupType, DataType.DOUBLE);
+        final MetricData metricData = getNumericMetricDataForRange(locator, range, gran, rollupType, DataType.NUMERIC);
 
         if (metricData.getData().getPoints().size() > 0) {
             return metricData;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/DataType.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/DataType.java
@@ -32,20 +32,21 @@ public class DataType {
     public final static DataType DOUBLE = new DataType("D");
     public final static DataType BOOLEAN = new DataType("B");
     public final static DataType BIGINT = new DataType("BI");
+    public final static DataType NUMERIC = new DataType("N");
 
     public static DataType getMetricType(Object metricValue) {
         if (metricValue instanceof String) {
             return STRING;
         } else if (metricValue instanceof Integer) {
-            return INT;
+            return NUMERIC;
         } else if (metricValue instanceof Long) {
-            return LONG;
+            return NUMERIC;
         } else if (metricValue instanceof Double) {
-            return DOUBLE;
+            return NUMERIC;
         } else if (metricValue instanceof Boolean) {
             return BOOLEAN;
         } else if (metricValue instanceof BigInteger) {
-            return BIGINT;
+            return NUMERIC;
         } else {
             throw new RuntimeException("Unknown metric value type " + metricValue.getClass());
         }
@@ -53,7 +54,7 @@ public class DataType {
 
     public static boolean isNumericMetric(Object metricValue) {
         final DataType metricType = getMetricType(metricValue);
-        return metricType == DataType.INT || metricType == DataType.LONG || metricType == DataType.DOUBLE;
+        return metricType == DataType.NUMERIC;
     }
 
     public static boolean isStringMetric(Object metricValue) {
@@ -67,7 +68,7 @@ public class DataType {
     }
 
     public static boolean isKnownMetricType(DataType incoming) {
-        return incoming.equals(STRING) || incoming.equals(INT) || incoming.equals(LONG) || incoming.equals(DOUBLE)
+        return incoming.equals(STRING) || incoming.equals(NUMERIC)
                 || incoming.equals(BOOLEAN);
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/DataType.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/DataType.java
@@ -37,16 +37,10 @@ public class DataType {
     public static DataType getMetricType(Object metricValue) {
         if (metricValue instanceof String) {
             return STRING;
-        } else if (metricValue instanceof Integer) {
-            return NUMERIC;
-        } else if (metricValue instanceof Long) {
-            return NUMERIC;
-        } else if (metricValue instanceof Double) {
+        } else if (metricValue instanceof Number) {
             return NUMERIC;
         } else if (metricValue instanceof Boolean) {
             return BOOLEAN;
-        } else if (metricValue instanceof BigInteger) {
-            return NUMERIC;
         } else {
             throw new RuntimeException("Unknown metric value type " + metricValue.getClass());
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Metric.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Metric.java
@@ -50,14 +50,14 @@ public class Metric implements IMetric {
         // TODO: Until we start handling BigInteger throughout, let's try to cast it to double if the int value is less
         // than Double.MAX_VALUE
 
-        if (dataType == DataType.BIGINT) {
+        if (metricValue instanceof BigInteger) {
             BigDecimal maybeDouble = new BigDecimal((BigInteger) metricValue);
             if (maybeDouble.compareTo(DOUBLE_MAX) > 0) {
                 log.warn("BigInteger metric value " + ((BigInteger)metricValue).toString() + " for metric "
                         + locator.toString() + " is bigger than Double.MAX_VALUE");
                 throw new RuntimeException("BigInteger cannot be force cast to double as it exceeds Double.MAX_VALUE");
             }
-            this.dataType = DataType.DOUBLE;
+            this.dataType = DataType.NUMERIC;
             this.metricValue = ((BigInteger) metricValue).doubleValue();
         }
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/IMetricSerializerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/IMetricSerializerTest.java
@@ -23,6 +23,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
 
 public class IMetricSerializerTest {
@@ -109,5 +110,11 @@ public class IMetricSerializerTest {
         String reserialized = mapper.writeValueAsString(deserialized);
         Assert.assertEquals(metric, deserialized);
         Assert.assertEquals(serialized, reserialized);
+    }
+
+    @Test
+    public void testBigIntMetricConvertsIntoDouble() {
+        Metric metric = new Metric(goneIn, BigInteger.valueOf(12345l), 122345l,sixtySeconds,"bigguys");
+        Assert.assertTrue(metric.getMetricValue() instanceof Double);
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/MetricTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/MetricTest.java
@@ -37,20 +37,20 @@ public class MetricTest {
         Assert.assertTrue(DataType.isKnownMetricType(metric.getDataType()));
 
         metric = new Metric(locator, 1234567L, System.currentTimeMillis(), new TimeValue(5, TimeUnit.HOURS), "Unknown");
-        Assert.assertEquals("L", metric.getDataType().toString());
-        Assert.assertTrue(metric.getDataType().equals(DataType.LONG));
+        Assert.assertEquals("N", metric.getDataType().toString());
+        Assert.assertTrue(metric.getDataType().equals(DataType.NUMERIC));
         Assert.assertTrue("Metric should be numeric", metric.isNumeric());
         Assert.assertTrue(DataType.isKnownMetricType(metric.getDataType()));
 
         metric = new Metric(locator, 1234567.678, System.currentTimeMillis(), new TimeValue(5, TimeUnit.HOURS), "Unknown");
-        Assert.assertEquals("D", metric.getDataType().toString());
-        Assert.assertTrue(metric.getDataType().equals(DataType.DOUBLE));
+        Assert.assertEquals("N", metric.getDataType().toString());
+        Assert.assertTrue(metric.getDataType().equals(DataType.NUMERIC));
         Assert.assertTrue("Metric should be numeric", metric.isNumeric());
         Assert.assertTrue(DataType.isKnownMetricType(metric.getDataType()));
 
         metric = new Metric(locator, 1234567, System.currentTimeMillis(), new TimeValue(5, TimeUnit.HOURS), "Unknown");
-        Assert.assertEquals("I", metric.getDataType().toString());
-        Assert.assertTrue(metric.getDataType().equals(DataType.INT));
+        Assert.assertEquals("N", metric.getDataType().toString());
+        Assert.assertTrue(metric.getDataType().equals(DataType.NUMERIC));
         Assert.assertTrue("Metric should be numeric", metric.isNumeric());
         Assert.assertTrue(DataType.isKnownMetricType(metric.getDataType()));
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainerTest.java
@@ -53,7 +53,7 @@ public class JSONMetricsContainerTest {
         Assert.assertEquals(1234566, metricsCollection.get(0).getTtlInSeconds());
         Assert.assertEquals(1234567890L, metricsCollection.get(0).getCollectionTime());
         Assert.assertEquals("milliseconds", metricsCollection.get(0).getUnit());
-        Assert.assertEquals("L", metricsCollection.get(0).getDataType().toString());
+        Assert.assertEquals("N", metricsCollection.get(0).getDataType().toString());
 
         Assert.assertEquals("ac1.mzord.status", metricsCollection.get(1).getLocator().toString());
         Assert.assertEquals("Website is up", metricsCollection.get(1).getMetricValue());


### PR DESCRIPTION
Another smaller PR that is a part of the larger whole PR #412 

This PR gets rid of usages of the following DataTypes in bf-core:
- DataType.INT
- DataType.LONG
- DataType.Double
-DataType.Bigint

All these are replaced by a single data type - DataType.Numeric

The DataType value is used in blueflood-core, only for serializing/de-serializing String and Boolean metrics and does not serve any purpose for numeric metrics. However, for UDPSerialization it is required to deserialize the UDP datagram. 

This is the first step towards stopping caching of DataType information in the metadata cache
This PR is also a response to the review comments made here https://github.com/rackerlabs/blueflood/pull/412#discussion_r23191294. 