### PR TITLE
Make the elasticsearch index name configurable

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -19,7 +19,9 @@ package com.rackspacecloud.blueflood.io;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.google.common.annotations.VisibleForTesting;
+import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.ElasticClientManager;
+import com.rackspacecloud.blueflood.service.ElasticIOConfig;
 import com.rackspacecloud.blueflood.service.RemoteElasticSearchServer;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.Locator;
@@ -47,7 +49,7 @@ import static com.rackspacecloud.blueflood.io.ElasticIO.ESFieldLabel.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 
 public class ElasticIO implements DiscoveryIO {
-    public static final String INDEX_NAME = "metric_metadata";
+    public static final String INDEX_NAME = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME);
     
     static enum ESFieldLabel {
         metric_name,

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -49,7 +49,8 @@ import static com.rackspacecloud.blueflood.io.ElasticIO.ESFieldLabel.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 
 public class ElasticIO implements DiscoveryIO {
-    public static final String INDEX_NAME = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME);
+    public static final String INDEX_NAME_WRITE = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_WRITE);
+    public static final String INDEX_NAME_READ = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_READ);
     
     static enum ESFieldLabel {
         metric_name,
@@ -134,7 +135,7 @@ public class ElasticIO implements DiscoveryIO {
         if (md.getMetricName() == null) {
             throw new IllegalArgumentException("trying to insert metric discovery without a metricName");
         }
-        return client.prepareIndex(INDEX_NAME, ES_TYPE)
+        return client.prepareIndex(INDEX_NAME_WRITE, ES_TYPE)
                 .setId(md.getDocumentId())
                 .setSource(md.createSourceContent())
                 .setCreate(true)
@@ -165,7 +166,7 @@ public class ElasticIO implements DiscoveryIO {
             );
         }
 
-        SearchResponse response = client.prepareSearch(INDEX_NAME)
+        SearchResponse response = client.prepareSearch(INDEX_NAME_READ)
                 .setRouting(tenant)
                 .setSize(100000)
                 .setVersion(true)

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/ElasticIOConfig.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/ElasticIOConfig.java
@@ -19,7 +19,8 @@ package com.rackspacecloud.blueflood.service;
 public enum ElasticIOConfig implements ConfigDefaults {
     ELASTICSEARCH_HOSTS("127.0.0.1:9300"),
     ELASTICSEARCH_CLUSTERNAME("elasticsearch"),
-    ELASTICSEARCH_INDEX_NAME("metric_metadata");
+    ELASTICSEARCH_INDEX_NAME_WRITE("metric_metadata"),
+    ELASTICSEARCH_INDEX_NAME_READ("metric_metadata");
 
     static {
         Configuration.getInstance().loadDefaults(ElasticIOConfig.values());

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/ElasticIOConfig.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/ElasticIOConfig.java
@@ -18,7 +18,8 @@ package com.rackspacecloud.blueflood.service;
 
 public enum ElasticIOConfig implements ConfigDefaults {
     ELASTICSEARCH_HOSTS("127.0.0.1:9300"),
-    ELASTICSEARCH_CLUSTERNAME("elasticsearch");
+    ELASTICSEARCH_CLUSTERNAME("elasticsearch"),
+    ELASTICSEARCH_INDEX_NAME("metric_metadata");
 
     static {
         Configuration.getInstance().loadDefaults(ElasticIOConfig.values());

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
@@ -102,7 +102,7 @@ public class ElasticIOTest {
     public void setup() throws IOException {
         esSetup = new EsSetup();
         esSetup.execute(EsSetup.deleteAll());
-        esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME)
+        esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
                 .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
         elasticIO = new ElasticIO(esSetup.client());

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -64,7 +64,7 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
 
         esSetup = new EsSetup();
         esSetup.execute(EsSetup.deleteAll());
-        esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME)
+        esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
                 .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
         elasticIO = new ElasticIO(esSetup.client());


### PR DESCRIPTION
Sometimes, we need to make use of aliases in elasticsearch in order to make the index migrations configurable. By making the index name which the ES client uses while talking to elastic search configurable, we can change these names and hence the aliases easily.
