### PR TITLE
WIP: Increasing the Metrics List search result limit

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -161,7 +161,7 @@ public class ElasticIO implements DiscoveryIO {
                 );
         SearchResponse response = client.prepareSearch(INDEX_NAME)
                 .setRouting(tenant)
-                .setSize(100000)
+                .setSize(200000)
                 .setVersion(true)
                 .setQuery(qb)
                 .execute()


### PR DESCRIPTION
https://github.com/rackerlabs/blueflood/commit/dfec1a9c6e2c83598680379cd0d7c70d42ed07ed had previously increased it to 100k from 500. 

Therefore, the finder does not return statsd metrics and shows only monitoring metrics in grafana. This PR doubles the result set size. 

