### PR TITLE
[RFR] Dedup ES search results before returning

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -19,6 +19,7 @@ package com.rackspacecloud.blueflood.io;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.ElasticClientManager;
 import com.rackspacecloud.blueflood.service.ElasticIOConfig;
@@ -178,9 +179,15 @@ public class ElasticIO implements DiscoveryIO {
             SearchResult result = convertHitToMetricDiscoveryResult(hit);
             results.add(result);
         }
-        return results;
+        return dedupResults(results);
     }
 
+    private List<SearchResult> dedupResults(List<SearchResult> results) {
+        HashMap<String, SearchResult> dedupedResults = new HashMap<String, SearchResult>();
+        for (SearchResult result : results)
+            dedupedResults.put(result.getMetricName(), result);
+        return Lists.newArrayList(dedupedResults.values());
+    }
 
     public static class Discovery {
         private Map<String, Object> annotation = new HashMap<String, Object>();

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -50,8 +50,8 @@ import static com.rackspacecloud.blueflood.io.ElasticIO.ESFieldLabel.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 
 public class ElasticIO implements DiscoveryIO {
-    public static final String INDEX_NAME_WRITE = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_WRITE);
-    public static final String INDEX_NAME_READ = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_READ);
+    public static String INDEX_NAME_WRITE = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_WRITE);
+    public static String INDEX_NAME_READ = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_READ);
     
     static enum ESFieldLabel {
         metric_name,
@@ -141,6 +141,16 @@ public class ElasticIO implements DiscoveryIO {
                 .setSource(md.createSourceContent())
                 .setCreate(true)
                 .setRouting(md.getTenantId());
+    }
+
+    @VisibleForTesting
+    public void setINDEX_NAME_WRITE (String indexNameWrite) {
+        INDEX_NAME_WRITE = indexNameWrite;
+    }
+
+    @VisibleForTesting
+    public void setINDEX_NAME_READ (String indexNameRead) {
+        INDEX_NAME_READ = indexNameRead;
     }
     
     public List<SearchResult> search(String tenant, String query) throws Exception {

--- a/blueflood-elasticsearch/src/main/resources/metrics_mapping_v1.json
+++ b/blueflood-elasticsearch/src/main/resources/metrics_mapping_v1.json
@@ -1,0 +1,21 @@
+{
+    "metrics": {
+        "_routing": {
+            "required": true
+        },
+        "properties": {
+            "tenantId": {
+                "type": "string",
+                "index": "not_analyzed"
+            },
+            "unit": {
+                "type": "string",
+                "index": "not_analyzed"
+            },
+            "metric_name": {
+                "type": "string",
+                "index": "not_analyzed"
+            }
+        }
+    }
+}

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
@@ -239,4 +239,21 @@ public class ElasticIOTest {
             Assert.assertTrue(result.getMetricName().equals("one.two.three00.fourA.five0") || result.getMetricName().equals("one.two.three01.fourA.five0"));
         }
     }
+
+    @Test
+    public void testDeDupMetrics() throws Exception {
+        String ES_DUP = ElasticIO.INDEX_NAME_WRITE + "_2";
+        esSetup.execute(EsSetup.createIndex(ES_DUP)
+                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping_v1.json")));
+        elasticIO.setINDEX_NAME_WRITE(ES_DUP);
+        ArrayList metricList = new ArrayList();
+        metricList.add(new Metric(createTestLocator(TENANT_A, 0, "A", 0), "blarg", 0, new TimeValue(1, TimeUnit.DAYS), UNIT));
+        elasticIO.insertDiscovery(metricList);
+        esSetup.client().admin().indices().prepareRefresh().execute().actionGet();
+        esSetup.client().admin().indices().prepareAliases().addAlias(ES_DUP, "metric_metadata_read")
+                .addAlias(ElasticIO.INDEX_NAME_WRITE, "metric_metadata_read").execute().actionGet();
+        elasticIO.setINDEX_NAME_READ("metric_metadata_read");
+        List<SearchResult> results = elasticIO.search(TENANT_A, "one.two.three00.fourA.five0");
+        Assert.assertEquals(results.size(), 1);
+    }
 }

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
@@ -242,8 +242,14 @@ public class ElasticIOTest {
 
     @Test
     public void testDeDupMetrics() throws Exception {
-        // Create another index
+        // New index name and the locator to be written to it
         String ES_DUP = ElasticIO.INDEX_NAME_WRITE + "_2";
+        Locator testLocator = createTestLocator(TENANT_A, 0, "A", 0);
+        // Metric is aleady there in old
+        List<SearchResult> results = elasticIO.search(TENANT_A, testLocator.getMetricName());
+        Assert.assertEquals(results.size(), 1);
+        Assert.assertEquals(results.get(0).getMetricName(), testLocator.getMetricName());
+        // Actually create the new index
         esSetup.execute(EsSetup.createIndex(ES_DUP)
                 .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping_v1.json")));
         // Insert metric into the new index
@@ -256,9 +262,9 @@ public class ElasticIOTest {
         esSetup.client().admin().indices().prepareAliases().addAlias(ES_DUP, "metric_metadata_read")
                 .addAlias(ElasticIO.INDEX_NAME_WRITE, "metric_metadata_read").execute().actionGet();
         elasticIO.setINDEX_NAME_READ("metric_metadata_read");
-        List<SearchResult> results = elasticIO.search(TENANT_A, "one.two.three00.fourA.five0");
+        results = elasticIO.search(TENANT_A, testLocator.getMetricName());
         // Should just be one result
         Assert.assertEquals(results.size(), 1);
-        Assert.assertEquals(results.get(0).getMetricName(), "one.two.three00.fourA.five0");
+        Assert.assertEquals(results.get(0).getMetricName(), testLocator.getMetricName());
     }
 }


### PR DESCRIPTION
While using aliases, its possible that we return duplicate metric names after searching multiple indices. This PR adds de-duplication before returning back the results.

__TODO__

1. ~~Add a test~~
