### PR TITLE
Adding counterValue field to counter query result

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BasicRollupsOutputSerializer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BasicRollupsOutputSerializer.java
@@ -156,6 +156,21 @@ public interface BasicRollupsOutputSerializer<T> {
                 return rawSample;
             }
         },
+        COUNTER_VALUE("counterValue") {
+            @Override
+            Object convertRollupToObject(Rollup rollup) throws Exception {
+                if (rollup instanceof CounterRollup)
+                    return ((CounterRollup) rollup).getCount();
+                else
+                    // gauge, set, basic
+                    throw new Exception(String.format("counter value not supported for this type: %s", rollup.getClass().getSimpleName()));
+            }
+
+            @Override
+            Object convertRawSampleToObject(Object rawSample) {
+                return rawSample;
+            }
+        },
         SUM("sum") {
             @Override
             Object convertRollupToObject(Rollup rollup) throws Exception {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/utils/PlotRequestParser.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/utils/PlotRequestParser.java
@@ -41,8 +41,9 @@ public class PlotRequestParser {
         DEFAULT_BASIC.add(BasicRollupsOutputSerializer.MetricStat.AVERAGE);
         DEFAULT_BASIC.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
         
+        DEFAULT_COUNTER.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
         DEFAULT_COUNTER.add(BasicRollupsOutputSerializer.MetricStat.COUNTER_VALUE);
-        
+
         DEFAULT_GAUGE.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
         DEFAULT_GAUGE.add(BasicRollupsOutputSerializer.MetricStat.LATEST);
         

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/utils/PlotRequestParser.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/utils/PlotRequestParser.java
@@ -41,7 +41,7 @@ public class PlotRequestParser {
         DEFAULT_BASIC.add(BasicRollupsOutputSerializer.MetricStat.AVERAGE);
         DEFAULT_BASIC.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
         
-        DEFAULT_COUNTER.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
+        DEFAULT_COUNTER.add(BasicRollupsOutputSerializer.MetricStat.COUNTER_VALUE);
         
         DEFAULT_GAUGE.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
         DEFAULT_GAUGE.add(BasicRollupsOutputSerializer.MetricStat.LATEST);

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
@@ -153,8 +153,12 @@ public class JSONBasicRollupOutputSerializerTest {
         for (int i = 0; i < data.size(); i++) {
             final JSONObject dataJSON = (JSONObject)data.get(i);
             
+            Assert.assertNotNull(dataJSON.get("numPoints"));
+            Assert.assertEquals((long) (i + 1000), dataJSON.get("numPoints"));
+
             Assert.assertNotNull(dataJSON.get("counterValue"));
             Assert.assertEquals((long) (i + 1000), dataJSON.get("counterValue"));
+
             Assert.assertNull(dataJSON.get("rate"));
         }
     }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
@@ -153,8 +153,8 @@ public class JSONBasicRollupOutputSerializerTest {
         for (int i = 0; i < data.size(); i++) {
             final JSONObject dataJSON = (JSONObject)data.get(i);
             
-            Assert.assertNotNull(dataJSON.get("numPoints"));
-            Assert.assertEquals((long) (i + 1000), dataJSON.get("numPoints"));
+            Assert.assertNotNull(dataJSON.get("counterValue"));
+            Assert.assertEquals((long) (i + 1000), dataJSON.get("counterValue"));
             Assert.assertNull(dataJSON.get("rate"));
         }
     }


### PR DESCRIPTION
To post a counter to BF via statsd backend or directly via the http endpoint the payload is:
```
curl -i -XPOST 'http://localhost:19000/v2.0/5405533/ingest/aggregated' -d '
  {
  "tenantId": "5405533",
  "timestamp": 1429567619000,
  "counters": [
    {
      "name": "tilo_counter",
      "rate": 1,
      "value": 32
    },
    {
      "name": "tilo_another_counter",
      "rate": 1,
      "value": 4424
    }
  ]
}'
```
But while querying the data back the field that is returned is numPoints as shown below:

```
curl -i -X GET "http://localhost:20000/v2.0/5405533/views/tilo_counter?from=1429564800000&to=1429568400000&points=20"
HTTP/1.1 200 OK
Content-Length: 208

{
  "unit": "unknown",
  "values": [
    {
      "numPoints": 32,
      "timestamp": 1429567500000
    }
  ],
  "metadata": {
    "limit": null,
    "next_href": null,
    "count": 1,
    "marker": null
  }
}
```

This is confusing to say the least and is not quite correct because CounterRollup.getCount does not really represent the number of points. Fixing that by replacing the numPoints field with counterValue field which is more intuitive and is more correct too. Query result after this PR is:

```
url -i -X GET "http://localhost:20000/v2.0/5405533/views/tilo_counter?from=1429564800000&to=1429568400000&points=20"
HTTP/1.1 200 OK
Content-Length: 234

{
  "unit": "unknown",
  "values": [
    {
      "numPoints": 32,
      "timestamp": 1429567500000,
      "counterValue": 32
    }
  ],
  "metadata": {
    "limit": null,
    "next_href": null,
    "count": 1,
    "marker": null
  }
}
```


