### PR TITLE
Events

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/GenericElasticSearchIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/GenericElasticSearchIO.java
@@ -1,0 +1,9 @@
+package com.rackspacecloud.blueflood.io;
+
+import java.util.List;
+import java.util.Map;
+
+public interface GenericElasticSearchIO {
+    public void insert(String tenant, List<Map<String, Object>> metrics) throws Exception;
+    public List<Map<String, Object>> search(String tenant, Map<String, List<String>> query) throws Exception;
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -32,6 +32,7 @@ public enum CoreConfig implements ConfigDefaults {
     QUERY_MODULES(""),
     DISCOVERY_MODULES(""),
     EVENT_LISTENER_MODULES(""),
+    EVENTS_MODULES(""),
 
     MAX_LOCATOR_FETCH_THREADS("2"),
     MAX_ROLLUP_READ_THREADS("20"),

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Event.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Event.java
@@ -9,14 +9,27 @@ public class Event {
     private String data = "";
     private String tags = "";
 
+    public static enum FieldLabels {
+        when,
+        what,
+        data,
+        tags,
+        tenantId
+    }
+
+    public static final String untilParameterName = "until";
+    public static final String fromParameterName = "from";
+    public static final String tagsParameterName = FieldLabels.tags.name();
 
     public Map<String, Object> toMap() {
-        Map<String, Object> map = new HashMap<String, Object>();
-        map.put("when", getWhen());
-        map.put("what", getWhat());
-        map.put("data", getData());
-        map.put("tags", getTags());
-        return map;
+        return new HashMap<String, Object>() {
+            {
+                put(FieldLabels.when.name(), getWhen());
+                put(FieldLabels.what.name(), getWhat());
+                put(FieldLabels.data.name(), getData());
+                put(FieldLabels.tags.name(), getTags());
+            }
+        };
     }
 
     public long getWhen() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Event.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Event.java
@@ -1,0 +1,53 @@
+package com.rackspacecloud.blueflood.types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Event {
+    private long when = 0;
+    private String what = "";
+    private String data = "";
+    private String tags = "";
+
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put("when", getWhen());
+        map.put("what", getWhat());
+        map.put("data", getData());
+        map.put("tags", getTags());
+        return map;
+    }
+
+    public long getWhen() {
+        return when;
+    }
+
+    public void setWhen(long when) {
+        this.when = when;
+    }
+
+    public String getWhat() {
+        return what;
+    }
+
+    public void setWhat(String what) {
+        this.what = what;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/EventModuleLoader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/EventModuleLoader.java
@@ -19,7 +19,7 @@ public class EventModuleLoader {
     public static synchronized void loadEventModule() {
         List<String> modules = Configuration.getInstance().getListProperty(CoreConfig.EVENTS_MODULES);
 
-        if (modules.isEmpty())
+        if (modules.isEmpty() || instance != null)
             return;
 
         ClassLoader classLoader = GenericElasticSearchIO.class.getClassLoader();

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/EventModuleLoader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/EventModuleLoader.java
@@ -1,0 +1,45 @@
+package com.rackspacecloud.blueflood.utils;
+
+import com.rackspacecloud.blueflood.io.GenericElasticSearchIO;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class EventModuleLoader {
+    private static final Logger log = LoggerFactory.getLogger(EventModuleLoader.class);
+    private static GenericElasticSearchIO instance = null;
+
+    public static GenericElasticSearchIO getInstance() {
+        return instance;
+    }
+
+    public static synchronized void loadEventModule() {
+        List<String> modules = Configuration.getInstance().getListProperty(CoreConfig.EVENTS_MODULES);
+
+        if (modules.isEmpty())
+            return;
+
+        ClassLoader classLoader = GenericElasticSearchIO.class.getClassLoader();
+        for (String module : modules) {
+            log.info("Loading metric event module " + module);
+            try {
+                Class discoveryClass = classLoader.loadClass(module);
+                instance = (GenericElasticSearchIO) discoveryClass.newInstance();
+                log.info("Registering metric event module " + module);
+            } catch (InstantiationException e) {
+                log.error("Unable to create instance of metric event class for: " + module, e);
+            } catch (IllegalAccessException e) {
+                log.error("Error starting metric event module: " + module, e);
+            } catch (ClassNotFoundException e) {
+                log.error("Unable to locate metric event module: " + module, e);
+            } catch (RuntimeException e) {
+                log.error("Error starting metric event module: " + module, e);
+            } catch (Throwable e) {
+                log.error("Error starting metric event module: " + module, e);
+            }
+        }
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/EventTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/EventTest.java
@@ -1,0 +1,45 @@
+package com.rackspacecloud.blueflood.types;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class EventTest {
+    Event event = new Event();
+
+    @Before
+    public void setUp() {
+        event.setWhen(1);
+        event.setData("2");
+        event.setTags("3");
+        event.setWhat("4");
+    }
+
+    @Test
+    public void testSettersGetters() {
+        Assert.assertEquals(event.getWhen(), 1);
+        Assert.assertEquals(event.getData(), "2");
+        Assert.assertEquals(event.getTags(), "3");
+        Assert.assertEquals(event.getWhat(), "4");
+    }
+
+    @Test
+    public void testConvertToMap() {
+        Map<String, Object> properties = event.toMap();
+
+        Assert.assertEquals(properties.get(Event.FieldLabels.when.name()), 1L);
+        Assert.assertEquals(properties.get(Event.FieldLabels.data.name()), "2");
+        Assert.assertEquals(properties.get(Event.FieldLabels.tags.name()), "3");
+        Assert.assertEquals(properties.get(Event.FieldLabels.what.name()), "4");
+    }
+
+    @Test
+    public void testStringConstants() {
+        Assert.assertEquals(Event.fromParameterName, "from");
+        Assert.assertEquals(Event.untilParameterName, "until");
+        Assert.assertEquals(Event.tagsParameterName, "tags");
+
+    }
+}

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/EventElasticSearchIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/EventElasticSearchIO.java
@@ -1,0 +1,117 @@
+package com.rackspacecloud.blueflood.io;
+
+import com.rackspacecloud.blueflood.service.ElasticClientManager;
+import com.rackspacecloud.blueflood.service.RemoteElasticSearchServer;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+public class EventElasticSearchIO implements GenericElasticSearchIO {
+    public static final String EVENT_INDEX = "events";
+    public static final String ES_TYPE = "graphite_event";
+    private final Client client;
+
+
+    static enum ESFieldLabel {
+        when,
+        what,
+        data,
+        tags,
+        tenantid
+    }
+
+    // TODO refactor me! Move out of here
+    private static final String untilQueryName = "until";
+    private static final String fromQueryName = "from";
+
+    public EventElasticSearchIO() {
+        this(RemoteElasticSearchServer.getInstance());
+    }
+    public EventElasticSearchIO(Client client) {
+        this.client = client;
+    }
+    public EventElasticSearchIO(ElasticClientManager manager) {
+        this(manager.getClient());
+    }
+
+    @Override
+    public void insert(String tenant, List<Map<String, Object>> events) throws Exception {
+        for (Map<String, Object> event : events) {
+            event.put(ESFieldLabel.tenantid.toString(), tenant);
+            client.prepareIndex(EVENT_INDEX, ES_TYPE)
+                    .setSource(event)
+                    .setRouting(tenant)
+                    .execute()
+                    .actionGet();
+        }
+    }
+
+    @Override
+    public List<Map<String, Object>> search(String tenant, Map<String, List<String>> query) throws Exception {
+        BoolQueryBuilder qb = boolQuery()
+                .must(termQuery(ESFieldLabel.tenantid.toString(), tenant));
+
+        if (query != null) {
+            qb = extractQueryParameters(query, qb);
+        }
+
+        SearchResponse response = client.prepareSearch(EVENT_INDEX)
+                .setRouting(tenant)
+                .setSize(100000)
+                .setVersion(true)
+                .setQuery(qb)
+                .execute()
+                .actionGet();
+
+        List<Map<String, Object>> events = new ArrayList<Map<String, Object>>();
+        for (SearchHit hit : response.getHits().getHits()) {
+            events.add(hit.getSource());
+        }
+
+        return events;
+    }
+
+    private BoolQueryBuilder extractQueryParameters(Map<String, List<String>> query, BoolQueryBuilder qb) {
+        String tagsQuery = extractFieldFromQuery(ESFieldLabel.tags.toString(), query);
+        String untilQuery = extractFieldFromQuery(untilQueryName, query);
+        String fromQuery = extractFieldFromQuery(fromQueryName, query);
+
+        if (!tagsQuery.equals(""))
+            qb = qb.must(termQuery(ESFieldLabel.tags.toString(), tagsQuery));
+
+        if (!untilQuery.equals("") && !fromQuery.equals("")) {
+            qb = qb.must(rangeQuery(ESFieldLabel.when.toString())
+                    .to(Long.parseLong(untilQuery))
+                    .from(Long.parseLong(fromQuery)));
+        } else if (!untilQuery.equals("")) {
+            qb = qb.must(rangeQuery(ESFieldLabel.when.toString()).to(Long.parseLong(untilQuery)));
+        } else if (!fromQuery.equals("")) {
+            qb = qb.must(rangeQuery(ESFieldLabel.when.toString()).from(Long.parseLong(fromQuery)));
+        }
+
+        return qb;
+    }
+
+    private String extractFieldFromQuery(String name, Map<String, List<String>> query) {
+        String result = "";
+        if (query.containsKey(name)) {
+            try {
+                result = query.get(name).get(0);
+            }
+            catch (IndexOutOfBoundsException e) {
+                result = "";
+            }
+        }
+        return result;
+    }
+}

--- a/blueflood-elasticsearch/src/main/resources/events_mapping.json
+++ b/blueflood-elasticsearch/src/main/resources/events_mapping.json
@@ -4,7 +4,7 @@
       "required": true
     },
     "properties": {
-      "tenantid": {
+      "tenantId": {
         "type": "string",
         "index": "not_analyzed"
       },

--- a/blueflood-elasticsearch/src/main/resources/events_mapping.json
+++ b/blueflood-elasticsearch/src/main/resources/events_mapping.json
@@ -1,0 +1,27 @@
+{
+  "graphite_event": {
+    "_routing": {
+      "required": true
+    },
+    "properties": {
+      "tenantid": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "what": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "data": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "tags": {
+        "type": "string"
+      },
+      "when": {
+        "type": "long"
+      }
+    }
+  }
+}

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/EventElasticSearchIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/EventElasticSearchIOTest.java
@@ -1,0 +1,156 @@
+package com.rackspacecloud.blueflood.io;
+
+import com.github.tlrx.elasticsearch.test.EsSetup;
+import junit.framework.Assert;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+public class EventElasticSearchIOTest {
+    private EventElasticSearchIO searchIO;
+    private EsSetup esSetup;
+
+    private static final String TENANT_1 = "tenant1";
+    private static final String TENANT_2 = "otheruser2";
+    private static final String TENANT_RANGE = "rangetenant";
+    private static final String TENANT_WITH_SYMBOLS = "tenant-id_id#id";
+    private static final int TENANT_1_EVENTS_NUM = 3;
+    private static final int TENANT_2_EVENTS_NUM = 7;
+    private static final int TENANT_WITH_SYMBOLS_NUM = 2;
+    private static final int TENANT_RANGE_EVENTS_NUM = 10;
+    private static final int RANGE_STEP_IN_SECONDS = 15 * 60;
+
+
+    @Test
+    public void testNonCrossTenantSearch() throws Exception {
+        Map<String, List<String>> query = new HashMap<String, List<String>>();
+        query.put("tags", Arrays.asList("event"));
+        List<Map<String, Object>> results = searchIO.search(TENANT_1, query);
+        Assert.assertEquals(TENANT_1_EVENTS_NUM, results.size());
+
+        results = searchIO.search(TENANT_2, query);
+        Assert.assertEquals(TENANT_2_EVENTS_NUM, results.size());
+
+        results = searchIO.search(TENANT_RANGE, query);
+        Assert.assertEquals(TENANT_RANGE_EVENTS_NUM, results.size());
+
+        results = searchIO.search(TENANT_WITH_SYMBOLS, query);
+        Assert.assertEquals(TENANT_WITH_SYMBOLS_NUM, results.size());
+    }
+
+    @Test
+    public void testEmptyQueryParameters() throws Exception {
+        Map<String, List<String>> query = new HashMap<String, List<String>>();
+        query.put("tags", new ArrayList<String>());
+        query.put("from", new ArrayList<String>());
+        query.put("until", new ArrayList<String>());
+
+        List<Map<String, Object>> results = searchIO.search(TENANT_1, query);
+        Assert.assertEquals(TENANT_1_EVENTS_NUM, results.size());
+    }
+
+
+
+    @Test
+    public void testEventTagsOnlySearch() throws Exception {
+        Map<String, List<String>> query = new HashMap<String, List<String>>();
+        query.put("tags", Arrays.asList("sample"));
+        List<Map<String, Object>> results = searchIO.search(TENANT_1, query);
+        Assert.assertEquals(TENANT_1_EVENTS_NUM, results.size());
+
+        query.put("tags", Arrays.asList("1"));
+        results = searchIO.search(TENANT_1, query);
+        Assert.assertEquals(1, results.size());
+
+        query.put("tags", Arrays.asList("database"));
+        results = searchIO.search(TENANT_1, query);
+        Assert.assertEquals(0, results.size());
+    }
+
+    @Test
+    public void testEmptyQuery() throws Exception {
+        List<Map<String, Object>> results = searchIO.search(TENANT_1, null);
+        Assert.assertEquals(TENANT_1_EVENTS_NUM, results.size());
+    }
+
+    @Test
+    public void testRangeOnlySearch() throws Exception {
+        Map<String, List<String>> query = new HashMap<String, List<String>>();
+        final int eventCountToCapture = TENANT_RANGE_EVENTS_NUM / 2;
+        final int secondsDelta = 10;
+        DateTime fromDateTime = new DateTime().minusSeconds(RANGE_STEP_IN_SECONDS * eventCountToCapture - secondsDelta);
+        query.put("from", Arrays.asList(Long.toString(fromDateTime.getMillis() / 1000)));
+        List<Map<String, Object>> results = searchIO.search(TENANT_RANGE, query);
+        Assert.assertEquals(eventCountToCapture, results.size());
+
+        DateTime untilDateTime = new DateTime().minusSeconds(RANGE_STEP_IN_SECONDS * eventCountToCapture - secondsDelta);
+        query.clear();
+        query.put("until", Arrays.asList(Long.toString(untilDateTime.getMillis() / 1000)));
+        results = searchIO.search(TENANT_RANGE, query);
+        Assert.assertEquals(eventCountToCapture, results.size());
+
+        query.clear();
+        fromDateTime = new DateTime().minusSeconds(RANGE_STEP_IN_SECONDS * 2 - secondsDelta);
+        untilDateTime = new DateTime().minusSeconds(RANGE_STEP_IN_SECONDS - secondsDelta);
+        query.put("from", Arrays.asList(Long.toString(fromDateTime.getMillis() / 1000)));
+        query.put("until", Arrays.asList(Long.toString(untilDateTime.getMillis() / 1000)));
+        results = searchIO.search(TENANT_RANGE, query);
+        Assert.assertEquals(1, results.size());
+    }
+
+    @Before
+    public void setup() throws Exception {
+        esSetup = new EsSetup();
+        esSetup.execute(EsSetup.deleteAll());
+        esSetup.execute(EsSetup
+                .createIndex(EventElasticSearchIO.EVENT_INDEX)
+                .withMapping(EventElasticSearchIO.ES_TYPE, EsSetup.fromClassPath("events_mapping.json")));
+        searchIO = new EventElasticSearchIO(esSetup.client());
+
+        createTestEvents(TENANT_1, TENANT_1_EVENTS_NUM);
+        createTestEvents(TENANT_2, TENANT_2_EVENTS_NUM);
+        createTestEvents(TENANT_WITH_SYMBOLS, TENANT_WITH_SYMBOLS_NUM);
+        createRangeEvents(TENANT_RANGE, TENANT_RANGE_EVENTS_NUM, RANGE_STEP_IN_SECONDS);
+
+        esSetup.client().admin().indices().prepareRefresh().execute().actionGet();
+    }
+
+    private void createTestEvents(String tenant, int eventCount) throws Exception {
+        ArrayList<Map<String, Object>> eventList = new ArrayList<Map<String, Object>>();
+        DateTime date = new DateTime();
+        for (int i=0; i<eventCount; i++) {
+            Map<String, Object> event = new HashMap<String, Object>();
+            event.put("what", String.format("[%s] %s %d", tenant, "Event title sample", i));
+            event.put("when", date.getMillis() / 1000);
+            event.put("data", String.format("[%s] %s %d", tenant, "Event data sample", i));
+            event.put("tags", String.format("[%s] %s %d", tenant, "Event tags sample", i));
+            eventList.add(event);
+        }
+
+        searchIO.insert(tenant, eventList);
+    }
+
+    private void createRangeEvents(String tenant, int eventCount, int stepInSeconds) throws Exception {
+        ArrayList<Map<String, Object>> eventList = new ArrayList<Map<String, Object>>();
+        DateTime date = new DateTime();
+        for (int i=0;i<eventCount; i++) {
+            Map<String, Object> event = new HashMap<String, Object>();
+            event.put("what", "1");
+            event.put("when", date.getMillis() / 1000);
+            event.put("data", "2");
+            event.put("tags", "event");
+            eventList.add(event);
+
+            date = date.minusSeconds(stepInSeconds);
+        }
+        searchIO.insert(tenant, eventList);
+    }
+
+    @After
+    public void tearDown() {
+        esSetup.terminate();
+    }
+}

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
@@ -1,0 +1,110 @@
+package com.rackspacecloud.blueflood.inputs.handlers;
+
+import com.rackspacecloud.blueflood.http.HttpRequestHandler;
+import com.rackspacecloud.blueflood.http.HttpResponder;
+import com.rackspacecloud.blueflood.io.GenericElasticSearchIO;
+import com.rackspacecloud.blueflood.io.Constants;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.handler.codec.http.*;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+
+public class HttpEventsIngestionHandler implements HttpRequestHandler {
+    private static final Logger log = LoggerFactory.getLogger(HttpEventsIngestionHandler.class);
+    private GenericElasticSearchIO searchIO;
+
+    public HttpEventsIngestionHandler(GenericElasticSearchIO searchIO) {
+        this.searchIO = searchIO;
+    }
+
+    @Override
+    public void handle(ChannelHandlerContext ctx, HttpRequest request) {
+        final String tenantId = request.getHeader("tenantId");
+
+        String response = "";
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            Event event = objectMapper.readValue(request.getContent().array(), Event.class);
+            if (event.getWhen() == 0) {
+                event.setWhen(new DateTime().getMillis() / 1000);
+            }
+
+            if (event.getWhat().equals("")) {
+                throw new Exception("Event should contain at least 'what' field.");
+            }
+            searchIO.insert(tenantId, Arrays.asList(event.toMap()));
+        }
+        catch (Exception e) {
+            log.error(String.format("Exception %s", e.toString()));
+            response = String.format("Error: %s", e.getMessage());
+        }
+
+        sendResponse(ctx, request, response, HttpResponseStatus.OK);
+    }
+
+    private void sendResponse(ChannelHandlerContext channel, HttpRequest request, String messageBody,
+                              HttpResponseStatus status) {
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+        if (messageBody != null && !messageBody.isEmpty()) {
+            response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
+        }
+        HttpResponder.respond(channel, request, response);
+    }
+
+    private static class Event {
+        private long when = 0;
+        private String what = "";
+        private String data = "";
+        private String tags = "";
+
+
+        public Map<String, Object> toMap() {
+            Map<String, Object> map = new HashMap<String, Object>();
+            map.put("when", getWhen());
+            map.put("what", getWhat());
+            map.put("data", getData());
+            map.put("tags", getTags());
+            return map;
+        }
+
+        public long getWhen() {
+            return when;
+        }
+
+        public void setWhen(long when) {
+            this.when = when;
+        }
+
+        public String getWhat() {
+            return what;
+        }
+
+        public void setWhat(String what) {
+            this.what = what;
+        }
+
+        public String getData() {
+            return data;
+        }
+
+        public void setData(String data) {
+            this.data = data;
+        }
+
+        public String getTags() {
+            return tags;
+        }
+
+        public void setTags(String tags) {
+            this.tags = tags;
+        }
+    }
+
+}

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
@@ -5,6 +5,7 @@ import com.rackspacecloud.blueflood.http.HttpResponder;
 import com.rackspacecloud.blueflood.io.GenericElasticSearchIO;
 import com.rackspacecloud.blueflood.io.Constants;
 
+import com.rackspacecloud.blueflood.types.Event;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.ChannelHandlerContext;
@@ -56,55 +57,6 @@ public class HttpEventsIngestionHandler implements HttpRequestHandler {
             response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
         HttpResponder.respond(channel, request, response);
-    }
-
-    private static class Event {
-        private long when = 0;
-        private String what = "";
-        private String data = "";
-        private String tags = "";
-
-
-        public Map<String, Object> toMap() {
-            Map<String, Object> map = new HashMap<String, Object>();
-            map.put("when", getWhen());
-            map.put("what", getWhat());
-            map.put("data", getData());
-            map.put("tags", getTags());
-            return map;
-        }
-
-        public long getWhen() {
-            return when;
-        }
-
-        public void setWhen(long when) {
-            this.when = when;
-        }
-
-        public String getWhat() {
-            return what;
-        }
-
-        public void setWhat(String what) {
-            this.what = what;
-        }
-
-        public String getData() {
-            return data;
-        }
-
-        public void setData(String data) {
-            this.data = data;
-        }
-
-        public String getTags() {
-            return tags;
-        }
-
-        public void setTags(String tags) {
-            this.tags = tags;
-        }
     }
 
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
@@ -27,7 +27,7 @@ public class HttpEventsIngestionHandler implements HttpRequestHandler {
 
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
-        final String tenantId = request.getHeader("tenantId");
+        final String tenantId = request.getHeader(Event.FieldLabels.tenantId.name());
 
         String response = "";
         ObjectMapper objectMapper = new ObjectMapper();
@@ -38,7 +38,7 @@ public class HttpEventsIngestionHandler implements HttpRequestHandler {
             }
 
             if (event.getWhat().equals("")) {
-                throw new Exception("Event should contain at least 'what' field.");
+                throw new Exception(String.format("Event should contain at least '%s' field.", Event.FieldLabels.what.name()));
             }
             searchIO.insert(tenantId, Arrays.asList(event.toMap()));
         }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -31,6 +31,7 @@ import com.rackspacecloud.blueflood.io.IMetricsWriter;
 import com.rackspacecloud.blueflood.service.*;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.MetricsCollection;
+import com.rackspacecloud.blueflood.utils.EventModuleLoader;
 import com.rackspacecloud.blueflood.utils.Metrics;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import org.jboss.netty.bootstrap.ServerBootstrap;
@@ -86,6 +87,9 @@ public class HttpMetricsIngestionServer {
         router.post("/v2.0/:tenantId/ingest/multi", new HttpMultitenantMetricsIngestionHandler(processor, timeout));
         router.post("/v2.0/:tenantId/ingest", new HttpMetricsIngestionHandler(processor, timeout));
         router.post("/v2.0/:tenantId/ingest/aggregated", new HttpStatsDIngestionHandler(processor, timeout));
+        router.post("/v2.0/:tenantId/events", new HttpEventsIngestionHandler(EventModuleLoader.getInstance()));
+
+        EventModuleLoader.loadEventModule();
 
         log.info("Starting metrics listener HTTP server on port {}", httpIngestPort);
         ServerBootstrap server = new ServerBootstrap(

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -87,9 +87,9 @@ public class HttpMetricsIngestionServer {
         router.post("/v2.0/:tenantId/ingest/multi", new HttpMultitenantMetricsIngestionHandler(processor, timeout));
         router.post("/v2.0/:tenantId/ingest", new HttpMetricsIngestionHandler(processor, timeout));
         router.post("/v2.0/:tenantId/ingest/aggregated", new HttpStatsDIngestionHandler(processor, timeout));
+        EventModuleLoader.loadEventModule();
         router.post("/v2.0/:tenantId/events", new HttpEventsIngestionHandler(EventModuleLoader.getInstance()));
 
-        EventModuleLoader.loadEventModule();
 
         log.info("Starting metrics listener HTTP server on port {}", httpIngestPort);
         ServerBootstrap server = new ServerBootstrap(

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandler.java
@@ -1,0 +1,74 @@
+package com.rackspacecloud.blueflood.outputs.handlers;
+
+import com.rackspacecloud.blueflood.http.HTTPRequestWithDecodedQueryParams;
+import com.rackspacecloud.blueflood.http.HttpRequestHandler;
+import com.rackspacecloud.blueflood.http.HttpResponder;
+import com.rackspacecloud.blueflood.io.GenericElasticSearchIO;
+import com.rackspacecloud.blueflood.io.Constants;
+
+import com.rackspacecloud.blueflood.utils.DateTimeParser;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.handler.codec.http.*;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+
+public class HttpEventsQueryHandler implements HttpRequestHandler {
+    private static final Logger log = LoggerFactory.getLogger(HttpEventsQueryHandler.class);
+    private GenericElasticSearchIO searchIO;
+
+    public HttpEventsQueryHandler(GenericElasticSearchIO searchIO) {
+        this.searchIO = searchIO;
+    }
+
+
+    @Override
+    public void handle(ChannelHandlerContext ctx, HttpRequest request) {
+        final String tenantId = request.getHeader("tenantId");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String responseBody;
+        try {
+            HTTPRequestWithDecodedQueryParams requestWithParams = (HTTPRequestWithDecodedQueryParams) request;
+            Map<String, List<String>> params = requestWithParams.getQueryParams();
+
+            parseDateFieldInQuery(params, "from");
+            parseDateFieldInQuery(params, "until");
+
+            List<Map<String, Object>> searchResult = searchIO.search(tenantId, params);
+            responseBody = objectMapper.writeValueAsString(searchResult);
+        }
+        catch (Exception e) {
+            log.error(String.format("Exception %s", e.toString()));
+            responseBody = String.format("Error: %s", e.getMessage());
+        }
+
+        sendResponse(ctx, request, responseBody, HttpResponseStatus.OK);
+    }
+
+    private void sendResponse(ChannelHandlerContext channel, HttpRequest request, String messageBody,
+                              HttpResponseStatus status) {
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+        if (messageBody != null && !messageBody.isEmpty()) {
+            response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
+        }
+        HttpResponder.respond(channel, request, response);
+    }
+
+    private void parseDateFieldInQuery(Map<String, List<String>> params, String name) {
+        if (params.containsKey(name)) {
+            String fromValue = extractDateFieldFromQuery(params.get(name));
+            params.put(name, Arrays.asList(fromValue));
+        }
+    }
+
+    private String extractDateFieldFromQuery(List<String> value) {
+        DateTime dateTime = DateTimeParser.parse(value.get(0));
+        return Long.toString(dateTime.getMillis() / 1000);
+    }
+}

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
@@ -63,10 +63,10 @@ public class HttpMetricDataQueryServer {
         router.post("/v2.0/:tenantId/views", new HttpMultiRollupsQueryHandler());
         router.get("/v2.0/:tenantId/views/histograms/:metricName", new HttpHistogramQueryHandler());
         router.get("/v2.0/:tenantId/metrics/search", new HttpMetricsIndexHandler());
+        EventModuleLoader.loadEventModule();
         router.get("/v2.0/:tenantId/events/get_data", new HttpEventsQueryHandler(EventModuleLoader.getInstance()));
 
         QueryDiscoveryModuleLoader.loadDiscoveryModule();
-        EventModuleLoader.loadEventModule();
 
         log.info("Starting metric data query server (HTTP) on port {}", this.httpQueryPort);
         ServerBootstrap server = new ServerBootstrap(

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
@@ -22,6 +22,7 @@ import com.rackspacecloud.blueflood.http.QueryStringDecoderAndRouter;
 import com.rackspacecloud.blueflood.http.RouteMatcher;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.HttpConfig;
+import com.rackspacecloud.blueflood.utils.EventModuleLoader;
 import com.rackspacecloud.blueflood.utils.QueryDiscoveryModuleLoader;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.ChannelPipeline;
@@ -62,8 +63,10 @@ public class HttpMetricDataQueryServer {
         router.post("/v2.0/:tenantId/views", new HttpMultiRollupsQueryHandler());
         router.get("/v2.0/:tenantId/views/histograms/:metricName", new HttpHistogramQueryHandler());
         router.get("/v2.0/:tenantId/metrics/search", new HttpMetricsIndexHandler());
+        router.get("/v2.0/:tenantId/events/get_data", new HttpEventsQueryHandler(EventModuleLoader.getInstance()));
 
         QueryDiscoveryModuleLoader.loadDiscoveryModule();
+        EventModuleLoader.loadEventModule();
 
         log.info("Starting metric data query server (HTTP) on port {}", this.httpQueryPort);
         ServerBootstrap server = new ServerBootstrap(

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/utils/DateTimeParser.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/utils/DateTimeParser.java
@@ -1,0 +1,187 @@
+package com.rackspacecloud.blueflood.utils;
+
+import org.apache.commons.lang.StringUtils;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DateTimeParser {
+    public static DateTime parse(String dateTimeOffsetString) {
+        String stringToParse = dateTimeOffsetString.replace(" ", "").replace(",", "").replace("_", "");
+
+        if (StringUtils.isNumeric(stringToParse) && !isLikelyDateTime(stringToParse))
+            return dateTimeFromTimestamp(stringToParse);
+
+        DateTime dateTime = tryParseDateTime("HH:mmyyyyMMdd", stringToParse);
+        if (dateTime != null)
+            return dateTime;
+
+        List<String> splitList = splitDateTimeAndOffset(stringToParse);
+        String offset = splitList.get(1);
+        String dateTimeString = splitList.get(0);
+
+        DateTimeOffsetParser parser = new DateTimeOffsetParser(dateTimeString, offset);
+        return parser.updateDateTime(new DateTime());
+    }
+
+    private static class DateTimeOffsetParser {
+        private String dateTime = "";
+        private String offset = "";
+
+        public DateTimeOffsetParser(String dateTimeString, String offsetString) {
+            this.dateTime = dateTimeString;
+            this.offset = offsetString;
+        }
+
+        public DateTime updateDateTime(DateTime baseDateTime) {
+            baseDateTime = extractAndUpdateTime(baseDateTime);
+            baseDateTime = extractAndUpdateDate(baseDateTime);
+            if (!offset.equals(""))
+                baseDateTime = updateDateTimeWithOffset(baseDateTime);
+            return baseDateTime;
+        }
+
+        private DateTime updateDateTimeWithOffset(DateTime baseDateTime) {
+            if (offset.equals(""))
+                return baseDateTime;
+            Pattern p = Pattern.compile("(-?\\d*)([a-z]*)");
+            Matcher m = p.matcher(offset);
+            if (!m.matches())
+                return baseDateTime;
+
+            int count = Integer.parseInt(m.group(1));
+            String unit = m.group(2);
+
+            DateTime dateTimeWithOffset = baseDateTime;
+            if (unit.startsWith("s"))
+                dateTimeWithOffset = baseDateTime.plusSeconds(count);
+            else if (unit.startsWith("min"))
+                dateTimeWithOffset = baseDateTime.plusMinutes(count);
+            else if (unit.startsWith("h"))
+                dateTimeWithOffset = baseDateTime.plusHours(count);
+            else if (unit.startsWith("d"))
+                dateTimeWithOffset = baseDateTime.plusDays(count);
+            else if (unit.startsWith("mon"))
+                dateTimeWithOffset = baseDateTime.plusMonths(count);
+            else if (unit.startsWith("y"))
+                dateTimeWithOffset = baseDateTime.plusYears(count);
+
+            return dateTimeWithOffset;
+        }
+
+        private DateTime extractAndUpdateTime(DateTime inputDateTime) {
+            DateTime resultDateTime = inputDateTime.withSecondOfMinute(0).withMillisOfSecond(0);
+
+            if (dateTime.equals("") || dateTime.contains("now"))
+                return resultDateTime;
+
+            int hour = 0;
+            int minute = 0;
+            Pattern p = Pattern.compile("(\\d{1,2}):(\\d{2})([a|p]m)?(.*)");
+            Matcher m = p.matcher(dateTime);
+            if (m.matches()) {
+                hour = Integer.parseInt(m.group(1));
+                minute = Integer.parseInt(m.group(2));
+
+                String middayModifier = m.group(3);
+                if (middayModifier != null && middayModifier.equals("pm"))
+                    hour = (hour + 12) % 24;
+
+                dateTime = m.group(4);
+            }
+
+            if (dateTime.contains("noon")) {
+                hour = 12;
+                dateTime = dateTime.replace("noon", "");
+            }
+            else if (dateTime.contains("teatime")) {
+                hour = 16;
+                dateTime = dateTime.replace("teatime", "");
+            } else if (dateTime.contains("midnight"))
+                dateTime = dateTime.replace("midnight", "");
+
+            return resultDateTime.withHourOfDay(hour).withMinuteOfHour(minute);
+        }
+
+
+        private DateTime extractAndUpdateDate(DateTime resultDateTime) {
+            String stringToParse = this.dateTime;
+
+            if (stringToParse.contains("tomorrow")) {
+                resultDateTime = resultDateTime.plusDays(1);
+                stringToParse = stringToParse.replace("tomorrow", "");
+            } else if (stringToParse.contains("yesterday")) {
+                resultDateTime = resultDateTime.minusDays(1);
+                stringToParse = stringToParse.replace("yesterday", "");
+            } else if (stringToParse.contains("today"))
+                stringToParse = stringToParse.replace("today", "");
+
+
+            String[] datePatterns = {"MM/dd/YY", "MM/dd/YYYY", "YYYYMMdd", "MMMMddYYYY"};
+            for (String s : datePatterns) {
+                DateTime date = tryParseDateTime(s, stringToParse);
+                if (date != null) {
+                    resultDateTime = resultDateTime.withDate(date.getYear(), date.getMonthOfYear(), date.getDayOfMonth());
+                    break;
+                }
+            }
+
+            // Keep original datetime year
+            String monthDayOptionalYearFormat = "MMMMdd";
+            DateTime date = tryParseDateTime(monthDayOptionalYearFormat, stringToParse);
+            if (date != null)
+                resultDateTime = resultDateTime.withDate(resultDateTime.getYear(), date.getMonthOfYear(), date.getDayOfMonth());
+
+
+            // Keep as much of original datetime as possible
+            String dayOfWeekFormat = "EEE";
+            date = tryParseDateTime(dayOfWeekFormat, stringToParse);
+            if (date != null)
+                while (resultDateTime.getDayOfWeek() != date.getDayOfWeek())
+                    resultDateTime = resultDateTime.minusDays(1);
+            return resultDateTime;
+        }
+    }
+
+    private static List<String> splitDateTimeAndOffset(String stringToSplit) {
+        String offset = "";
+        String dateTimeString = stringToSplit;
+        if (stringToSplit.contains("+")) {
+            String[] offsetSplit = stringToSplit.split("\\+", 2);
+            dateTimeString = offsetSplit[0];
+            offset = offsetSplit.length > 1 ? offsetSplit[1] : "";
+        } else if (stringToSplit.contains("-")) {
+            String[] offsetSplit = stringToSplit.split("-", 2);
+            dateTimeString = offsetSplit[0];
+            offset = offsetSplit.length > 1 ? "-" + offsetSplit[1] : "";
+        }
+
+        return Arrays.asList(dateTimeString, offset);
+    }
+
+    private static DateTime dateTimeFromTimestamp(String stringToParse) {
+        return new DateTime(Long.parseLong(stringToParse) * 1000);
+    }
+
+    private static DateTime tryParseDateTime(String format, String dateTime) {
+        DateTime resultDateTime;
+        try {
+            resultDateTime = DateTimeFormat.forPattern(format).parseDateTime(dateTime);
+        }
+        catch (IllegalArgumentException e) {
+            resultDateTime = null;
+        }
+        return resultDateTime;
+    }
+
+    private static boolean isLikelyDateTime(String stringToParse) {
+        return stringToParse.length() == 8 &&
+                Integer.parseInt(stringToParse.substring(0, 4)) > 1900 &&
+                Integer.parseInt(stringToParse.substring(4, 6)) < 13 &&
+                Integer.parseInt(stringToParse.substring(6)) < 32;
+    }
+}

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandlerTest.java
@@ -2,6 +2,7 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.rackspacecloud.blueflood.http.HTTPRequestWithDecodedQueryParams;
 import com.rackspacecloud.blueflood.io.GenericElasticSearchIO;
+import com.rackspacecloud.blueflood.types.Event;
 import junit.framework.Assert;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -35,12 +36,15 @@ public class HttpEventsIngestionHandlerTest {
     }
 
     private Map<String, Object> createRandomEvent() {
-        Map<String, Object> event = new HashMap<String, Object>();
-        event.put("what", "1");
-        event.put("when", (long)2);
-        event.put("data", "3");
-        event.put("tags", "4");
-        return  event;
+        Event event = new Event() {
+            {
+                setWhat("1");
+                setWhen(2);
+                setData("3");
+                setTags("4");
+            }
+        };
+        return event.toMap();
     }
 
     private HttpRequest createPutOneEventRequest(Map<String, Object> event) throws IOException {
@@ -81,7 +85,7 @@ public class HttpEventsIngestionHandlerTest {
 
     @Test public void testMinimumEventPut() throws Exception {
         Map<String, Object> event = new HashMap<String, Object>();
-        event.put("data", "data");
+        event.put(Event.FieldLabels.data.name(), "data");
 
         ArgumentCaptor<DefaultHttpResponse> argument = ArgumentCaptor.forClass(DefaultHttpResponse.class);
 
@@ -93,10 +97,10 @@ public class HttpEventsIngestionHandlerTest {
 
     @Test public void testApplyingCurrentTimeWhenEmpty() throws Exception {
         Map<String, Object> event = createRandomEvent();
-        event.remove("when");
+        event.remove(Event.FieldLabels.when.name());
         handler.handle(context, createPutOneEventRequest(event));
 
-        event.put("when", convertDateTimeToTimestamp(new DateTime()));
+        event.put(Event.FieldLabels.when.name(), convertDateTimeToTimestamp(new DateTime()));
         verify(searchIO).insert(TENANT, Arrays.asList(event));
     }
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandlerTest.java
@@ -1,0 +1,108 @@
+package com.rackspacecloud.blueflood.inputs.handlers;
+
+import com.rackspacecloud.blueflood.http.HTTPRequestWithDecodedQueryParams;
+import com.rackspacecloud.blueflood.io.GenericElasticSearchIO;
+import junit.framework.Assert;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.*;
+import org.jboss.netty.handler.codec.http.*;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+
+public class HttpEventsIngestionHandlerTest {
+
+    private GenericElasticSearchIO searchIO;
+    private HttpEventsIngestionHandler handler;
+    private ChannelHandlerContext context;
+    private Channel channel;
+    private static final String TENANT = "tenant";
+
+    public HttpEventsIngestionHandlerTest() {
+        searchIO = mock(GenericElasticSearchIO.class);
+        handler = new HttpEventsIngestionHandler(searchIO);
+        channel = mock(Channel.class);
+        context = mock(ChannelHandlerContext.class);
+        when(context.getChannel()).thenReturn(channel);
+        when(channel.write(anyString())).thenReturn(new SucceededChannelFuture(channel));
+    }
+
+    private Map<String, Object> createRandomEvent() {
+        Map<String, Object> event = new HashMap<String, Object>();
+        event.put("what", "1");
+        event.put("when", (long)2);
+        event.put("data", "3");
+        event.put("tags", "4");
+        return  event;
+    }
+
+    private HttpRequest createPutOneEventRequest(Map<String, Object> event) throws IOException {
+        List<Map<String, Object>> events = new ArrayList<Map<String, Object>>();
+        events.add(event);
+
+        final String requestBody = new ObjectMapper().writeValueAsString(events.get(0));
+        return createRequest(HttpMethod.POST, "", requestBody);
+    }
+
+    private HttpRequest createRequest(HttpMethod method, String uri, String requestBody) {
+        DefaultHttpRequest rawRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, method, "/v2.0/" + TENANT + "/events/" + uri);
+        rawRequest.setHeader("tenantId", TENANT);
+        if (!requestBody.equals(""))
+            rawRequest.setContent(ChannelBuffers.copiedBuffer(requestBody.getBytes()));
+        return HTTPRequestWithDecodedQueryParams.createHttpRequestWithDecodedQueryParams(rawRequest);
+    }
+
+    @Test
+    public void testElasticSearchInsertCalledWhenPut() throws Exception {
+        List<Map<String, Object>> events = new ArrayList<Map<String, Object>>();
+        Map<String, Object> event = createRandomEvent();
+        events.add(event);
+        handler.handle(context, createPutOneEventRequest(event));
+        verify(searchIO).insert(TENANT, events);
+    }
+
+
+    @Test public void testMalformedEventPut() throws Exception {
+        final String malformedJSON = "{\"when\":, what]}";
+        handler.handle(context, createRequest(HttpMethod.POST, "", malformedJSON));
+
+        ArgumentCaptor<DefaultHttpResponse> argument = ArgumentCaptor.forClass(DefaultHttpResponse.class);
+        verify(searchIO, never()).insert(anyString(), anyList());
+        verify(channel).write(argument.capture());
+        Assert.assertNotSame(argument.getValue().getContent().toString(Charset.defaultCharset()), "");
+    }
+
+    @Test public void testMinimumEventPut() throws Exception {
+        Map<String, Object> event = new HashMap<String, Object>();
+        event.put("data", "data");
+
+        ArgumentCaptor<DefaultHttpResponse> argument = ArgumentCaptor.forClass(DefaultHttpResponse.class);
+
+        handler.handle(context, createPutOneEventRequest(event));
+        verify(searchIO, never()).insert(anyString(), anyList());
+        verify(channel).write(argument.capture());
+        Assert.assertEquals(argument.getValue().getContent().toString(Charset.defaultCharset()), "Error: Event should contain at least 'what' field.");
+    }
+
+    @Test public void testApplyingCurrentTimeWhenEmpty() throws Exception {
+        Map<String, Object> event = createRandomEvent();
+        event.remove("when");
+        handler.handle(context, createPutOneEventRequest(event));
+
+        event.put("when", convertDateTimeToTimestamp(new DateTime()));
+        verify(searchIO).insert(TENANT, Arrays.asList(event));
+    }
+
+    private long convertDateTimeToTimestamp(DateTime date) {
+        return date.getMillis() / 1000;
+    }
+
+
+}

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerTest.java
@@ -1,0 +1,98 @@
+package com.rackspacecloud.blueflood.outputs.handlers;
+
+import com.rackspacecloud.blueflood.http.HTTPRequestWithDecodedQueryParams;
+import com.rackspacecloud.blueflood.io.GenericElasticSearchIO;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.*;
+import org.jboss.netty.handler.codec.http.*;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+
+public class HttpEventsQueryHandlerTest {
+
+    private GenericElasticSearchIO searchIO;
+    private HttpEventsQueryHandler handler;
+    private ChannelHandlerContext context;
+    private Channel channel;
+    private static final String TENANT = "tenant";
+
+    public HttpEventsQueryHandlerTest() {
+        searchIO = mock(GenericElasticSearchIO.class);
+        handler = new HttpEventsQueryHandler(searchIO);
+        channel = mock(Channel.class);
+        context = mock(ChannelHandlerContext.class);
+        when(context.getChannel()).thenReturn(channel);
+        when(channel.write(anyString())).thenReturn(new SucceededChannelFuture(channel));
+    }
+
+    private Map<String, Object> createRandomEvent() {
+        Map<String, Object> event = new HashMap<String, Object>();
+        event.put("what", "1");
+        event.put("when", (long)2);
+        event.put("data", "3");
+        event.put("tags", "4");
+        return  event;
+    }
+
+    private HttpRequest createGetRequest(String uri) {
+        return createRequest(HttpMethod.GET, uri, "");
+    }
+
+    private HttpRequest createRequest(HttpMethod method, String uri, String requestBody) {
+        DefaultHttpRequest rawRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, method, "/v2.0/" + TENANT + "/events/" + uri);
+        rawRequest.setHeader("tenantId", TENANT);
+        if (!requestBody.equals(""))
+            rawRequest.setContent(ChannelBuffers.copiedBuffer(requestBody.getBytes()));
+        return HTTPRequestWithDecodedQueryParams.createHttpRequestWithDecodedQueryParams(rawRequest);
+    }
+
+
+    @Test
+    public void testElasticSearchSearchCalledWhenGet() throws Exception {
+        testQuery("", new HashMap<String, List<String>>());
+    }
+
+    private void testQuery(String query, Map<String, List<String>> params) throws Exception {
+        handler.handle(context, createGetRequest(query));
+        verify(searchIO).search(TENANT, params);
+    }
+
+
+    @Test public void testQueryParametersParse() throws Exception {
+        Map<String, List<String>> params = new HashMap<String, List<String>>();
+        params.put("until", Arrays.asList(nowTimestamp()));
+        testQuery("?until=now", params);
+
+        params.clear();
+        params.put("until", Arrays.asList(nowTimestamp()));
+        params.put("from", Arrays.asList("1422828000"));
+        testQuery("?until=now&from=1422828000", params);
+
+        params.clear();
+        params.put("tags", Arrays.asList("event"));
+        testQuery("?tags=event", params);
+    }
+
+    @Test
+    public void testDateQueryParamProcessing() throws Exception {
+        Map<String, List<String>> params = new HashMap<String, List<String>>();
+
+        params.clear();
+        params.put("until", Arrays.asList(nowTimestamp()));
+        params.put("from", Arrays.asList(Long.toString(convertDateTimeToTimestamp(new DateTime(2014, 12, 30, 0, 0, 0, 0)))));
+        testQuery("?until=now&from=00:00_2014_12_30", params);
+    }
+
+
+    private long convertDateTimeToTimestamp(DateTime date) {
+        return date.getMillis() / 1000;
+    }
+
+    private String nowTimestamp() {
+        return Long.toString(convertDateTimeToTimestamp(new DateTime().withSecondOfMinute(0).withMillisOfSecond(0)));
+    }
+}

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerTest.java
@@ -2,6 +2,7 @@ package com.rackspacecloud.blueflood.outputs.handlers;
 
 import com.rackspacecloud.blueflood.http.HTTPRequestWithDecodedQueryParams;
 import com.rackspacecloud.blueflood.io.GenericElasticSearchIO;
+import com.rackspacecloud.blueflood.types.Event;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.*;
 import org.jboss.netty.handler.codec.http.*;
@@ -27,15 +28,6 @@ public class HttpEventsQueryHandlerTest {
         context = mock(ChannelHandlerContext.class);
         when(context.getChannel()).thenReturn(channel);
         when(channel.write(anyString())).thenReturn(new SucceededChannelFuture(channel));
-    }
-
-    private Map<String, Object> createRandomEvent() {
-        Map<String, Object> event = new HashMap<String, Object>();
-        event.put("what", "1");
-        event.put("when", (long)2);
-        event.put("data", "3");
-        event.put("tags", "4");
-        return  event;
     }
 
     private HttpRequest createGetRequest(String uri) {
@@ -64,16 +56,16 @@ public class HttpEventsQueryHandlerTest {
 
     @Test public void testQueryParametersParse() throws Exception {
         Map<String, List<String>> params = new HashMap<String, List<String>>();
-        params.put("until", Arrays.asList(nowTimestamp()));
+        params.put(Event.untilParameterName, Arrays.asList(nowTimestamp()));
         testQuery("?until=now", params);
 
         params.clear();
-        params.put("until", Arrays.asList(nowTimestamp()));
-        params.put("from", Arrays.asList("1422828000"));
+        params.put(Event.untilParameterName, Arrays.asList(nowTimestamp()));
+        params.put(Event.fromParameterName, Arrays.asList("1422828000"));
         testQuery("?until=now&from=1422828000", params);
 
         params.clear();
-        params.put("tags", Arrays.asList("event"));
+        params.put(Event.tagsParameterName, Arrays.asList("event"));
         testQuery("?tags=event", params);
     }
 
@@ -82,8 +74,8 @@ public class HttpEventsQueryHandlerTest {
         Map<String, List<String>> params = new HashMap<String, List<String>>();
 
         params.clear();
-        params.put("until", Arrays.asList(nowTimestamp()));
-        params.put("from", Arrays.asList(Long.toString(convertDateTimeToTimestamp(new DateTime(2014, 12, 30, 0, 0, 0, 0)))));
+        params.put(Event.untilParameterName, Arrays.asList(nowTimestamp()));
+        params.put(Event.fromParameterName, Arrays.asList(Long.toString(convertDateTimeToTimestamp(new DateTime(2014, 12, 30, 0, 0, 0, 0)))));
         testQuery("?until=now&from=00:00_2014_12_30", params);
     }
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/utils/DateTimeParserTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/utils/DateTimeParserTest.java
@@ -1,0 +1,168 @@
+package com.rackspacecloud.blueflood.utils;
+
+import com.rackspacecloud.blueflood.utils.DateTimeParser;
+import junit.framework.Assert;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class DateTimeParserTest {
+    @Test
+    public void testFromUnixTimestamp() {
+        long unixTimestamp = nowDateTime().getMillis() / 1000;
+
+        Assert.assertEquals(DateTimeParser.parse(Long.toString(unixTimestamp)),
+                nowDateTime());
+    }
+
+    @Test
+    public void testPlainTimeDateFormat() {
+        // %H:%M%Y%m%d
+        DateTimeFormatter formatter = DateTimeFormat.forPattern("HH:mmyyyyMMdd");
+        String dateTimeWithSpace = "10:55 2014 12 20";
+        String dateTimeWithUnderscore = "10:55_2014_12_20";
+
+        Assert.assertEquals(DateTimeParser.parse(dateTimeWithSpace),
+                new DateTime(formatter.parseDateTime(dateTimeWithSpace.replace(" ", ""))));
+
+        Assert.assertEquals(DateTimeParser.parse(dateTimeWithUnderscore),
+                new DateTime(formatter.parseDateTime(dateTimeWithUnderscore.replace("_", ""))));
+    }
+
+    @Test
+    public void testNowKeyword() {
+        String nowTimestamp = "now";
+
+        Assert.assertEquals(DateTimeParser.parse(nowTimestamp),
+                nowDateTime());
+    }
+
+    @Test
+    public void testRegularHourMinute() {
+        String hourMinuteTimestamp = "12:24";
+        String hourMinuteWithAm = "9:13am";
+        String hourMinuteWithPm = "09:13pm";
+
+        Assert.assertEquals(DateTimeParser.parse(hourMinuteTimestamp),
+                referenceDateTime().withHourOfDay(12).withMinuteOfHour(24));
+
+        Assert.assertEquals(DateTimeParser.parse(hourMinuteWithAm),
+                referenceDateTime().withHourOfDay(9).withMinuteOfHour(13));
+
+        Assert.assertEquals(DateTimeParser.parse(hourMinuteWithPm),
+                referenceDateTime().withHourOfDay(21).withMinuteOfHour(13));
+    }
+
+    @Test
+    public void testHourMinuteKeywords() {
+        String noonTimestamp = "noon";
+        String teatimeTimestamp = "teatime";
+        String midnightTimestamp = "midnight";
+
+        Assert.assertEquals(DateTimeParser.parse(noonTimestamp),
+                referenceDateTime().withHourOfDay(12).withMinuteOfHour(0));
+
+        Assert.assertEquals(DateTimeParser.parse(teatimeTimestamp),
+                referenceDateTime().withHourOfDay(16).withMinuteOfHour(0));
+
+        Assert.assertEquals(DateTimeParser.parse(midnightTimestamp),
+                referenceDateTime().withHourOfDay(0).withMinuteOfHour(0));
+    }
+
+    @Test
+    public void testDayKeywords() {
+        String todayTimestamp = "today";
+        String yesterdayTimestamp = "yesterday";
+        String tomorrowTimeStamp = "tomorrow";
+
+        Assert.assertEquals(DateTimeParser.parse(todayTimestamp),
+                referenceDateTime());
+
+        Assert.assertEquals(DateTimeParser.parse(yesterdayTimestamp),
+                referenceDateTime().minusDays(1));
+
+        Assert.assertEquals(DateTimeParser.parse(tomorrowTimeStamp),
+                referenceDateTime().plusDays(1));
+    }
+
+    @Test
+    public void testDateFormats() {
+        int currentYear = referenceDateTime().getYear();
+        testFormat("12/30/14", new DateTime(2014, 12, 30, 0, 0, 0, 0));
+        testFormat("12/30/2014", new DateTime(2014, 12, 30, 0, 0, 0, 0));
+        testFormat("Jul 30", new DateTime(currentYear, 07, 30, 0, 0, 0, 0));
+        testFormat("Jul 30, 2013", new DateTime(2013, 07, 30, 0, 0, 0, 0));
+        testFormat("20141230", new DateTime(2014, 12, 30, 0, 0, 0, 0));
+    }
+
+    @Test
+    public void testDayOfWeekFormat() {
+        DateTime todayDate = referenceDateTime();
+        for (String dateTimeString: Arrays.asList("Sun", "14:42 Sun", "noon Sun")) {
+            DateTime date = DateTimeParser.parse(dateTimeString);
+            Assert.assertEquals(date.getDayOfWeek(), 7);
+            Assert.assertTrue(todayDate.getYear() == date.getYear());
+            Assert.assertTrue(todayDate.getDayOfYear() - date.getDayOfYear() <= 7);
+        }
+    }
+
+    @Test
+    public void testIncrementDecrement() {
+        testFormat("now-10h", nowDateTime().minusHours(10));
+        testFormat("now+10h", nowDateTime().plusHours(10));
+    }
+
+    @Test
+    public void testDecrementUnits() {
+        testFormat("now-10s", nowDateTime().minusSeconds(10));
+        testFormat("now-15min", nowDateTime().minusMinutes(15));
+        testFormat("now-100h", nowDateTime().minusHours(100));
+        testFormat("now-2d", nowDateTime().minusDays(2));
+        testFormat("now-6mon", nowDateTime().minusMonths(6));
+        testFormat("now-5y", nowDateTime().minusYears(5));
+
+        testFormat("-6h", nowDateTime().minusHours(6));
+    }
+
+    @Test
+    public void testIncrementUnits() {
+        testFormat("now+10s", nowDateTime().plusSeconds(10));
+        testFormat("now+15min", nowDateTime().plusMinutes(15));
+        testFormat("now+100h", nowDateTime().plusHours(100));
+        testFormat("now+2d", nowDateTime().plusDays(2));
+        testFormat("now+6mon", nowDateTime().plusMonths(6));
+        testFormat("now+5y", nowDateTime().plusYears(5));
+    }
+
+    @Test
+    public void testComplexFormats() {
+        testFormat("12:24 yesterday", nowDateTime().minusDays(1).withHourOfDay(12).withMinuteOfHour(24));
+        testFormat("12:24 tomorrow", nowDateTime().plusDays(1).withHourOfDay(12).withMinuteOfHour(24));
+        testFormat("12:24 today", nowDateTime().withHourOfDay(12).withMinuteOfHour(24));
+        testFormat("noon 12/30/2014", nowDateTime().withDate(2014, 12, 30).withHourOfDay(12).withMinuteOfHour(0));
+
+        int currentYear = referenceDateTime().getYear();
+        testFormat("15:45 12/30/14", new DateTime(2014, 12, 30, 15, 45, 0, 0));
+        testFormat("teatime 12/30/2014", new DateTime(2014, 12, 30, 16, 0, 0, 0));
+        testFormat("midnight Jul 30", new DateTime(currentYear, 07, 30, 0, 0, 0, 0));
+        testFormat("Jul 30, 2013", new DateTime(2013, 07, 30, 0, 0, 0, 0));
+        testFormat("Jul 30", new DateTime(currentYear, 07, 30, 0, 0, 0, 0));
+        testFormat("20141230", new DateTime(2014, 12, 30, 0, 0, 0, 0));
+    }
+
+    private void testFormat(String dateString, DateTime date) {
+        Assert.assertEquals(DateTimeParser.parse(dateString), date);
+    }
+
+    private static DateTime referenceDateTime() {
+        return new DateTime().withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0).withMillisOfSecond(0);
+    }
+
+    private static DateTime nowDateTime() {
+        return new DateTime().withSecondOfMinute(0).withMillisOfSecond(0);
+    }
+
+}


### PR DESCRIPTION
This PR adds _events (annotations)_. Events interface mimics `graphite-web` API.

```json
{
  "what": "",
  "when": 0,
  "tags": "",
  "data": ""
}
```

* Ingestion is `POST` request at `/events/` with serialized event as request body.
* Query is `GET` request at `/events/get_data`. Returns array of events. Accepts `from`, `until`, `tags` query parameters.

Store events in `ElasticSearch` with `tenant-id` as routing parameter.
