### PR TITLE
George/multiplot simple number bug

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -453,7 +453,7 @@ public class AstyanaxReader extends AstyanaxIO {
 
         for (Column<Long> column : results) {
             try {
-                points.add(pointFromColumn(column, gran, serializer));
+                points.add(pointFromColumn(column, serializer));
             } catch (RuntimeException ex) {
                 log.error("Problem deserializing data for " + locator + " (" + range + ") from " + CF.getName(), ex);
             }
@@ -504,14 +504,13 @@ public class AstyanaxReader extends AstyanaxIO {
 
         AbstractSerializer serializer = serializerFor(rollupType, dataType, gran);
         for (Column<Long> column : columnList) {
-            points.add(new Points.Point(column.getName(), column.getValue(serializer)));
+            points.add(pointFromColumn(column, serializer));
         }
 
         return points;
     }
 
-    // todo: don't need gran anymore.
-    private Points.Point pointFromColumn(Column<Long> column, Granularity gran, AbstractSerializer serializer) {
+    private Points.Point pointFromColumn(Column<Long> column, AbstractSerializer serializer) {
         if (serializer instanceof NumericSerializer.RawSerializer)
             return new Points.Point(column.getName(), new SimpleNumber(column.getValue(serializer)));
         else

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupsOutputSerializer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupsOutputSerializer.java
@@ -126,7 +126,11 @@ public class JSONBasicRollupsOutputSerializer implements BasicRollupsOutputSeria
             numPoints += rollup.getCount().longValue();
             filterStatsObject = getFilteredStatsForRollup(rollup, filterStats);
         } else {
-            throw new SerializationException("Unsupported data type for Point");
+            String errString =
+              String.format("Unsupported datatype for Point %s",
+                point.getData().getClass());
+            log.error(errString);
+            throw new SerializationException(errString);
         }
 
         // Set all filtered stats to null if numPoints is 0


### PR DESCRIPTION
1. Fixed AstyanaxReader.getPointsFromColumns() to use pointFromColumn()
   	 instead of generating points with "new".  This fixes
	 multiplot query because it causes it to return SimpleNumber's
	 instead of Integers.
2. Removed extraneous gran param from pointFromColumn()
3. Improved error messages in JSONBasicRollupsOutputSerializer.java
4. Increased Multiplot test coverage in BatchMetricsQueryHandlerIntegrationTest
     to test Full resolution metrics and confirm that it is returning
     SimpleNumbers instead of integers.
5. Create metricLocator and strLocator vars in BatchMetricsQueryHandlerIntegrationTest
     to make the code a bit more readable.
