### PR TITLE
Add a configuration option for sync rollups on read operations

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -83,11 +83,11 @@ public class RollupHandler {
                     .withMaxPoolSize(ESthreadCount).withName("Rolluphandler ES executors").build();
         }
         if (!Configuration.getInstance().getBooleanProperty(CoreConfig.PERFORM_ROLLUPS_ON_READ_SYNC)) {
-            ThreadPoolExecutor RollupsOnReadExecutors = new ThreadPoolBuilder().withUnboundedQueue()
+            ThreadPoolExecutor rollupsOnReadExecutors = new ThreadPoolBuilder().withUnboundedQueue()
                     .withCorePoolSize(Configuration.getInstance().getIntegerProperty(CoreConfig.ROLLUP_ON_READ_THREADS))
                     .withMaxPoolSize(Configuration.getInstance().getIntegerProperty(CoreConfig.ROLLUP_ON_READ_THREADS))
                     .withName("Rollups on Read Executors").build();
-            rollupsOnReadExecutor = MoreExecutors.listeningDecorator(RollupsOnReadExecutors);
+            rollupsOnReadExecutor = MoreExecutors.listeningDecorator(rollupsOnReadExecutors);
         }
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -144,7 +144,8 @@ public enum CoreConfig implements ConfigDefaults {
     USE_ES_FOR_UNITS("false"),
     // Should at least be equal to the number of the netty worker threads, if http module is getting loaded
     ES_UNIT_THREADS("50"),
-    ROLLUP_ON_READ_THREADS("50");
+    ROLLUP_ON_READ_THREADS("50"),
+    PERFORM_ROLLUPS_ON_READ_SYNC("false");
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());


### PR DESCRIPTION
This PR adds a configuration option for doing rollups on read synchronously. There might be a value in playing around with this option depending on the work-load.