### PR TITLE
Add a flag to turn off Rollups on Read for mplot

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -147,7 +147,7 @@ public class RollupHandler {
             for (final Map.Entry<Locator, MetricData> metricData : metricDataMap.entrySet()) {
                 repairMetrics(metricData.getKey(), metricData.getValue(), from, to, g);
             }
-        } else if (locators.size() > 1 && Configuration.getInstance().getBooleanProperty(CoreConfig.TURN_OFF_RR_MPLOT) == false){
+        } else if (locators.size() > 1 && Configuration.getInstance().getBooleanProperty(CoreConfig.TURN_OFF_RR_MPLOT) == false) {
             ArrayList<ListenableFuture<Boolean>> futures = new ArrayList<ListenableFuture<Boolean>>();
             for (final Map.Entry<Locator, MetricData> metricData : metricDataMap.entrySet()) {
                 futures.add(

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -82,7 +82,7 @@ public class RollupHandler {
                     .withCorePoolSize(ESthreadCount)
                     .withMaxPoolSize(ESthreadCount).withName("Rolluphandler ES executors").build();
         }
-        if (!Configuration.getInstance().getBooleanProperty(CoreConfig.PERFORM_ROLLUPS_ON_READ_SYNC)) {
+        if (!Configuration.getInstance().getBooleanProperty(CoreConfig.TURN_OFF_RR_MPLOT)) {
             ThreadPoolExecutor rollupsOnReadExecutors = new ThreadPoolBuilder().withUnboundedQueue()
                     .withCorePoolSize(Configuration.getInstance().getIntegerProperty(CoreConfig.ROLLUP_ON_READ_THREADS))
                     .withMaxPoolSize(Configuration.getInstance().getIntegerProperty(CoreConfig.ROLLUP_ON_READ_THREADS))
@@ -143,11 +143,11 @@ public class RollupHandler {
             }
         }
 
-        if (Configuration.getInstance().getBooleanProperty(CoreConfig.PERFORM_ROLLUPS_ON_READ_SYNC)) {
+        if (locators.size() == 1) {
             for (final Map.Entry<Locator, MetricData> metricData : metricDataMap.entrySet()) {
                 repairMetrics(metricData.getKey(), metricData.getValue(), from, to, g);
             }
-        } else {
+        } else if (locators.size() > 1 && Configuration.getInstance().getBooleanProperty(CoreConfig.TURN_OFF_RR_MPLOT) == true){
             ArrayList<ListenableFuture<Boolean>> futures = new ArrayList<ListenableFuture<Boolean>>();
             for (final Map.Entry<Locator, MetricData> metricData : metricDataMap.entrySet()) {
                 futures.add(

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -147,7 +147,7 @@ public class RollupHandler {
             for (final Map.Entry<Locator, MetricData> metricData : metricDataMap.entrySet()) {
                 repairMetrics(metricData.getKey(), metricData.getValue(), from, to, g);
             }
-        } else if (locators.size() > 1 && Configuration.getInstance().getBooleanProperty(CoreConfig.TURN_OFF_RR_MPLOT) == true){
+        } else if (locators.size() > 1 && Configuration.getInstance().getBooleanProperty(CoreConfig.TURN_OFF_RR_MPLOT) == false){
             ArrayList<ListenableFuture<Boolean>> futures = new ArrayList<ListenableFuture<Boolean>>();
             for (final Map.Entry<Locator, MetricData> metricData : metricDataMap.entrySet()) {
                 futures.add(

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -145,7 +145,7 @@ public enum CoreConfig implements ConfigDefaults {
     // Should at least be equal to the number of the netty worker threads, if http module is getting loaded
     ES_UNIT_THREADS("50"),
     ROLLUP_ON_READ_THREADS("50"),
-    PERFORM_ROLLUPS_ON_READ_SYNC("false");
+    TURN_OFF_RR_MPLOT("false");
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());


### PR DESCRIPTION
We need a flag to turn off rollups on read for mplot queries because they seem to affect the performance of the entire cluster.