### PR TITLE
Multiplot/fetch_multi changes

### DIFF
--- a/contrib/graphite/blueflood.py
+++ b/contrib/graphite/blueflood.py
@@ -52,10 +52,6 @@ class TenantBluefloodFinder(object):
   __fetch_multi__ = 'tenant_blueflood'
   def __init__(self, config=None):
     print("Blueflood Finder v22")
-#    if os.path.isfile("/root/pdb-flag"):
-#      import remote_pdb
-#      remote_pdb.RemotePdb('127.0.0.1', 4444).set_trace()
-
     if config is not None:
       bf_config = config.get('blueflood', {})
       urls = bf_config.get('urls', bf_config.get('url', '').strip('/'))

--- a/contrib/graphite/blueflood.py
+++ b/contrib/graphite/blueflood.py
@@ -51,10 +51,10 @@ def calc_res(start, stop):
 class TenantBluefloodFinder(object):
   __fetch_multi__ = 'tenant_blueflood'
   def __init__(self, config=None):
-    print("Blueflood Finder v23-deb2")
-    if os.path.isfile("/root/pdb-flag"):
-      import remote_pdb
-      remote_pdb.RemotePdb('127.0.0.1', 4444).set_trace()
+    print("Blueflood Finder v22")
+#    if os.path.isfile("/root/pdb-flag"):
+#      import remote_pdb
+#      remote_pdb.RemotePdb('127.0.0.1', 4444).set_trace()
 
     if config is not None:
       bf_config = config.get('blueflood', {})

--- a/contrib/graphite/blueflood.py
+++ b/contrib/graphite/blueflood.py
@@ -5,6 +5,9 @@ import time
 import requests
 import json
 import auth
+import sys
+import traceback
+import os.path
 
 try:
     from graphite_api.intervals import Interval, IntervalSet
@@ -15,25 +18,60 @@ except ImportError:
 
 # curl -XPOST -H "Accept: application/json, text/plain, */*" -H "Content-Type: application/x-www-form-urlencoded" 'http://127.0.0.1:8888/render' -d "target=rackspace.*.*.*.*.*.*.*.*.available&from=-6h&until=now&format=json&maxDataPoints=1552"
 
-class TenantBluefloodFinder(object):
 
+secs_per_res = {
+  'FULL': 1,
+  'MIN5': 5*60,
+  'MIN20': 20*60,
+  'MIN60': 60*60,
+  'MIN240': 240*60,
+  'MIN1440': 1440*60}
+
+def calc_res(start, stop):
+  # make an educated guess about the likely number of data points returned.
+  num_points = (stop - start) / 60
+  res = 'FULL'
+  if num_points > 400:
+    num_points = (stop - start) / secs_per_res['MIN5']
+    res = 'MIN5'
+  if num_points > 800:
+    num_points = (stop - start) / secs_per_res['MIN20']
+    res = 'MIN20'
+  if num_points > 800:
+    num_points = (stop - start) / secs_per_res['MIN60']
+    res = 'MIN60'
+  if num_points > 800:
+    num_points = (stop - start) / secs_per_res['MIN240']
+    res = 'MIN240'
+  if num_points > 800:
+    num_points = (stop - start) / secs_per_res['MIN1440']
+    res = 'MIN1440'
+  return res
+
+class TenantBluefloodFinder(object):
+  __fetch_multi__ = 'tenant_blueflood'
   def __init__(self, config=None):
-    authentication_module = None
+    print("Blueflood Finder v21")
+#    if os.path.isfile("/root/pdb-flag"):
+#      import remote_pdb
+#      remote_pdb.RemotePdb('127.0.0.1', 4444).set_trace()
+
     if config is not None:
-      if 'urls' in config['blueflood']:
-        urls = config['blueflood']['urls']
-      else:
-        urls = [config['blueflood']['url'].strip('/')]
-      tenant = config['blueflood']['tenant']
-      if 'authentication_module' in config['blueflood']:
-        authentication_module = config['blueflood']['authentication_module']
-        authentication_class = config['blueflood']['authentication_class']
+      bf_config = config.get('blueflood', {})
+      urls = bf_config.get('urls', bf_config.get('url', '').strip('/'))
+      tenant = bf_config.get('tenant', None)
+      authentication_module =  bf_config.get('authentication_module', None)
+      authentication_class =  bf_config.get('authentication_class', None)
+      enable_submetrics = bf_config.get('enable_submetrics', False)
+      submetric_aliases = bf_config.get('submetric_aliases', {})
     else:
       from django.conf import settings
       urls = getattr(settings, 'BF_QUERY')
       tenant = getattr(settings, 'BF_TENANT')
       authentication_module = getattr(settings, 'BF_AUTHENTICATION_MODULE', None)
       authentication_class = getattr(settings, 'BF_AUTHENTICATION_CLASS', None)
+      enable_submetrics = getattr(settings, 'BF_ENABLE_SUBMETRICS', False)
+      submetric_aliases = getattr(settings, 'BF_SUBMETRIC_ALIASES', {})
 
     if authentication_module:
       module = __import__(authentication_module)
@@ -43,37 +81,105 @@ class TenantBluefloodFinder(object):
 
     self.tenant = tenant
     self.bf_query_endpoint = urls[0]
+    self.enable_submetrics = enable_submetrics
+    self.submetric_aliases = submetric_aliases
+    self.client = BluefloodClient(self.bf_query_endpoint, self.tenant, 
+                                  self.enable_submetrics, self.submetric_aliases)
+    print("BF finder submetrics enabled: ", enable_submetrics)
 
+  def complete(self, metric, query_depth):
+    #is submetric name complete?
+    return len(metric.split('.')) == (query_depth - 1)
+
+  def make_request(self, url, payload, headers):
+    if auth.is_active():
+      headers['X-Auth-Token'] = auth.get_token(False)
+    r = requests.get(url, params=payload, headers=headers)
+    if r.status_code == 401 and auth.is_active():
+      headers['X-Auth-Token'] = auth.get_token(True)
+      r = requests.get(url, params=payload, headers=headers)
+    return r
+
+  def find_metrics_endpoint(self, endpoint, tenant):
+    return "%s/v2.0/%s/metrics/search" % (endpoint, tenant)
+
+  def find_metrics(self, query):
+    print "BluefloodClient.find_metrics: " + str(query)
+    payload = {'query': query}
+    headers = auth.headers()
+    endpoint = self.find_metrics_endpoint(self.bf_query_endpoint, self.tenant)
+    r = self.make_request(endpoint, payload, headers)
+
+    if r.status_code == 200:
+        return [m['metric'] for m in r.json()]
+    else:
+      return []
 
   def find_nodes(self, query):
+    #yields all valid metric names matching glob based query
     try:
-      query_depth = len(query.pattern.split('.'))
-      #print 'DAS QUERY ' + str(query_depth) + ' ' + query.pattern
-      client = Client(self.bf_query_endpoint, self.tenant)
-      values = client.find_metrics(query.pattern)
-      
-      for obj in values:
-        metric = obj['metric']
-        parts = metric.split('.')
-        metric_depth = len(parts)
-        if metric_depth > query_depth:
-          yield BranchNode('.'.join(parts[:query_depth]))
-        else:
-          yield LeafNode(metric, TenantBluefloodReader(metric, self.tenant, self.bf_query_endpoint))
+      print "TenantBluefloodFinder.query: " + str(query.pattern)
+      query_parts = query.pattern.split('.')
+      query_depth = len(query_parts)
+
+      # If searching for all submetrics aliases, (i.e <metric-name>.*),  we must confirm
+      #  that <metric-name> is a valid complete metric name.
+      #  If so, return leaf nodes for each submetric alias that is enabled
+      if self.enable_submetrics and query_parts[-1] == '*':
+        for metric in self.find_metrics('.'.join(query_parts[0:-1])):
+          if self.complete(metric, query_depth):
+            metric_parts = metric.split('.')
+            for alias, _ in self.submetric_aliases.items():
+              yield TenantBluefloodLeafNode('.'.join(metric_parts + [alias]),
+                                            TenantBluefloodReader(metric, self.tenant, 
+                                                                  self.bf_query_endpoint, 
+                                                                  self.enable_submetrics, 
+                                                                  self.submetric_aliases))
+              
+      #if searching for a particular submetric alias, create a leaf node for it
+      if self.enable_submetrics and query_parts[-1] in self.submetric_aliases:
+        for metric in self.find_metrics('.'.join(query_parts[0:-1])):
+          if self.complete(metric, query_depth):
+            yield TenantBluefloodLeafNode('.'.join([metric, query_parts[-1]]), TenantBluefloodReader(metric, self.tenant, self.bf_query_endpoint, self.enable_submetrics, self.submetric_aliases))
+
+      #every thing else is a branch node, or a non-submetric leaf
+      for metric in self.find_metrics(query.pattern):
+          metric_parts = metric.split('.')
+          if query_depth < len(metric_parts):
+            yield BranchNode('.'.join(metric_parts[:query_depth]))
+          elif len(metric_parts) == query_depth:
+            # If submetrics are enabled, yield a full match as a branch node
+            if self.enable_submetrics:
+              yield BranchNode('.'.join(metric_parts[:query_depth]))
+            else:
+              yield TenantBluefloodLeafNode(metric, TenantBluefloodReader(metric, self.tenant, self.bf_query_endpoint, self.enable_submetrics, self.submetric_aliases))
+
+
     except Exception as e:
-     print "Exception in Blueflood find_nodes: " 
+     print "Exception in Blueflood find_nodes: "
      print e
+     exc_info = sys.exc_info()
+     tb = traceback.format_exception(*exc_info)
+     for line in tb:
+       print(line)
      raise e
 
+  def fetch_multi(self, nodes, start_time, end_time):
+    return self.client.fetch_multi(nodes, start_time, end_time)
+
 class TenantBluefloodReader(object):
-  __slots__ = ('metric', 'tenant', 'bf_query_endpoint')
+  __slots__ = ('metric', 'tenant', 'bf_query_endpoint', 
+               'enable_submetrics', 'submetric_aliases')
   supported = True
 
-  def __init__(self, metric, tenant, endpoint):
+  def __init__(self, metric, tenant, endpoint, enable_submetrics, submetric_aliases):
+
     # print 'READER ' + tenant + ' ' + metric
     self.metric = metric
     self.tenant = tenant
     self.bf_query_endpoint = endpoint
+    self.enable_submetrics = enable_submetrics
+    self.submetric_aliases = submetric_aliases
 
   def get_intervals(self):
     # todo: make this a lot smarter.
@@ -87,105 +193,202 @@ class TenantBluefloodReader(object):
     if not self.metric:
       return ((start_time, end_time, 1), [])
     else:
-      client = Client(self.bf_query_endpoint, self.tenant)
-      values = client.get_values(self.metric, start_time, end_time)
-      # value keys in order of preference.
-      value_res_order = ['average', 'latest', 'numPoints']
+      client = BluefloodClient(self.bf_query_endpoint, self.tenant,
+                                  self.enable_submetrics, self.submetric_aliases)
+      reader = TenantBluefloodReader(self.metric, self.tenant, self.bf_query_endpoint, 
+                                     self.enable_submetrics, self.submetric_aliases)
+      node = TenantBluefloodLeafNode(self.metric, reader)
 
-      # determine the step
-      minTime = 0x7fffffffffffffff
-      maxTime = 0
-      lastTime = 0
-      step = 1
-      value_arr = []
-      for obj in values:
-        timestamp = obj['timestamp'] / 1000
-        step = timestamp - lastTime
-        lastTime = timestamp
-        minTime = min(minTime, timestamp)
-        maxTime = max(maxTime, timestamp)
-        present_keys = [_ for _ in value_res_order if _ in obj]
-        if present_keys:
-            value_arr.append(obj[present_keys[0]])
+      time_info, cache = client.fetch_multi([node], start_time, end_time)
+      return (time_info, cache[self.metric])
 
-      time_info = (minTime, maxTime, step)
-      return (time_info, value_arr)
-
-SECONDS_IN_5MIN = 300
-SECONDS_IN_20MIN = 1200
-SECONDS_IN_60MIN = 3600
-SECONDS_IN_240MIN = 14400
-SECONDS_IN_1440MIN = 86400
-
-class Client(object):
-  def __init__(self, host, tenant):
+class BluefloodClient(object):
+  def __init__(self, host, tenant, enable_submetrics, submetric_aliases):
     self.host = host
     self.tenant = tenant
+    self.enable_submetrics = enable_submetrics
+    self.submetric_aliases = submetric_aliases
+    # This is the maximum number of json characters permitted by the
+    #  BF multiplot handler.
+    # The actual max is 8000, but I want to leave a margin for error
+    #  because I can't be certain of the exact way the json is generated
+    self.maxlen_per_req = 7000
+    # this is for: "'' ," that surround each metric
+    self.overhead_per_metric = 4
+    self.maxmetrics_per_req = 100
 
-  def make_request(self, url, payload, headers):
+  def gen_data_key(self, values):
+    # Determines which key to use for the data
+    if not len(values):
+      return None
+    value_res_order = ['average', 'latest', 'numPoints']
+    present_keys = [v for v in value_res_order if v in values[0]]
+    if present_keys:
+      return present_keys[0]
+    else:
+      return None
+
+  def current_datapoint_passed(self, v_iter, ts):
+    # Determines if the current datapoint is too old to be considered
+    if not len(v_iter):
+      return False
+    datapoint_ts = v_iter[0]['timestamp']/1000
+    if (ts > datapoint_ts):
+      return True
+    return False
+
+  def current_datapoint_valid(self, v_iter, data_key, ts, step):
+    # Determines if the current datapoint be included in the current step
+    #assumes current_datapoint_passed() is true
+    if (not len(v_iter)) or not (data_key in v_iter[0]):
+      return False
+    datapoint_ts = v_iter[0]['timestamp']/1000
+    if (datapoint_ts < (ts + step)):
+      return True
+    return False
+
+  def process_path(self, values, start_time, end_time, step, data_key):
+    # Generates datapoints in graphite-api format
+    # Graphite-api requires the points be "step" seconds apart in time
+    #  with Null's interleaved if needed
+    if not data_key:
+      print "No valid keys present"
+      return []
+    v_iter = sorted(values, key=lambda x: x['timestamp'])
+    ret_arr = []
+    for ts in range(start_time, end_time, step):
+      # Skip datapoints that have already passed
+      while self.current_datapoint_passed(v_iter, ts):
+        v_iter = v_iter[1:]
+      if self.current_datapoint_valid(v_iter, data_key, ts, step):
+        ret_arr.append(v_iter[0][data_key])
+      else:
+        ret_arr.append(None)
+
+    return ret_arr
+
+  def get_multi_endpoint(self, endpoint, tenant):
+    return "%s/v2.0/%s/views" % (endpoint, tenant)
+
+  def get_metric_list(self, endpoint, tenant, metric_list, payload, headers):
+    #Generate Multiplot query to get metrics in list
+    url = self.get_multi_endpoint(endpoint,tenant)
     if auth.is_active():
       headers['X-Auth-Token'] = auth.get_token(False)
-    r = requests.get(url, params=payload, headers=headers)
+    r = requests.post(url, params=payload, data=json.dumps(metric_list), headers=headers)
     if r.status_code == 401 and auth.is_active():
       headers['X-Auth-Token'] = auth.get_token(True)
-      r = requests.get(url, params=payload, headers=headers)
-    return r
-
-
-  def find_metrics(self, query):
-    payload = {'query': query}
-    headers = auth.headers()
-    r = self.make_request("%s/v2.0/%s/metrics/search" % (self.host, self.tenant), payload, headers)
+      r = requests.post(url, params=payload, data=json.dumps(metric_list), headers=headers)
     if r.status_code != 200:
-      print str(r.status_code) + ' in find_metrics ' + r.url + ' ' + r.text
-      return []
+      print("get_metric_list failed; response: ", r.status_code, tenant, metric_list)
+      return None
     else:
-      try:
-        return r.json()
-      except TypeError:
-        # we need to parse the json ourselves.
-        return json.loads(r.text)
-      except ValueError:
-        return ['there was an error']
+      return r.json()['metrics']
 
-  def get_values(self, metric, start, stop):
-    # make an educated guess about the likely number of data points returned.
-    num_points = (stop - start) / 60
-    res = 'FULL'
-
-    if num_points > 800:
-      num_points = (stop - start) / SECONDS_IN_5MIN
-      res = 'MIN5'
-    if num_points > 800:
-      num_points = (stop - start) / SECONDS_IN_20MIN
-      res = 'MIN20'
-    if num_points > 800:
-      num_points = (stop - start) / SECONDS_IN_60MIN
-      res = 'MIN60'
-    if num_points > 800:
-      num_points = (stop - start) / SECONDS_IN_240MIN
-      res = 'MIN240'
-    if num_points > 800:
-      num_points = (stop - start) / SECONDS_IN_1440MIN
-      res = 'MIN1440'
-
+  def gen_payload(self, start_time, end_time, res):
     payload = {
-      'from': start * 1000,
-      'to': stop * 1000,
+      'from': start_time * 1000,
+      'to': end_time * 1000,
       'resolution': res
     }
-    #print 'USING RES ' + res
+    if self.enable_submetrics:
+      payload['select'] = ','.join(self.submetric_aliases.values())
+    return payload
+
+  def gen_keys(self, node, metrics):
+    # returns metrics_key and data_key
+    #  metrics_key, (the name of the metric, which varies
+    #  depending on if submetric aliases are used.
+    #
+    metrics_key = None
+    data_key = None
+    if self.enable_submetrics:
+      path_parts = node.path.split('.')
+      test_key = '.'.join(path_parts[0:-1])
+      if test_key in metrics:
+        metrics_key = test_key
+        data_key = self.submetric_aliases[path_parts[-1]]
+    elif node.path in metrics:
+      metrics_key = node.path
+      data_key = self.gen_data_key(metrics[metrics_key])
+    return metrics_key, data_key
+
+  def gen_cache(self, nodes, responses, start_time, real_end_time, step):
+    metrics = {x['metric'] : x['data'] for x in responses}
+    cache = {}
+    for n in nodes:
+      metrics_key, data_key = self.gen_keys(n, metrics)
+      if metrics_key:
+        cache[n.path] = self.process_path(metrics[metrics_key], start_time, real_end_time, step, data_key)
+    return cache
+
+  def group_has_room(self, cur_metric, cur_path, tot_len, remaining_paths):
+    if cur_metric >= self.maxmetrics_per_req:
+      return False
+    if cur_path >= len(remaining_paths):
+      return False
+    new_total = tot_len + len(remaining_paths[cur_path]) + self.overhead_per_metric
+    if new_total >= self.maxlen_per_req:
+      return False
+    return True
+  
+  def gen_next_group(self, remaining_paths, groups):
+    # creates a group of metrics that doesn't exceed limits
+    cur_metric = 0
+    cur_path = 0
+    tot_len = 2 # for the brackets
+    while self.group_has_room(cur_metric, cur_path, tot_len, remaining_paths):
+      tot_len += len(remaining_paths[cur_path]) + 2 # for the ", "
+      cur_metric += 1
+      cur_path += 1
+    return remaining_paths[cur_path:], groups + [remaining_paths[0:cur_path]]
+
+  def gen_groups(self, nodes):
+    # creates groups of metrics none of which exceed limits
+    groups = []
+    remaining_paths = [node.path for node in nodes]
+    if self.enable_submetrics:
+      remaining_paths = ['.'.join(p.split('.')[0:-1]) for p in remaining_paths]
+    while remaining_paths:
+      new_remaining_paths, groups = self.gen_next_group(remaining_paths, groups)
+      #check for infinite loops/should never happen
+      if len(remaining_paths) == len(new_remaining_paths):
+        raise IndexError("Invalid path found; breaking out of loop.")
+      else:
+        remaining_paths = new_remaining_paths
+    return groups
+
+  def gen_responses(self, groups, payload):
+    #converts groups of requests into a single list of responses
     headers = auth.headers()
-    r = self.make_request("%s/v2.0/%s/views/%s" % (self.host, self.tenant, metric), payload, headers)
-    if r.status_code != 200:
-      print str(r.status_code) + ' in get_values ' + r.text
-      return {'values': []}
-    else:
-      try:
-        return r.json()['values']
-      except TypeError:
-        # parse that json yo
-        return json.loads(r.text)['values']
-      except ValueError:
-        print 'ValueError in get_values'
-        return {'values': []}
+    responses = reduce(lambda x,y: x+y,
+                     [self.get_metric_list(self.host,
+                                           self.tenant, g, payload, headers)
+                      for g in groups])
+    responses = responses or []
+    return responses
+  
+  def fetch_multi(self, nodes, start_time, end_time):
+    try:
+      res = calc_res(start_time, end_time)
+      step = secs_per_res[res]
+      payload = self.gen_payload(start_time, end_time, res)
+      # Limit size of MPlot requests by dividing into groups
+      groups = self.gen_groups(nodes)
+      responses = self.gen_responses(groups, payload)
+      real_end_time = end_time + step
+      cache = self.gen_cache(nodes, responses, start_time, real_end_time, step)
+      time_info = (start_time, real_end_time, step)
+      return (time_info, cache)
+
+    except Exception as e:
+      print "Exception in Blueflood fetch_multi: "
+      print e
+      exc_info = sys.exc_info()
+      tb = traceback.format_exception(*exc_info)
+      for line in tb:
+        print(line)
+      raise e
+
+class TenantBluefloodLeafNode(LeafNode):
+  __fetch_multi__ = 'tenant_blueflood'

--- a/contrib/graphite/blueflood.py
+++ b/contrib/graphite/blueflood.py
@@ -51,7 +51,7 @@ def calc_res(start, stop):
 class TenantBluefloodFinder(object):
   __fetch_multi__ = 'tenant_blueflood'
   def __init__(self, config=None):
-    print("Blueflood Finder v21")
+    print("Blueflood Finder v22")
 #    if os.path.isfile("/root/pdb-flag"):
 #      import remote_pdb
 #      remote_pdb.RemotePdb('127.0.0.1', 4444).set_trace()

--- a/contrib/graphite/blueflood.py
+++ b/contrib/graphite/blueflood.py
@@ -51,10 +51,10 @@ def calc_res(start, stop):
 class TenantBluefloodFinder(object):
   __fetch_multi__ = 'tenant_blueflood'
   def __init__(self, config=None):
-    print("Blueflood Finder v22")
-#    if os.path.isfile("/root/pdb-flag"):
-#      import remote_pdb
-#      remote_pdb.RemotePdb('127.0.0.1', 4444).set_trace()
+    print("Blueflood Finder v23-deb2")
+    if os.path.isfile("/root/pdb-flag"):
+      import remote_pdb
+      remote_pdb.RemotePdb('127.0.0.1', 4444).set_trace()
 
     if config is not None:
       bf_config = config.get('blueflood', {})
@@ -145,9 +145,9 @@ class TenantBluefloodFinder(object):
           yield TenantBluefloodLeafNode('.'.join([metric, query_parts[-1]]), TenantBluefloodReader(metric, self.tenant, self.bf_query_endpoint, self.enable_submetrics, self.submetric_aliases))
 
     #everything else is a branch node
-    else:
-      for metric in self.find_metrics(query.pattern):
-        metric_parts = metric.split('.')
+    for metric in self.find_metrics(query.pattern):
+      metric_parts = metric.split('.')
+      if not self.complete(metric, query_depth):
         yield BranchNode('.'.join(metric_parts[:query_depth]))
 
   def find_nodes_without_submetrics(self, query):

--- a/contrib/graphite/tests.py
+++ b/contrib/graphite/tests.py
@@ -2,8 +2,9 @@ from unittest import TestCase
 import unittest
 import os
 import datetime
-
-from blueflood import TenantBluefloodFinder, auth
+import requests_mock
+from blueflood import TenantBluefloodFinder, TenantBluefloodReader, TenantBluefloodLeafNode, \
+     BluefloodClient, auth, calc_res, secs_per_res
 
 #To run these test you need to set up the environment vars below
 try:
@@ -18,7 +19,8 @@ try:
                   'apikey': auth_api_key,
                   'urls': [auth_url],
                   'tenant': auth_tenant}}
-except:
+except Exception as e:
+  print e
   print "Auth env undefined, not running auth tests"
   auth_config = None
 
@@ -47,9 +49,26 @@ except:
         self.startTime = startTime
         self.endTime = endTime
 
+def exc_callback(request, context):
+  raise ValueError("Test exceptions")
+
 class BluefloodTests(TestCase):
-  def test_conf(self):
-    pass
+  def setUp(self):
+    self.alias_key = '_avg'
+    config = {'blueflood':
+              {'urls':["http://dummy.com"],
+               'tenant':'dummyTenant',
+               'submetric_aliases': {self.alias_key:'average'}}}
+    self.finder = TenantBluefloodFinder(config)
+    self.metric1 = "a.b.c"
+    self.metric2 = "e.f.g"
+    self.reader = TenantBluefloodReader(self.metric1, self.finder.tenant, self.finder.bf_query_endpoint, 
+                                     self.finder.enable_submetrics, self.finder.submetric_aliases)
+    self.node1 = TenantBluefloodLeafNode(self.metric1, self.reader)
+    self.node2 = TenantBluefloodLeafNode(self.metric2, self.reader)
+    self.bfc = BluefloodClient(self.finder.bf_query_endpoint, self.finder.tenant, 
+                               self.finder.enable_submetrics, self.finder.submetric_aliases)
+    auth.set_auth(None)
 
   def run_find(self, finder):
     nodes = list(finder.find_nodes(FindQuery('rackspace.*', 0, 100)))
@@ -93,6 +112,250 @@ class BluefloodTests(TestCase):
       self.run_find(finder)
       self.unset_UTC_mock()
       self.assertTrue(self.authCount == 1)
+
+  def test_gen_groups(self):
+    # one time through without submetrics
+    self.bfc.enable_submetrics = False
+    
+    #only 1 metric per group even though room for more
+    self.bfc.maxmetrics_per_req = 1
+    self.bfc.maxlen_per_req = 20
+    groups = self.bfc.gen_groups([self.node1, self.node2])
+    self.assertTrue(groups == [['a.b.c'], ['e.f.g']])
+
+    #allow 2 metrics per group
+    self.bfc.maxmetrics_per_req = 2
+    groups = self.bfc.gen_groups([self.node1, self.node2])
+    self.assertTrue(groups == [['a.b.c', 'e.f.g']])
+
+    #now only room for 1 per group
+    self.bfc.maxlen_per_req = 12
+    groups = self.bfc.gen_groups([self.node1, self.node2])
+    self.assertTrue(groups == [['a.b.c'], ['e.f.g']])
+
+    #no room for metric in a group
+    self.bfc.maxlen_per_req = 11
+    with self.assertRaises(IndexError):
+      groups = self.bfc.gen_groups([self.node1, self.node2])
+
+    # now with submetrics
+    self.bfc.enable_submetrics = True
+
+    #only 1 metric per group even though room for more
+    self.bfc.maxmetrics_per_req = 1
+    self.bfc.maxlen_per_req = 15
+    groups = self.bfc.gen_groups([self.node1, self.node2])
+    self.assertTrue(groups == [['a.b'], ['e.f']])
+
+    #allow 2 metrics per group
+    self.bfc.maxmetrics_per_req = 2
+    groups = self.bfc.gen_groups([self.node1, self.node2])
+    self.assertTrue(groups == [['a.b', 'e.f']])
+
+    #now only room for 1 per group
+    self.bfc.maxlen_per_req = 10
+    groups = self.bfc.gen_groups([self.node1, self.node2])
+    self.assertTrue(groups == [['a.b'], ['e.f']])
+
+    #no room for metric in a group
+    self.bfc.maxlen_per_req = 9
+    with self.assertRaises(IndexError):
+      groups = self.bfc.gen_groups([self.node1, self.node2])
+
+  def make_data(self, start, step):
+    # should be 0th element in response
+    first_timestamp = start * 1000
+    # should be skipped because it overlaps first_timestamp + 1000*step
+    second_timestamp = first_timestamp + (1000 * step - 1)
+    # should be 4th element
+    third_timestamp = first_timestamp + (5000 * step - 1)
+    # should be 7th element
+    fourth_timestamp = first_timestamp + (7000 * step + 1)
+    
+    metric1 = self.metric1
+    metric2 = self.metric2
+    if self.bfc.enable_submetrics:
+      submetric = '.' + self.alias_key
+      metric1 += submetric
+      metric2 += submetric
+    node1 = TenantBluefloodLeafNode(metric1, self.reader)
+    node2 = TenantBluefloodLeafNode(metric2, self.reader)
+    return ([node1, node2],
+            [{u'data': 
+              [{u'timestamp': fourth_timestamp, u'average': 14449.97, u'numPoints': 1}, 
+               {u'timestamp': third_timestamp, u'average': 4449.97, u'numPoints': 1}], 
+              u'metric': self.metric1, u'type': u'number', u'unit': u'unknown'}, 
+             {u'data': 
+              [{u'timestamp': second_timestamp, u'average': 26421.18, u'numPoints': 1},
+               {u'timestamp': first_timestamp, u'average': 6421.18, u'numPoints': 1}], 
+              u'metric': self.metric2, u'type': u'number', u'unit': u'unknown'}])
+    
+  def test_gen_cache(self):
+    step = 3000
+    start = 1426120000
+    end = 1426147000
+    nodes, responses = self.make_data(start, step)
+    cache = self.bfc.gen_cache(nodes, responses, start, end, step)
+    self.assertTrue(cache == 
+                    {nodes[1].path: [6421.18, None, None, None, None, None, None, None, None], 
+                     nodes[0].path: [None, None, None, None, 4449.97, None, None, 14449.97, None]})
+
+    # check that it handles unfound metric correctly
+    nodes[1].path += '.dummy'
+    cache = self.bfc.gen_cache(nodes, responses, start, end, step)
+    self.assertTrue(cache == 
+                    {nodes[0].path: [None, None, None, None, 4449.97, None, None, 14449.97, None]})
+
+    # now with submetrics
+    self.bfc.enable_submetrics = True
+    nodes, responses = self.make_data(start, step)
+    cache = self.bfc.gen_cache(nodes, responses, start, end, step)
+    self.assertTrue(cache == 
+                    {nodes[1].path: [6421.18, None, None, None, None, None, None, None, None], 
+                     nodes[0].path: [None, None, None, None, 4449.97, None, None, 14449.97, None]})
+
+  def test_gen_responses(self):
+    step = 3000
+    start = 1426120000
+    end = 1426147000
+    groups1 = [[self.metric1, self.metric2]]
+    payload = self.bfc.gen_payload(start, end, 'FULL')
+    endpoint = self.bfc.get_multi_endpoint(self.finder.bf_query_endpoint, self.finder.tenant)
+    # test 401 error
+    with requests_mock.mock() as m:
+      m.post(endpoint, json={}, status_code=401)
+      responses = self.bfc.gen_responses(groups1, payload)
+      self.assertTrue(responses == [])
+    
+    #test single group
+    _, responses = self.make_data(start, step)
+    with requests_mock.mock() as m:
+      m.post(endpoint, json={'metrics':responses}, status_code=200)
+      new_responses = self.bfc.gen_responses(groups1, payload)
+      self.assertTrue(responses == new_responses)
+
+    #test multiple groups
+    groups2 = [[self.metric1], [self.metric2]]
+    with requests_mock.mock() as m:
+      global json_data
+      json_data = [{'metrics':responses[0:1]},{'metrics':responses[1:]}]
+      def json_callback(request, context):
+        global json_data
+        response = json_data[0]
+        json_data = json_data[1:]
+        return response
+
+      m.post(endpoint, json=json_callback, status_code=200)
+      new_responses = self.bfc.gen_responses(groups2, payload)
+      self.assertTrue(responses == new_responses)
+
+  
+  def test_find_nodes(self):
+    endpoint = self.finder.find_metrics_endpoint(self.finder.bf_query_endpoint, self.finder.tenant)
+
+    # one time through without submetrics
+    self.finder.enable_submetrics = False
+    with requests_mock.mock() as m:
+      #test 401 errors
+      query = FindQuery("*", 1, 2)
+      m.get(endpoint, json={}, status_code=401)
+      metrics = self.finder.find_nodes(query)
+      self.assertTrue(list(metrics) == [])
+
+    with requests_mock.mock() as m:
+      query = FindQuery("*", 1, 2)
+      m.get(endpoint, json=exc_callback, status_code=401)
+      with self.assertRaises(ValueError):
+        list(self.finder.find_nodes(query))
+
+    def get_start(x):
+      return lambda y: '.'.join(y.split('.')[0:x])
+
+    get_path = lambda x: x.path
+    def query_test(query_pattern, jdata, qlen, search_results):
+      with requests_mock.mock() as m:
+        query = FindQuery(query_pattern, 1, 2)
+        m.get(endpoint, json=jdata, status_code=200)
+        metrics = self.finder.find_nodes(query)
+        self.assertSequenceEqual(map(get_path, list(metrics)),
+                                 map(get_start(qlen), search_results))
+
+    query_test("*", 
+               [{u'metric': self.metric1, u'unit': u'percent'}, 
+                {u'metric': self.metric2, u'unit': u'percent'}],
+               1, [self.metric1, self.metric2])
+
+    query_test("a.*", 
+               [{u'metric': self.metric1, u'unit': u'percent'}],
+               2, [self.metric1])
+
+    query_test("a.b.*", 
+               [{u'metric': self.metric1, u'unit': u'percent'}],
+               3, [self.metric1])
+
+    query_test("a.b.c", 
+               [{u'metric': self.metric1, u'unit': u'percent'}],
+               3, [self.metric1])
+
+    # now again, with submetrics
+    self.finder.enable_submetrics = True
+    query_test("*", 
+               [{u'metric': self.metric1, u'unit': u'percent'}, 
+                {u'metric': self.metric2, u'unit': u'percent'}],
+               1, [self.metric1, self.metric2])
+
+    query_test("a.*", 
+               [{u'metric': self.metric1, u'unit': u'percent'}],
+               2, [self.metric1])
+
+    query_test("a.b.*", 
+               [{u'metric': self.metric1, u'unit': u'percent'}],
+               3, [self.metric1])
+
+    query_test("a.b.c", 
+               [{u'metric': self.metric1, u'unit': u'percent'}],
+               3, [self.metric1])
+
+    query_test("a.b.c.*", 
+               [{u'metric': self.metric1, u'unit': u'percent'}],
+               4, [self.metric1 + '.' + self.alias_key])
+
+    query_test("a.b.c._avg", 
+               [{u'metric': self.metric1, u'unit': u'percent'}],
+               4, [self.metric1 + '.' + self.alias_key])
+
+  def test_fetch(self):
+    step = 3000
+    start = 1426120000
+    end = 1426147000
+    endpoint = self.bfc.get_multi_endpoint(self.finder.bf_query_endpoint, self.finder.tenant)
+    nodes, responses = self.make_data(start, step)
+    with requests_mock.mock() as m:
+      m.post(endpoint, json={'metrics':responses}, status_code=200)
+      time_info, cache = self.finder.fetch_multi(nodes, start, end)
+      self.assertSequenceEqual(time_info, (1426120000, 1426147300, 300))
+      self.assertDictEqual(cache,
+                           {'e.f.g': 
+                            [6421.18, None, None, None, None, None, None, None, None, 26421.18, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None], 
+                            'a.b.c': 
+                            [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 4449.97, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 14449.97, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]})
+
+      time2, seq = self.reader.fetch(start, end)
+      self.assertSequenceEqual(time2, (1426120000, 1426147300, 300))
+      self.assertSequenceEqual(seq, cache[self.metric1])
+
+    with requests_mock.mock() as m:
+      m.post(endpoint, json=exc_callback, status_code=200)
+      with self.assertRaises(ValueError):
+        self.reader.fetch(start, end)
+
+
+  def test_calc_res(self):
+    start = 0
+    stop1 = secs_per_res['MIN240']*801
+    stop2 = stop1 - 1
+    self.assertEqual(calc_res(start, stop1), 'MIN1440')
+    self.assertEqual(calc_res(start, stop2), 'MIN240')
 
 if __name__ == '__main__':
   unittest.main()

--- a/contrib/graphite/tests.py
+++ b/contrib/graphite/tests.py
@@ -309,7 +309,8 @@ class BluefloodTests(TestCase):
                2, [self.metric1])
 
     query_test("a.b.*", 
-               [{u'metric': self.metric1, u'unit': u'percent'}],
+               [{u'metric': self.metric1, u'unit': u'percent'},
+                {u'metric': 'a.bb.c', u'unit': u'percent'}],
                3, [self.metric1])
 
     query_test("a.b.c", 
@@ -317,7 +318,8 @@ class BluefloodTests(TestCase):
                3, [self.metric1])
 
     query_test("a.b.c.*", 
-               [{u'metric': self.metric1, u'unit': u'percent'}],
+               [{u'metric': self.metric1, u'unit': u'percent'},
+                {u'metric': (self.metric1 + 'd'), u'unit': u'percent'}],
                4, [self.metric1 + '.' + self.alias_key])
 
     query_test("a.b.c._avg", 


### PR DESCRIPTION
Made a number of fixes/enhancements to the finder:

1. Graphite requires the datapoints returned by the finder to be 
equidistant in time, (interleaved with Null datapoints if necessary.)
We weren't doing this so the timescale was off on graphs with sparse data.

2. Improved performance significantly by switching to fetch_multi/multiplot.
(Note this required updating the graphite-api code from version 1.0.1 to 
Head of master.  Since we also had to patch that code I created a new repo
for it here: https://github.com/rackerlabs/graphite-api/tree/george/fetch_multi_with_patches

3. One other detail about fetch_multi is that it has to take the multiplot limits into
account.  Multplot allows only 100 metrics per call, and has implicit limit of around
7000 json characters. So my changes batch up each of graphite-apis fetch_multi() calls
into to the minimum number of multiplot calls that still abide by those limits.

4. Now supports specificy specific submetric names in the config file, (rather
than just assuming "average", "num_points" or "latest" as we were before.
This required changes on both the search side, and the fetch_multi side.
This work was based on the changes suggested and created by Alex Weeks:
https://github.com/aweeks

5. Finally added a bunch of tests to get coverage of this file up to 93%:
https://23282e1499f9e238db58e26751fc6d96be63cc17-www.googledrive.com/host/0B28IWTWKORCkfnlLYmljbW1NQ295NWhWbmtfbDJ1UXYwQm9xdlVuMjN0NFV1QTNmcDltY2M/x/blueflood.html
