### PR TITLE
Query by points in Finder instead of by resolution

### DIFF
--- a/contrib/graphite/blueflood.py
+++ b/contrib/graphite/blueflood.py
@@ -241,6 +241,7 @@ class TenantBluefloodReader(object):
       node = TenantBluefloodLeafNode(self.metric, reader)
 
       time_info, dictionary = client.fetch_multi([node], start_time, end_time)
+      
       return (time_info, dictionary[self.metric])
 
 class BluefloodClient(object):
@@ -335,7 +336,7 @@ class BluefloodClient(object):
     payload = {
       'from': start_time * 1000,
       'to': end_time * 1000,
-      'resolution': res
+      'points': 1000
     }
     if self.enable_submetrics:
       payload['select'] = ','.join(self.submetric_aliases.values())
@@ -429,7 +430,7 @@ class BluefloodClient(object):
       return (time_info, dictionary)
 
     except Exception as e:
-      print "Exception in Blueflood fetch_multi: "
+      print "Exception in Blueflood 3: "
       print e
       exc_info = sys.exc_info()
       tb = traceback.format_exception(*exc_info)

--- a/contrib/graphite/blueflood.py
+++ b/contrib/graphite/blueflood.py
@@ -430,7 +430,7 @@ class BluefloodClient(object):
       return (time_info, dictionary)
 
     except Exception as e:
-      print "Exception in Blueflood 3: "
+      print "Exception in Blueflood fetch_multi: "
       print e
       exc_info = sys.exc_info()
       tb = traceback.format_exception(*exc_info)


### PR DESCRIPTION
We want the ability to query by points in the blueflood-finder for Grafana to take advantage of getByPoints smart querying. getByPoints maps points to resolution, but it proceeds to the next coarser resolution if it finds that the data belonging to one resolution has TTLd out. This is useful for graphing over a long period of time. 

TODO:
Test the finder manually using Grafana. 

