### PR TITLE
Fix ES units bug

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -59,6 +59,7 @@ public class RollupHandler {
     
     protected RollupHandler() {
         if (Util.shouldUseESForUnits()) {
+            // The number of threads getting used for ES_UNIT_THREADS, should at least be equal netty worker threads
             ESUnitExecutor = Executors.newFixedThreadPool(Configuration.getInstance().getIntegerProperty(CoreConfig.ES_UNIT_THREADS));
         }
     }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -35,9 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class RollupHandler {
     private static final Logger log = LoggerFactory.getLogger(RollupHandler.class);
@@ -57,6 +55,13 @@ public class RollupHandler {
     protected final Histogram numHistogramPointsReturned = Metrics.histogram(RollupHandler.class, "Histogram points returned");
 
     private static final boolean ROLLUP_REPAIR = Configuration.getInstance().getBooleanProperty(CoreConfig.REPAIR_ROLLUPS_ON_READ);
+    private ExecutorService ESUnitExecutor = null;
+    
+    protected RollupHandler() {
+        if (Util.shouldUseESForUnits()) {
+            ESUnitExecutor = Executors.newFixedThreadPool(Configuration.getInstance().getIntegerProperty(CoreConfig.ES_UNIT_THREADS));
+        }
+    }
 
     protected MetricData getRollupByGranularity(
             final String tenantId,
@@ -71,7 +76,7 @@ public class RollupHandler {
         final Locator locator = Locator.createLocatorFromPathComponents(tenantId, metricName);
 
         if (Util.shouldUseESForUnits()) {
-             unitFuture = Executors.newFixedThreadPool(1).submit(new Callable() {
+             unitFuture = ESUnitExecutor.submit(new Callable() {
 
                  @Override
                  public Object call() throws Exception {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -142,7 +142,8 @@ public enum CoreConfig implements ConfigDefaults {
     TENANTIDS_TO_KEEP(""),
 
     USE_ES_FOR_UNITS("false"),
-    ES_UNIT_THREADS("50"); // Should at least be equal to the number of the netty worker threads
+    // Should at least be equal to the number of the netty worker threads, if http module is getting loaded
+    ES_UNIT_THREADS("50");
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -141,7 +141,8 @@ public enum CoreConfig implements ConfigDefaults {
     STRING_METRICS_DROPPED("false"),
     TENANTIDS_TO_KEEP(""),
 
-    USE_ES_FOR_UNITS("false");
+    USE_ES_FOR_UNITS("false"),
+    ES_UNIT_THREADS("50"); // Should at least be equal to the number of the netty worker threads
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
@@ -22,7 +22,6 @@ import com.rackspacecloud.blueflood.http.QueryStringDecoderAndRouter;
 import com.rackspacecloud.blueflood.http.RouteMatcher;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.HttpConfig;
-import com.rackspacecloud.blueflood.utils.QueryDiscoveryModuleLoader;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelPipelineFactory;

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpConfig.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpConfig.java
@@ -38,7 +38,12 @@ public enum HttpConfig implements ConfigDefaults {
     // Maximum number of ACCEPT threads for HTTP output
     MAX_READ_ACCEPT_THREADS("10"),
 
-    // Maximum number of WORKER threads for HTTP output (must be included in connections calculations)
+    /*
+      Maximum number of WORKER threads for HTTP output (is included in connections calculations)
+      CoreConfig.ES_UNIT_THREADS should also be adjusted corresponding to the changes in this config
+      if CoreConfig,.USE_ES_FOR_UNITS is set to true, so that the ES_UNIT threads do not become a
+      bottleneck for the netty threads
+     */
     MAX_READ_WORKER_THREADS("50"),
 
     // Maximum number of ACCEPT threads for HTTP input server


### PR DESCRIPTION
Apparently, the way the current code was designed, for getting units out of ES, can blow away the entire stack, because it was spinning a single thread executor for every call. This re-structures the code a bit, so that the number of threads getting used for grabbing units out of ES, is bounded.