### PR TITLE
Add batch query capabilites to elastic io

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface DiscoveryIO {
     public void insertDiscovery(List<IMetric> metrics) throws Exception;
     public List<SearchResult> search(String tenant, String query) throws Exception;
-    public List<SearchResult> search(List<Locator> locators);
+    public List<SearchResult> search(String tenant, List<String> locators);
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
@@ -1,7 +1,6 @@
 package com.rackspacecloud.blueflood.io;
 
 import com.rackspacecloud.blueflood.types.IMetric;
-
 import java.util.List;
 
 public interface DiscoveryIO {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
@@ -1,9 +1,12 @@
 package com.rackspacecloud.blueflood.io;
 
 import com.rackspacecloud.blueflood.types.IMetric;
+import com.rackspacecloud.blueflood.types.Locator;
+
 import java.util.List;
 
 public interface DiscoveryIO {
     public void insertDiscovery(List<IMetric> metrics) throws Exception;
     public List<SearchResult> search(String tenant, String query) throws Exception;
+    public List<SearchResult> search(List<Locator> locators);
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
@@ -1,12 +1,11 @@
 package com.rackspacecloud.blueflood.io;
 
 import com.rackspacecloud.blueflood.types.IMetric;
-import com.rackspacecloud.blueflood.types.Locator;
 
 import java.util.List;
 
 public interface DiscoveryIO {
     public void insertDiscovery(List<IMetric> metrics) throws Exception;
     public List<SearchResult> search(String tenant, String query) throws Exception;
-    public List<SearchResult> search(String tenant, List<String> locators);
+    public List<SearchResult> search(String tenant, List<String> queries);
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface DiscoveryIO {
     public void insertDiscovery(List<IMetric> metrics) throws Exception;
     public List<SearchResult> search(String tenant, String query) throws Exception;
-    public List<SearchResult> search(String tenant, List<String> queries);
+    public List<SearchResult> search(String tenant, List<String> queries) throws Exception;
 }

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -150,10 +150,6 @@ public class ElasticIO implements DiscoveryIO {
         BoolQueryBuilder qb = boolQuery();
 
         for (String query : queries) {
-            // complain if someone is trying to search specifically on any tenant.
-            if (query.indexOf(tenantId.name()) >= 0) {
-                throw new Exception("Illegal query: " + query);
-            }
             qb.should(boolQuery()
                     .must(termQuery(tenantId.toString(), tenant))
                     .must(

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
@@ -166,6 +166,19 @@ public class ElasticIOTest {
         Assert.assertEquals(results.size(), 32);
     }
 
+    @Test
+    public void testBatchQueryWithWildCards2() throws Exception {
+        String tenantId = TENANT_A;
+        String query1 = "*.two.three00.fourA.five1";
+        String query2 = "*.two.three01.fourA.five2";
+        List<SearchResult> results;
+        ArrayList<String> queries = new ArrayList<String>();
+        queries.add(query1);
+        queries.add(query2);
+        results = elasticIO.search(tenantId, queries);
+        Assert.assertEquals(results.size(), 2);
+    }
+
     public void testWildcard(String tenantId, String unit) throws Exception {
         SearchResult entry;
         List<SearchResult> results;

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
@@ -166,5 +166,20 @@ public class ElasticIOTest {
                 Assert.assertTrue(results.contains(entry));
             }
         }
+
+        ArrayList<String> queries = new ArrayList<String>();
+        queries.add("one.two.*");
+        queries.add("*.fourA.*");
+        results = elasticIO.search(tenantId, queries);
+        for (Locator locator : locators) {
+            entry =  new SearchResult(tenantId, locator.getMetricName(), unit);
+            Assert.assertTrue((results.contains(entry)));
+        }
+        for (int x = 0; x < NUM_PARENT_ELEMENTS; x++) {
+            for (int z = 0; z < NUM_GRANDCHILD_ELEMENTS; z++) {
+                entry = createExpectedResult(tenantId, x, "A", z, unit);
+                Assert.assertTrue(results.contains(entry));
+            }
+        }
     }
 }

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
@@ -41,7 +41,6 @@ public class ElasticIOTest {
     private static final int NUM_DOCS = NUM_PARENT_ELEMENTS * CHILD_ELEMENTS.size() * NUM_GRANDCHILD_ELEMENTS;
     private static final String TENANT_A = "ratanasv";
     private static final String TENANT_B = "someotherguy";
-
     private static final String TENANT_C = "someothergal";
     private static final String UNIT = "horse length";
     private static final Map<String, List<Locator>> locatorMap = new HashMap<String, List<Locator>>();


### PR DESCRIPTION
Currently, its possible to only make one single query using the `DiscoveryIO` interface and specifically by `ElasticIO` implementation. 
This PR adds that capability

__TODO__

* ~~More tests~~