### PR TITLE
Fix discovery module loading

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/QueryDiscoveryModuleLoader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/QueryDiscoveryModuleLoader.java
@@ -64,6 +64,10 @@ public class QueryDiscoveryModuleLoader {
     }
 
     public static DiscoveryIO getDiscoveryInstance() {
+        if (discoveryInstance == null) {
+            // Try loading the discovery module instance
+            loadDiscoveryModule();
+        }
         return discoveryInstance;
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
@@ -63,8 +63,6 @@ public class HttpMetricDataQueryServer {
         router.get("/v2.0/:tenantId/views/histograms/:metricName", new HttpHistogramQueryHandler());
         router.get("/v2.0/:tenantId/metrics/search", new HttpMetricsIndexHandler());
 
-        QueryDiscoveryModuleLoader.loadDiscoveryModule();
-
         log.info("Starting metric data query server (HTTP) on port {}", this.httpQueryPort);
         ServerBootstrap server = new ServerBootstrap(
                     new NioServerSocketChannelFactory(


### PR DESCRIPTION
We were trying to create an object of `HttpMetricsIndexHandler` and "getting" the instance of discovery in it, even before actually loading it. This caused the instance to be `null` failing the metrics_list call.
This PR adds functionality to the discovery module loader, to try loading the discovery module, if `null`