### PR TITLE
Add toggle for token aware load balancing to Cassandra

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
@@ -68,7 +68,10 @@ public class AstyanaxIO {
     private static AstyanaxConfigurationImpl createPreferredAstyanaxConfiguration() {
         AstyanaxConfigurationImpl astyconfig = new AstyanaxConfigurationImpl()
                 .setDiscoveryType(NodeDiscoveryType.NONE)
-                .setConnectionPoolType(ConnectionPoolType.ROUND_ROBIN);
+                .setConnectionPoolType(
+                        config.getBooleanProperty(CoreConfig.ENABLE_TOKEN_AWARE_ROUTING) ?
+                                ConnectionPoolType.TOKEN_AWARE :
+                                ConnectionPoolType.ROUND_ROBIN);
 
         int numRetries = config.getIntegerProperty(CoreConfig.CASSANDRA_MAX_RETRIES);
         if (numRetries > 0) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -24,6 +24,7 @@ public enum CoreConfig implements ConfigDefaults {
     DEFAULT_CASSANDRA_PORT("19180"),
     // This number is only accurate if MAX_CASSANDRA_CONNECTIONS is evenly divisible by number of hosts
     MAX_CASSANDRA_CONNECTIONS("75"),
+    ENABLE_TOKEN_AWARE_ROUTING("false"),
 
     ROLLUP_KEYSPACE("DATA"),
     CLUSTER_NAME("Test Cluster"),


### PR DESCRIPTION
Add toggle for token aware load balancing strategy to Cassandra in
Astyanax. This will allow us to bypass coordinator nodes and talk
directly to the node that owns the data.