### PR TITLE
Adding support for average, min, max, variance to Gauge rollups

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BasicRollupsOutputSerializer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BasicRollupsOutputSerializer.java
@@ -38,7 +38,10 @@ public interface BasicRollupsOutputSerializer<T> {
         AVERAGE("average") {
             @Override
             Object convertRollupToObject(Rollup rollup) throws Exception {
-                if (rollup instanceof BasicRollup)
+                //since GaugeRollup is a subclass of BasicRollup it has to come before BasicRollup
+                if (rollup instanceof GaugeRollup)
+                    return ((GaugeRollup) rollup).getAverage();
+                else if (rollup instanceof BasicRollup)
                     return ((BasicRollup) rollup).getAverage();
                 else if (rollup instanceof TimerRollup)
                     return ((TimerRollup) rollup).getAverage();
@@ -55,7 +58,10 @@ public interface BasicRollupsOutputSerializer<T> {
         VARIANCE("variance") {
             @Override
             Object convertRollupToObject(Rollup rollup) throws Exception {
-                if (rollup instanceof BasicRollup)
+                //since GaugeRollup is a subclass of BasicRollup it has to come before BasicRollup
+                if (rollup instanceof GaugeRollup)
+                    return ((GaugeRollup) rollup).getVariance();
+                else if (rollup instanceof BasicRollup)
                     return ((BasicRollup) rollup).getVariance();
                 else if (rollup instanceof TimerRollup)
                     return ((TimerRollup) rollup).getVariance();
@@ -72,7 +78,10 @@ public interface BasicRollupsOutputSerializer<T> {
         MIN("min") {
             @Override
             Object convertRollupToObject(Rollup rollup) throws Exception {
-                if (rollup instanceof BasicRollup)
+                //since GaugeRollup is a subclass of BasicRollup, it has to come before BasicRollup
+                if (rollup instanceof GaugeRollup)
+                    return ((GaugeRollup) rollup).getMinValue();
+                else if (rollup instanceof BasicRollup)
                     return ((BasicRollup) rollup).getMinValue();
                 else if (rollup instanceof TimerRollup)
                     return ((TimerRollup) rollup).getMinValue();
@@ -89,7 +98,10 @@ public interface BasicRollupsOutputSerializer<T> {
         MAX("max") {
             @Override
             Object convertRollupToObject(Rollup rollup) throws Exception {
-                if (rollup instanceof BasicRollup)
+                //since GaugeRollup is a subclass of BasicRollup, it has to come before BasicRollup
+                if (rollup instanceof GaugeRollup)
+                    return ((GaugeRollup) rollup).getMaxValue();
+                else if (rollup instanceof BasicRollup)
                     return ((BasicRollup) rollup).getMaxValue();
                 else if (rollup instanceof TimerRollup)
                     return ((TimerRollup) rollup).getMaxValue();

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/FakeMetricDataGenerator.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/FakeMetricDataGenerator.java
@@ -27,6 +27,7 @@ import com.rackspacecloud.blueflood.types.Points;
 import com.rackspacecloud.blueflood.types.SetRollup;
 import com.rackspacecloud.blueflood.types.SimpleNumber;
 import com.rackspacecloud.blueflood.types.TimerRollup;
+import org.elasticsearch.index.analysis.CharMatcher;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -123,8 +124,10 @@ public class FakeMetricDataGenerator {
         long startTime = 1234567L;
         for (int i = 0; i < 5; i++) {
             long timeNow = startTime + i*1000;
-            Points.Point<GaugeRollup> point = new Points.Point<GaugeRollup>(timeNow, new GaugeRollup()
-                .withLatest(timeNow, i));
+            BasicRollup b = new BasicRollup();
+            b.setAverage(i);
+            GaugeRollup g = GaugeRollup.fromBasicRollup(b, timeNow, i);
+            Points.Point<GaugeRollup> point = new Points.Point<GaugeRollup>(timeNow, g.withLatest(timeNow, i));
             points.add(point);
         }
         return points;

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/utils/PlotRequestParser.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/utils/PlotRequestParser.java
@@ -45,6 +45,7 @@ public class PlotRequestParser {
         
         DEFAULT_GAUGE.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
         DEFAULT_GAUGE.add(BasicRollupsOutputSerializer.MetricStat.LATEST);
+        DEFAULT_GAUGE.add(BasicRollupsOutputSerializer.MetricStat.AVERAGE);
         
         DEFAULT_SET.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
         
@@ -70,7 +71,6 @@ public class PlotRequestParser {
         if (points == null && res == null) {
             throw new InvalidRequestException("Either 'points' or 'resolution' is required.");
         }
-
         if (points != null && points.size() != 1) {
             throw new InvalidRequestException("Invalid parameter: points=" + points);
         } else if (res != null && res.size() != 1) {

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
@@ -21,11 +21,8 @@ import com.google.common.collect.Sets;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.outputs.serializers.BasicRollupsOutputSerializer.MetricStat;
 import com.rackspacecloud.blueflood.outputs.utils.PlotRequestParser;
-import com.rackspacecloud.blueflood.types.BasicRollup;
-import com.rackspacecloud.blueflood.types.CounterRollup;
-import com.rackspacecloud.blueflood.types.Points;
+import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.exceptions.SerializationException;
-import com.rackspacecloud.blueflood.types.SimpleNumber;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.junit.Assert;
@@ -177,9 +174,10 @@ public class JSONBasicRollupOutputSerializerTest {
             Assert.assertEquals(1L, dataJSON.get("numPoints"));
             Assert.assertNotNull("latest");
             Assert.assertEquals(i, dataJSON.get("latest"));
-            
+            Assert.assertNotNull("average");
+            Assert.assertEquals(new Average(i), dataJSON.get("average"));
+
             // other fields were filtered out.
-            Assert.assertNull(dataJSON.get(MetricStat.AVERAGE.toString()));
             Assert.assertNull(dataJSON.get(MetricStat.VARIANCE.toString()));
             Assert.assertNull(dataJSON.get(MetricStat.MIN.toString()));
             Assert.assertNull(dataJSON.get(MetricStat.MAX.toString()));


### PR DESCRIPTION
GaugeRollups are inherited from BasicRollup. They can provide the functionality of min, max, average and variance out of the box. Those values just needed to be returned in BasicRollupsOutputSerializer. 