### PR TITLE
WIP: Fix samplecount bug

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Constants.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Constants.java
@@ -34,6 +34,8 @@ public class Constants {
     public static final byte VERSION_2_TIMER = 1;
 
     public static final byte VERSION_1_COUNTER_ROLLUP = 0;
+    public static final byte VERSION_2_COUNTER_ROLLUP = 1;
+
     public static final byte VERSION_1_SET_ROLLUP = VERSION_1_ROLLUP; // don't change this.
 
     public static final int DOUBLE = (int) MetricHelper.Type.DOUBLE;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/CounterRollup.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/CounterRollup.java
@@ -12,7 +12,7 @@ public class CounterRollup implements Rollup {
     /**
      * Number of pre-aggregated counters received by Blueflood
      */
-    private int sampleCount;
+    private long sampleCount;
     
     public CounterRollup() {
         this.rate = 0d;
@@ -29,7 +29,7 @@ public class CounterRollup implements Rollup {
         return this;
     }
 
-    public CounterRollup withSampleCount(int sampleCount) {
+    public CounterRollup withSampleCount(long sampleCount) {
         this.sampleCount = sampleCount;
         return this;
     }
@@ -42,7 +42,7 @@ public class CounterRollup implements Rollup {
         return rate;
     }
 
-    public int getSampleCount() { return sampleCount; }
+    public long getSampleCount() { return sampleCount; }
     
     private static Number promoteToDoubleOrLong(Number num) {
         if (num instanceof Float)
@@ -87,7 +87,7 @@ public class CounterRollup implements Rollup {
         
         Number count = 0L;
         double seconds = 0;
-        int sampleCount = 0;
+        long sampleCount = 0;
         for (Points.Point<CounterRollup> point : input.getPoints().values()) {
             count = sum(count, point.getData().getCount());
             sampleCount = sampleCount + point.getData().getSampleCount();

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -161,7 +161,7 @@ public class ElasticIO implements DiscoveryIO {
                 );
         SearchResponse response = client.prepareSearch(INDEX_NAME)
                 .setRouting(tenant)
-                .setSize(100000)
+                .setSize(200000)
                 .setVersion(true)
                 .setQuery(qb)
                 .execute()

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -161,7 +161,7 @@ public class ElasticIO implements DiscoveryIO {
                 );
         SearchResponse response = client.prepareSearch(INDEX_NAME)
                 .setRouting(tenant)
-                .setSize(200000)
+                .setSize(100000)
                 .setVersion(true)
                 .setQuery(qb)
                 .execute()

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
@@ -70,7 +70,7 @@ public class PreaggregateConversions {
             Rollup rollup = new CounterRollup()
                     .withCount(resolveNumber(counter.getValue()))
                     .withRate(counter.getRate().doubleValue())
-                    .withCount(sampleCount);
+                    .withSampleCount(sampleCount);
             PreaggregatedMetric metric = new PreaggregatedMetric(timestamp, locator, DEFAULT_TTL, rollup);
             list.add(metric);
         }


### PR DESCRIPTION
in PreaggregateConversions (https://github.com/rackerlabs/blueflood/compare/master...tilogaat:fix-samplecount-bug?expand=1#diff-b643ac2bbdc21b81d8434e67b8c56026L73) withCount was being invoked by passing the sampleCount and the Count was always being set to the sampleCount value in the counterRollup class. A side effect of this is that sampleCount should have been long, but was mistakenly set to int.