### PR TITLE
[RFR] Add an option to grab units from ES

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEvent.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEvent.java
@@ -22,7 +22,7 @@ import com.rackspacecloud.blueflood.types.Rollup;
 public class RollupEvent {
     private final Locator locator;
     private final Rollup rollup;
-    private final String unit;
+    private String unit;
     private final String granularityName;
     //Rollup slot in millis
     private final long timestamp;
@@ -53,5 +53,9 @@ public class RollupEvent {
 
     public long getTimestamp() {
         return timestamp;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
@@ -16,12 +16,23 @@
 
 package com.rackspacecloud.blueflood.eventemitter;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
 import com.rackspacecloud.blueflood.concurrent.ThreadPoolBuilder;
+import com.rackspacecloud.blueflood.io.DiscoveryIO;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.BasicRollup;
+import com.rackspacecloud.blueflood.utils.QueryDiscoveryModuleLoader;
+import com.rackspacecloud.blueflood.utils.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.concurrent.*;
 
 public class RollupEventEmitter extends Emitter<RollupEvent> {
+    private static final Logger log = LoggerFactory.getLogger(QueryDiscoveryModuleLoader.class);
     private static final int numberOfWorkers = 5;
     public static final String ROLLUP_EVENT_NAME = "rollup".intern();
     private static ThreadPoolExecutor eventExecutors;
@@ -41,10 +52,30 @@ public class RollupEventEmitter extends Emitter<RollupEvent> {
     @Override
     public Future emit(final String event, final RollupEvent... eventPayload) {
         //TODO: This hack will go away after Kafka Serializer is made generic
-        if(eventPayload[0].getRollup() instanceof BasicRollup) {
+        if(eventPayload[0].getRollup() instanceof BasicRollup && super.hasListeners(ROLLUP_EVENT_NAME)) {
             return eventExecutors.submit(new Runnable() {
                 @Override
                 public void run() {
+                    if (Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) && Configuration.getInstance().getListProperty(CoreConfig.DISCOVERY_MODULES).contains(Util.ElasticIOPath)) {
+                        QueryDiscoveryModuleLoader.loadDiscoveryModule();
+                        final DiscoveryIO discoveryIO = QueryDiscoveryModuleLoader.getDiscoveryInstance();
+                        // TODO: Sync for now, but we will have to make it async eventually
+                        Lists.transform(Arrays.asList(eventPayload), new Function<RollupEvent, RollupEvent>() {
+                            @Override
+                            public RollupEvent apply(RollupEvent event) {
+                                String unit;
+
+                                try {
+                                    unit = discoveryIO.search(event.getLocator().getTenantId(), event.getLocator().getMetricName()).get(0).getUnit();
+                                } catch (Exception e) {
+                                    log.warn("Exception encountered while getting units out of ES : %s", e.getMessage());
+                                    unit = Util.UNKNOWN;
+                                }
+                                event.setUnit(unit);
+                                return event;
+                            }
+                        });
+                    }
                     RollupEventEmitter.super.emit(event, eventPayload);
                 }
             });

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -38,6 +38,8 @@ import com.rackspacecloud.blueflood.io.serializers.NumericSerializer;
 import com.rackspacecloud.blueflood.io.serializers.StringMetadataSerializer;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.SlotState;
 import com.rackspacecloud.blueflood.types.*;
 import org.slf4j.Logger;
@@ -300,14 +302,18 @@ public class AstyanaxReader extends AstyanaxIO {
 
     public static String getUnitString(Locator locator) {
         String unitString = null;
-        try {
-            unitString = metaCache.get(locator, MetricMetadata.UNIT.name().toLowerCase(), String.class);
-        } catch (CacheException ex) {
-            log.warn("Cache exception reading unitString from MetadataCache: ", ex);
+        // Only grab units from cassandra, if we have to
+        if (!Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS)) {
+            try {
+                unitString = metaCache.get(locator, MetricMetadata.UNIT.name().toLowerCase(), String.class);
+            } catch (CacheException ex) {
+                log.warn("Cache exception reading unitString from MetadataCache: ", ex);
+            }
+            if (unitString == null) {
+                unitString = UNKNOWN;
+            }
         }
-        if (unitString == null) {
-            unitString = UNKNOWN;
-        }
+
         return unitString;
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -38,8 +38,6 @@ import com.rackspacecloud.blueflood.io.serializers.NumericSerializer;
 import com.rackspacecloud.blueflood.io.serializers.StringMetadataSerializer;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
-import com.rackspacecloud.blueflood.service.Configuration;
-import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.SlotState;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.Util;
@@ -303,7 +301,7 @@ public class AstyanaxReader extends AstyanaxIO {
     public static String getUnitString(Locator locator) {
         String unitString = null;
         // Only grab units from cassandra, if we have to
-        if (!Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS)) {
+        if (!Util.shouldUseESForUnits()) {
             try {
                 unitString = metaCache.get(locator, MetricMetadata.UNIT.name().toLowerCase(), String.class);
             } catch (CacheException ex) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -42,6 +42,7 @@ import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.SlotState;
 import com.rackspacecloud.blueflood.types.*;
+import com.rackspacecloud.blueflood.utils.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +57,6 @@ public class AstyanaxReader extends AstyanaxIO {
     private static final String dataTypeCacheKey = MetricMetadata.TYPE.toString().toLowerCase();
 
     private static final Keyspace keyspace = getKeyspace();
-    private static final String UNKNOWN = "unknown";
 
     public static AstyanaxReader getInstance() {
         return INSTANCE;
@@ -310,7 +310,7 @@ public class AstyanaxReader extends AstyanaxIO {
                 log.warn("Cache exception reading unitString from MetadataCache: ", ex);
             }
             if (unitString == null) {
-                unitString = UNKNOWN;
+                unitString = Util.UNKNOWN;
             }
         }
 
@@ -325,7 +325,7 @@ public class AstyanaxReader extends AstyanaxIO {
             log.warn("Cache exception reading type from MetadataCache. ", ex);
         }
         if (type == null) {
-            type = UNKNOWN;
+            type = Util.UNKNOWN;
         }
         return type;
     }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
@@ -27,6 +27,7 @@ import com.rackspacecloud.blueflood.service.SingleRollupWriteContext;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.mockito.internal.util.reflection.Whitebox;
@@ -122,8 +123,8 @@ public class IntegrationTestBase {
         }
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterClass
+    public static void tearDown() throws Exception {
         // meh
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
@@ -123,8 +123,8 @@ public class IntegrationTestBase {
         }
     }
 
-    @AfterClass
-    public static void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         // meh
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
@@ -29,7 +29,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.mockito.internal.util.reflection.Whitebox;
-import org.omg.CORBA.UNKNOWN;
 
 import java.lang.reflect.Method;
 import java.util.*;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/MetricData.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/MetricData.java
@@ -22,7 +22,7 @@ import com.rackspacecloud.blueflood.types.RollupType;
 
 public class MetricData {
     private final Points data;
-    private final String unit;
+    private String unit;
     private final Type type;
 
     public MetricData(Points points, String unit, Type type) {
@@ -42,6 +42,8 @@ public class MetricData {
     public String getType() {
         return type.toString();
     }
+
+    public void setUnit(String unit) { this.unit = unit; }
 
     public enum Type {
         NUMBER("number"),

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -27,17 +27,15 @@ import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.*;
-import com.rackspacecloud.blueflood.utils.DiscoveryModuleLoader;
 import com.rackspacecloud.blueflood.utils.Metrics;
+import com.rackspacecloud.blueflood.utils.QueryDiscoveryModuleLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 public class RollupHandler {
@@ -51,7 +49,6 @@ public class RollupHandler {
     protected final Meter rollupsRepairEntireRangeEmpty = Metrics.meter(RollupHandler.class, "BF-API", "Rollups repaired - entire range - no data");
     protected final Meter rollupsRepairedLeftEmpty = Metrics.meter(RollupHandler.class, "BF-API", "Rollups repaired - left - no data");
     protected final Meter rollupsRepairedRightEmpty = Metrics.meter(RollupHandler.class, "BF-API", "Rollups repaired - right - no data");
-    protected final Timer metricsForCheckTimer = Metrics.timer(RollupHandler.class, "Get metrics for check");
     protected final Timer metricsFetchTimer = Metrics.timer(RollupHandler.class, "Get metrics from db");
     protected final Timer rollupsCalcOnReadTimer = Metrics.timer(RollupHandler.class, "Rollups calculation on read");
     protected final Histogram numFullPointsReturned = Metrics.histogram(RollupHandler.class, "Full res points returned");
@@ -77,7 +74,7 @@ public class RollupHandler {
 
                 @Override
                 public Object call() throws Exception {
-                    DiscoveryIO discoveryIO = DiscoveryModuleLoader.getDiscoveryInstance();
+                    DiscoveryIO discoveryIO = QueryDiscoveryModuleLoader.getDiscoveryInstance();
                     if (discoveryIO == null) {
                         log.warn("USE_ES_FOR_UNITS has been set to true, but no discovery module found." +
                                 " Please check your config");

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -70,7 +70,7 @@ public class RollupHandler {
         String unit = null;
         final Locator locator = Locator.createLocatorFromPathComponents(tenantId, metricName);
 
-        if (Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS)) {
+        if (Util.shouldUseESForUnits()) {
              unitFuture = Executors.newFixedThreadPool(1).submit(new Callable() {
 
                  @Override

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.service;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 
 import java.io.IOException;
@@ -112,5 +113,10 @@ public class Configuration {
         List<String> list = Lists.newArrayList(getStringProperty(name).split("\\s*,\\s*"));
         list.removeAll(Arrays.asList("", null));
         return list;
+    }
+
+    @VisibleForTesting
+    public void setProperty(String name, String val) {
+      props.setProperty(name, val);
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -139,7 +139,9 @@ public enum CoreConfig implements ConfigDefaults {
     // how long we typically wait to schedule a rollup.
     ROLLUP_DELAY_MILLIS("300000"),
     STRING_METRICS_DROPPED("false"),
-    TENANTIDS_TO_KEEP("");
+    TENANTIDS_TO_KEEP(""),
+
+    USE_ES_FOR_UNITS("false");
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
@@ -39,6 +39,7 @@ public class IncomingMetricMetadataAnalyzer {
     private static final Logger log = LoggerFactory.getLogger(IncomingMetricMetadataAnalyzer.class);
     private static Timer scanMetricsTimer = Metrics.timer(IncomingMetricMetadataAnalyzer.class, "Scan meta for metrics");
     private static Timer checkMetaTimer = Metrics.timer(IncomingMetricMetadataAnalyzer.class, "Check meta");
+    private static Configuration config = Configuration.getInstance();
 
     private final MetadataCache cache;
     
@@ -102,8 +103,8 @@ public class IncomingMetricMetadataAnalyzer {
         if (typeProblem != null) {
             problems.add(typeProblem);
         }
-        if (!Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) || !Configuration.getInstance().getListProperty(CoreConfig.DISCOVERY_MODULES).contains(Util.ElasticIOPath)) {
-            if (Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) && !Configuration.getInstance().getListProperty(CoreConfig.DISCOVERY_MODULES).contains(Util.ElasticIOPath))
+        if (!config.getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) || !config.getListProperty(CoreConfig.DISCOVERY_MODULES).contains(Util.ElasticIOPath)) {
+            if (config.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) && !config.getInstance().getListProperty(CoreConfig.DISCOVERY_MODULES).contains(Util.ElasticIOPath))
                 log.warn("USE_ES_FOR_UNITS config found but ES discovery module not found in the config, will use the metadata cache for units");
             IncomingMetricException unitProblem = checkMeta(metric.getLocator(), MetricMetadata.UNIT.name().toLowerCase(),
                     metric.getUnit());

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
@@ -27,6 +27,7 @@ import com.rackspacecloud.blueflood.types.Metric;
 import com.rackspacecloud.blueflood.types.MetricMetadata;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.utils.Metrics;
+import com.rackspacecloud.blueflood.utils.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,18 +99,18 @@ public class IncomingMetricMetadataAnalyzer {
 
         IncomingMetricException typeProblem = checkMeta(metric.getLocator(), MetricMetadata.TYPE.name().toLowerCase(),
                 metric.getDataType().toString());
-        if (!Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS)) {
+        if (typeProblem != null) {
+            problems.add(typeProblem);
+        }
+        if (!Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) || !Configuration.getInstance().getListProperty(CoreConfig.DISCOVERY_MODULES).contains(Util.ElasticIOPath)) {
+            if (Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) && !Configuration.getInstance().getListProperty(CoreConfig.DISCOVERY_MODULES).contains(Util.ElasticIOPath))
+                log.warn("USE_ES_FOR_UNITS config found but ES discovery module not found in the config, will use the metadata cache for units");
             IncomingMetricException unitProblem = checkMeta(metric.getLocator(), MetricMetadata.UNIT.name().toLowerCase(),
                     metric.getUnit());
             if (unitProblem != null) {
                 problems.add(unitProblem);
             }
         }
-
-        if (typeProblem != null) {
-            problems.add(typeProblem);
-        }
-
         return problems;
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
@@ -40,6 +40,8 @@ public class IncomingMetricMetadataAnalyzer {
     private static Timer scanMetricsTimer = Metrics.timer(IncomingMetricMetadataAnalyzer.class, "Scan meta for metrics");
     private static Timer checkMetaTimer = Metrics.timer(IncomingMetricMetadataAnalyzer.class, "Check meta");
     private static Configuration config = Configuration.getInstance();
+    private static boolean USE_ES_FOR_UNITS = config.getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS);
+    private static boolean ES_MODULE_FOUND = config.getListProperty(CoreConfig.DISCOVERY_MODULES).contains(Util.ElasticIOPath);
 
     private final MetadataCache cache;
     
@@ -103,8 +105,8 @@ public class IncomingMetricMetadataAnalyzer {
         if (typeProblem != null) {
             problems.add(typeProblem);
         }
-        if (!config.getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) || !config.getListProperty(CoreConfig.DISCOVERY_MODULES).contains(Util.ElasticIOPath)) {
-            if (config.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) && !config.getInstance().getListProperty(CoreConfig.DISCOVERY_MODULES).contains(Util.ElasticIOPath))
+        if (!USE_ES_FOR_UNITS || !ES_MODULE_FOUND) {
+            if (USE_ES_FOR_UNITS && !ES_MODULE_FOUND)
                 log.warn("USE_ES_FOR_UNITS config found but ES discovery module not found in the config, will use the metadata cache for units");
             IncomingMetricException unitProblem = checkMeta(metric.getLocator(), MetricMetadata.UNIT.name().toLowerCase(),
                     metric.getUnit());

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IncomingMetricMetadataAnalyzer.java
@@ -98,14 +98,16 @@ public class IncomingMetricMetadataAnalyzer {
 
         IncomingMetricException typeProblem = checkMeta(metric.getLocator(), MetricMetadata.TYPE.name().toLowerCase(),
                 metric.getDataType().toString());
-        IncomingMetricException unitProblem = checkMeta(metric.getLocator(), MetricMetadata.UNIT.name().toLowerCase(),
-                metric.getUnit());
+        if (!Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS)) {
+            IncomingMetricException unitProblem = checkMeta(metric.getLocator(), MetricMetadata.UNIT.name().toLowerCase(),
+                    metric.getUnit());
+            if (unitProblem != null) {
+                problems.add(unitProblem);
+            }
+        }
 
         if (typeProblem != null) {
             problems.add(typeProblem);
-        }
-        if (unitProblem != null) {
-            problems.add(unitProblem);
         }
 
         return problems;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Util.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Util.java
@@ -19,6 +19,8 @@ package com.rackspacecloud.blueflood.utils;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.rackspacecloud.blueflood.io.Constants;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import org.apache.commons.codec.digest.DigestUtils;
 
 import java.text.DecimalFormat;
@@ -82,4 +84,9 @@ public class Util {
     public static String ElasticIOPath = "com.rackspacecloud.blueflood.io.ElasticIO".intern();
 
     public static String UNKNOWN = "unknown".intern();
+
+    public static boolean shouldUseESForUnits() {
+        return Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) &&
+                Configuration.getInstance().getListProperty(CoreConfig.DISCOVERY_MODULES).contains(ElasticIOPath);
+    }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Util.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Util.java
@@ -78,4 +78,8 @@ public class Util {
         else
             return numerator / denominator;
     }
+
+    public static String ElasticIOPath = "com.rackspacecloud.blueflood.io.ElasticIO".intern();
+
+    public static String UNKNOWN = "unknown".intern();
 }

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -18,6 +18,7 @@ package com.rackspacecloud.blueflood.io;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
+import com.google.common.annotations.VisibleForTesting;
 import com.rackspacecloud.blueflood.service.ElasticClientManager;
 import com.rackspacecloud.blueflood.service.RemoteElasticSearchServer;
 import com.rackspacecloud.blueflood.types.IMetric;
@@ -60,7 +61,7 @@ public class ElasticIO implements DiscoveryIO {
     
     private static final Logger log = LoggerFactory.getLogger(DiscoveryIO.class);;
     private static final String ES_TYPE = "metrics";
-    private final Client client;
+    private Client client;
     
     // todo: these should be instances per client.
     private final Timer searchTimer = Metrics.timer(ElasticIO.class, "Search Duration");
@@ -124,7 +125,6 @@ public class ElasticIO implements DiscoveryIO {
         } finally {
             ctx.stop();
         }
-        
     }
 
     private static String getUnit(Metric metric) {
@@ -225,5 +225,10 @@ public class ElasticIO implements DiscoveryIO {
             json = json.endObject();
             return json;
         }
+    }
+
+    @VisibleForTesting
+    public void setClient(Client client) {
+        this.client = client;
     }
 }

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -132,6 +132,12 @@
     </dependency>
 
     <dependency>
+      <artifactId>blueflood-elasticsearch</artifactId>
+      <groupId>com.rackspacecloud</groupId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
       <version>4.0.8.Final</version>

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -190,6 +190,14 @@
       <optional>true</optional>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.tlrx</groupId>
+      <artifactId>elasticsearch-test</artifactId>
+      <version>1.1.0</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
@@ -258,5 +258,6 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
     @AfterClass
     public static void shutdown() {
         vendor.shutdown();
+        httpQueryService.stopService();
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
@@ -57,7 +57,8 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
     private static DefaultHttpClient client;
 
     private HttpRollupsQueryHandler httpHandler;
-    private final Map<Locator, Map<Granularity, Integer>> answers = new HashMap<Locator, Map<Granularity,Integer>>();
+    private final Map<Locator, Map<Granularity, Integer>> locatorToPoints = new HashMap<Locator, Map<Granularity,Integer>>();
+    private final Map<Locator, String> locatorToUnit = new HashMap<Locator, String>();
 
     @BeforeClass
     public static void setUpHttp() {
@@ -115,8 +116,8 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
         answerForStringMetric.put(Granularity.MIN_240, 1440);
         answerForStringMetric.put(Granularity.MIN_1440, 1440);
 
-        answers.put(locators[0], answerForNumericMetric);
-        answers.put(locators[1], answerForStringMetric);
+        locatorToPoints.put(locators[0], answerForNumericMetric);
+        locatorToPoints.put(locators[1], answerForStringMetric);
     }
 
     @Test
@@ -136,7 +137,7 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
         points.put(Granularity.MIN_240, 5);
         points.put(Granularity.MIN_1440, 1);
 
-        testHTTPRollupHandlerGetByPoints(answers, points, baseMillis, baseMillis + 86400000);
+        testHTTPRollupHandlerGetByPoints(locatorToPoints, points, baseMillis, baseMillis + 86400000);
     }
 
     private void testGetRollupByResolution() throws Exception {
@@ -144,7 +145,7 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
             for (Resolution resolution : Resolution.values()) {
                 Granularity g = Granularity.granularities()[resolution.getValue()];
                 testHTTPHandlersGetByResolution(locator, resolution, baseMillis, baseMillis + 86400000,
-                        answers.get(locator).get(g));
+                        locatorToPoints.get(locator).get(g));
             }
         }
     }
@@ -160,6 +161,7 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
                         baseMillis + 86400000,
                         points.get(g2));
                 Assert.assertEquals((int) answers.get(locator).get(g2), data.getData().getPoints().size());
+                Assert.assertEquals(locatorToUnitMap.get(locator), data.getUnit());
             }
         }
     }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package com.rackspacecloud.blueflood.outputs.handlers;
 
-import com.netflix.astyanax.model.ColumnFamily;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
 import com.rackspacecloud.blueflood.io.*;
@@ -58,7 +57,6 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
 
     private HttpRollupsQueryHandler httpHandler;
     private final Map<Locator, Map<Granularity, Integer>> locatorToPoints = new HashMap<Locator, Map<Granularity,Integer>>();
-    private final Map<Locator, String> locatorToUnit = new HashMap<Locator, String>();
 
     @BeforeClass
     public static void setUpHttp() {
@@ -86,7 +84,6 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
 
             analyzer.scanMetrics(new ArrayList<IMetric>(metrics));
             writer.insertFull(metrics);
-
         }
 
         httpHandler = new HttpRollupsQueryHandler();
@@ -221,28 +218,6 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
         post.setEntity(entity);
         HttpResponse response = client.execute(post);
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-    }
-
-    private void generateRollups(Locator locator, long from, long to, Granularity destGranularity) throws Exception {
-        if (destGranularity == Granularity.FULL) {
-            throw new Exception("Can't roll up to FULL");
-        }
-
-        ColumnFamily<Locator, Long> destCF;
-        ArrayList<SingleRollupWriteContext> writeContexts = new ArrayList<SingleRollupWriteContext>();
-        for (Range range : Range.rangesForInterval(destGranularity, from, to)) {
-            destCF = CassandraModel.getColumnFamily(BasicRollup.class, destGranularity);
-            Points<SimpleNumber> input = AstyanaxReader.getInstance().getDataToRoll(SimpleNumber.class, locator, range,
-                    CassandraModel.CF_METRICS_FULL);
-            BasicRollup basicRollup = BasicRollup.buildRollupFromRawSamples(input);
-            writeContexts.add(new SingleRollupWriteContext(basicRollup, locator, destGranularity, destCF, range.start));
-
-            destCF = CassandraModel.getColumnFamily(HistogramRollup.class, destGranularity);
-            HistogramRollup histogramRollup = HistogramRollup.buildRollupFromRawSamples(input);
-            writeContexts.add(new SingleRollupWriteContext(histogramRollup, locator, destGranularity, destCF, range.start));
-        }
-
-        AstyanaxWriter.getInstance().insertRollups(writeContexts);
     }
 
     private URI getMetricsQueryURI() throws URISyntaxException {

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -155,7 +155,7 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
     }
 
     @AfterClass
-    public static void tearDown() throws Exception{
+    public static void tearDownClass() throws Exception{
         esSetup.terminate();
         httpQueryService.stopService();
     }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2013 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.outputs.handlers;
+
+import com.github.tlrx.elasticsearch.test.EsSetup;
+import com.rackspacecloud.blueflood.http.HttpClientVendor;
+import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.outputs.formats.MetricData;
+import com.rackspacecloud.blueflood.rollup.Granularity;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.service.HttpConfig;
+import com.rackspacecloud.blueflood.service.HttpQueryService;
+import com.rackspacecloud.blueflood.types.*;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.elasticsearch.client.Client;
+import org.junit.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+
+public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase {
+    private final long baseMillis = 1335820166000L;
+    private final String tenantId = "ac" + IntegrationTestBase.randString(8);
+    private final String metricName = "met_" + IntegrationTestBase.randString(8);
+    private final Locator locator = Locator.createLocatorFromPathComponents(tenantId, metricName);
+    private static int queryPort = 20000;
+    private final Map<Locator, Map<Granularity, Integer>> locatorToPoints = new HashMap<Locator, Map<Granularity,Integer>>();
+    private HttpRollupsQueryHandler httpHandler;
+    private ElasticIO elasticIO;
+    private EsSetup esSetup;
+    private static HttpQueryService httpQueryService;
+    private static HttpClientVendor vendor;
+    private static DefaultHttpClient client;
+
+    @BeforeClass
+    public static void setUpHttp() {
+        Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(),
+                "com.rackspacecloud.blueflood.outputs.handlers.HttpRollupHandlerWithESIntegrationTest.ElasticIOTest");
+        Configuration.getInstance().setProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT.name(), "20001");
+        Configuration.getInstance().setProperty(CoreConfig.USE_ES_FOR_UNITS.name(), "true");
+        queryPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT);
+        httpQueryService = new HttpQueryService();
+        httpQueryService.startService();
+        vendor = new HttpClientVendor();
+        client = vendor.getClient();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        super.setUp();
+        AstyanaxWriter writer = AstyanaxWriter.getInstance();
+
+        esSetup = new EsSetup();
+        esSetup.execute(EsSetup.deleteAll());
+        esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME).withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
+        elasticIO = new ElasticIO(esSetup.client());
+
+        final List<Metric> metrics = new ArrayList<Metric>();
+        for (int i = 0; i < 1440; i++) {
+            final long curMillis = baseMillis + i * 60000;
+            final Metric metric = getRandomIntMetric(locator, curMillis);
+            metrics.add(metric);
+        }
+
+        elasticIO.insertDiscovery(new ArrayList<IMetric>(metrics));
+        esSetup.client().admin().indices().prepareRefresh().execute().actionGet();
+
+        writer.insertFull(metrics);
+
+        httpHandler = new HttpRollupsQueryHandler();
+
+        // generate every level of rollup for the raw data
+        Granularity g = Granularity.FULL;
+        while (g != Granularity.MIN_1440) {
+            g = g.coarser();
+            generateRollups(locator, baseMillis, baseMillis + 86400000, g);
+        }
+
+        final Map<Granularity, Integer> answerForNumericMetric = new HashMap<Granularity, Integer>();
+        answerForNumericMetric.put(Granularity.FULL, 1440);
+        answerForNumericMetric.put(Granularity.MIN_5, 289);
+        answerForNumericMetric.put(Granularity.MIN_20, 73);
+        answerForNumericMetric.put(Granularity.MIN_60, 25);
+        answerForNumericMetric.put(Granularity.MIN_240, 7);
+        answerForNumericMetric.put(Granularity.MIN_1440, 2);
+
+        locatorToPoints.put(locator, answerForNumericMetric);
+    }
+
+    @After
+    public void tearDown() {
+        esSetup.terminate();
+    }
+
+    @Test
+    public void testMetricDataFetching() throws Exception {
+        final Map<Granularity, Integer> points = new HashMap<Granularity, Integer>();
+        points.put(Granularity.FULL, 1600);
+        points.put(Granularity.MIN_5, 287);
+        points.put(Granularity.MIN_20, 71);
+        points.put(Granularity.MIN_60, 23);
+        points.put(Granularity.MIN_240, 5);
+        points.put(Granularity.MIN_1440, 1);
+        for (Granularity g2 : Granularity.granularities()) {
+            MetricData data = httpHandler.GetDataByPoints(
+                    locator.getTenantId(),
+                    locator.getMetricName(),
+                    baseMillis,
+                    baseMillis + 86400000,
+                    points.get(g2));
+            Assert.assertEquals((int) locatorToPoints.get(locator).get(g2), data.getData().getPoints().size());
+            Assert.assertEquals(locatorToUnitMap.get(locator), data.getUnit());
+        }
+        Assert.assertEquals(locatorToUnitMap.get(locator), elasticIO.search(locator.getTenantId(), locator.getMetricName()).get(0).getUnit());
+        /* TODO: Fix the test to check for simple http return status codes
+        HttpGet get = new HttpGet(getMetricsQueryURI());
+        HttpResponse response = client.execute(get);
+        System.out.println(response.getEntity().getContent());
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        */
+    }
+
+    private URI getMetricsQueryURI() throws URISyntaxException {
+        URIBuilder builder = new URIBuilder().setScheme("http").setHost("127.0.0.1")
+                .setPort(queryPort).setPath("/v2.0/" + tenantId + "/views/" + metricName)
+                .setParameter("from", String.valueOf(baseMillis))
+                .setParameter("to", String.valueOf(baseMillis + 86400000))
+                .setParameter("resolution", "full");
+        return builder.build();
+    }
+
+    class ElasticIOTest extends ElasticIO {
+        Client esClient;
+        public ElasticIOTest() {
+            super();
+            EsSetup esSetup = new EsSetup();
+            //esSetup.execute(EsSetup.deleteAll());
+            esSetup.execute(EsSetup.createIndex(com.rackspacecloud.blueflood.io.ElasticIO.INDEX_NAME).withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
+            esClient = esSetup.client();
+            setClient(esClient);
+        }
+        public Client getESClient() {
+            return esClient;
+        }
+    }
+}

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -156,6 +156,8 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
 
     @AfterClass
     public static void tearDownClass() throws Exception{
+        Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(), "");
+        Configuration.getInstance().setProperty(CoreConfig.USE_ES_FOR_UNITS.name(), "false");
         esSetup.terminate();
         httpQueryService.stopService();
     }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -53,7 +53,7 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
     public static void setUpHttp() {
         Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(),
                 "com.rackspacecloud.blueflood.io.ElasticIO");
-        Configuration.getInstance().setProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT.name(), "20001");
+        // Configuration.getInstance().setProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT.name(), "20001");
         Configuration.getInstance().setProperty(CoreConfig.USE_ES_FOR_UNITS.name(), "true");
         queryPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT);
         httpQueryService = new HttpQueryService();

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
@@ -64,9 +64,9 @@ public class HttpMetricDataQueryServer {
 
         log.info("Starting metric data query server (HTTP) on port {}", this.httpQueryPort);
         ServerBootstrap server = new ServerBootstrap(
-                new NioServerSocketChannelFactory(
-                        Executors.newFixedThreadPool(acceptThreads),
-                        Executors.newFixedThreadPool(workerThreads)));
+                    new NioServerSocketChannelFactory(
+                            Executors.newFixedThreadPool(acceptThreads),
+                            Executors.newFixedThreadPool(workerThreads)));
         server.setPipelineFactory(new MetricsHttpServerPipelineFactory(router));
         server.bind(new InetSocketAddress(httpQueryHost, httpQueryPort));
     }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
@@ -29,6 +29,7 @@ import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
 import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
+import org.jboss.netty.channel.ServerChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +43,7 @@ public class HttpMetricDataQueryServer {
     private static final Logger log = LoggerFactory.getLogger(HttpMetricDataQueryServer.class);
     private final int httpQueryPort;
     private final String httpQueryHost;
-    private org.jboss.netty.channel.ServerChannel serverChannel;
+    private ServerChannel serverChannel;
 
     public HttpMetricDataQueryServer() {
         this.httpQueryPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT);
@@ -70,7 +71,7 @@ public class HttpMetricDataQueryServer {
                             Executors.newFixedThreadPool(acceptThreads),
                             Executors.newFixedThreadPool(workerThreads)));
         server.setPipelineFactory(new MetricsHttpServerPipelineFactory(router));
-        serverChannel = (org.jboss.netty.channel.ServerChannel) server.bind(new InetSocketAddress(httpQueryHost, httpQueryPort));
+        serverChannel =  (ServerChannel) server.bind(new InetSocketAddress(httpQueryHost, httpQueryPort));
     }
 
     private class MetricsHttpServerPipelineFactory implements ChannelPipelineFactory {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.rackspacecloud.blueflood.http.DefaultHandler;
 import com.rackspacecloud.blueflood.http.QueryStringDecoderAndRouter;
 import com.rackspacecloud.blueflood.http.RouteMatcher;
-
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.HttpConfig;
 import com.rackspacecloud.blueflood.utils.QueryDiscoveryModuleLoader;

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
@@ -19,6 +19,7 @@ package com.rackspacecloud.blueflood.outputs.handlers;
 import com.rackspacecloud.blueflood.http.DefaultHandler;
 import com.rackspacecloud.blueflood.http.QueryStringDecoderAndRouter;
 import com.rackspacecloud.blueflood.http.RouteMatcher;
+
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.HttpConfig;
 import com.rackspacecloud.blueflood.utils.QueryDiscoveryModuleLoader;

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
@@ -7,6 +7,7 @@ import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.io.DiscoveryIO;
 import com.rackspacecloud.blueflood.io.SearchResult;
 
+
 import com.rackspacecloud.blueflood.utils.QueryDiscoveryModuleLoader;
 import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.node.JsonNodeFactory;

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
@@ -6,6 +6,7 @@ import com.rackspacecloud.blueflood.http.HttpResponder;
 import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.io.DiscoveryIO;
 import com.rackspacecloud.blueflood.io.SearchResult;
+
 import com.rackspacecloud.blueflood.utils.QueryDiscoveryModuleLoader;
 import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.node.JsonNodeFactory;

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
@@ -6,8 +6,6 @@ import com.rackspacecloud.blueflood.http.HttpResponder;
 import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.io.DiscoveryIO;
 import com.rackspacecloud.blueflood.io.SearchResult;
-
-
 import com.rackspacecloud.blueflood.utils.QueryDiscoveryModuleLoader;
 import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.node.JsonNodeFactory;

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpQueryService.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpQueryService.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.service;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.rackspacecloud.blueflood.outputs.handlers.HttpMetricDataQueryServer;
 
 import java.io.IOException;
@@ -28,4 +29,7 @@ public class HttpQueryService implements QueryService {
     public void startService() {
         server = new HttpMetricDataQueryServer();
     }
+
+    @VisibleForTesting
+    public void stopService() { server.stopServer();}
 }


### PR DESCRIPTION
This PR is based on https://github.com/rackerlabs/blueflood/pull/431. It adds an option to grab units from ES during querying for data, if configured. This is a part of the step to stop storying units if ES is being used as a metrics index.

__TODO__

1. ~~Still lacks tests~~
2. ~~unit string as `unknown` is being used in a lot of places, so `intern` it.~~
3. ~~If the option is configured, do not persist unit during ingestion.~~