### PR TITLE
Changed counterValue to sum

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BasicRollupsOutputSerializer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BasicRollupsOutputSerializer.java
@@ -156,26 +156,13 @@ public interface BasicRollupsOutputSerializer<T> {
                 return rawSample;
             }
         },
-        COUNTER_VALUE("counterValue") {
-            @Override
-            Object convertRollupToObject(Rollup rollup) throws Exception {
-                if (rollup instanceof CounterRollup)
-                    return ((CounterRollup) rollup).getCount();
-                else
-                    // gauge, set, basic
-                    throw new Exception(String.format("counter value not supported for this type: %s", rollup.getClass().getSimpleName()));
-            }
-
-            @Override
-            Object convertRawSampleToObject(Object rawSample) {
-                return rawSample;
-            }
-        },
         SUM("sum") {
             @Override
             Object convertRollupToObject(Rollup rollup) throws Exception {
                 if (rollup instanceof TimerRollup)
                     return ((TimerRollup) rollup).getSum();
+                else if (rollup instanceof CounterRollup)
+                    return ((CounterRollup) rollup).getCount();
                 else
                     // every other type.
                     throw new Exception(String.format("sum not supported for this type: %s", rollup.getClass().getSimpleName()));

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/utils/PlotRequestParser.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/utils/PlotRequestParser.java
@@ -42,7 +42,7 @@ public class PlotRequestParser {
         DEFAULT_BASIC.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
         
         DEFAULT_COUNTER.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
-        DEFAULT_COUNTER.add(BasicRollupsOutputSerializer.MetricStat.COUNTER_VALUE);
+        DEFAULT_COUNTER.add(BasicRollupsOutputSerializer.MetricStat.SUM);
 
         DEFAULT_GAUGE.add(BasicRollupsOutputSerializer.MetricStat.NUM_POINTS);
         DEFAULT_GAUGE.add(BasicRollupsOutputSerializer.MetricStat.LATEST);

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
@@ -156,8 +156,8 @@ public class JSONBasicRollupOutputSerializerTest {
             Assert.assertNotNull(dataJSON.get("numPoints"));
             Assert.assertEquals((long) (i + 1000), dataJSON.get("numPoints"));
 
-            Assert.assertNotNull(dataJSON.get("counterValue"));
-            Assert.assertEquals((long) (i + 1000), dataJSON.get("counterValue"));
+            Assert.assertNotNull(dataJSON.get("sum"));
+            Assert.assertEquals((long) (i + 1000), dataJSON.get("sum"));
 
             Assert.assertNull(dataJSON.get("rate"));
         }


### PR DESCRIPTION
Modified parameter 'couterValue' to 'sum' for counter metric query.

Ingest the aggregated metric:
```
curl -i -XPOST 'http://localhost:19000/v2.0/5405533/ingest/aggregated' -d '
  {
  "tenantId": "5405533",
  "timestamp": 1433448000000,
  "counters": [
    {
      "name": "tilo_counter",
      "rate": 1,
      "value": 32
    },
    {
      "name": "tilo_another_counter",
      "rate": 1,
      "value": 4424
    }
  ]
}
```
Now Query the metric:
```
curl -i -X GET "http://localhost:20000/v2.0/5405533/views/tilo_counter?from=1433365293000&to=1433538093000&points=20"
```
Response: 
Before modification:
```
{
  "unit": "unknown",
  "values": [
    {
      "numPoints": 32,
      "timestamp": 1433448000000,
      "counterValue": 32
    }
  ],
  "metadata": {
    "limit": null,
    "next_href": null,
    "count": 1,
    "marker": null
  }
}
```
After Modification:
```
{
  "unit": "unknown",
  "values": [
    {
      "numPoints": 32,
      "timestamp": 1433448000000,
      "sum": 32
    }
  ],
  "metadata": {
    "limit": null,
    "next_href": null,
    "count": 1,
    "marker": null
  }
}
```