### PR TITLE
Fixing sampleCount bug 

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
@@ -70,7 +70,7 @@ public class PreaggregateConversions {
             Rollup rollup = new CounterRollup()
                     .withCount(resolveNumber(counter.getValue()))
                     .withRate(counter.getRate().doubleValue())
-                    .withCount(sampleCount);
+                    .withSampleCount((int)sampleCount);
             PreaggregatedMetric metric = new PreaggregatedMetric(timestamp, locator, DEFAULT_TTL, rollup);
             list.add(metric);
         }


### PR DESCRIPTION
convertCounters is wrongly invoking withCount for setting sampleCount. As a result, all count values are getting overridden to the sampleCount values which is incorrect. 

#452 has additional commits that probably should be made because sampleCount field in CounterRollup class is an int, but that is probably insufficient precision that has gone unnoticed because of this bug. 