### PR TITLE
Fix ElasticIOTest and KafkaServiceTest

### DIFF
--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/service/ElasticIOTest.java
@@ -266,5 +266,7 @@ public class ElasticIOTest {
         // Should just be one result
         Assert.assertEquals(results.size(), 1);
         Assert.assertEquals(results.get(0).getMetricName(), testLocator.getMetricName());
+        elasticIO.setINDEX_NAME_READ(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_READ.getDefaultValue());
+        elasticIO.setINDEX_NAME_WRITE(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_WRITE.getDefaultValue());
     }
 }

--- a/blueflood-kafka/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/KafkaServiceTest.java
+++ b/blueflood-kafka/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/KafkaServiceTest.java
@@ -51,9 +51,6 @@ public class KafkaServiceTest {
         RollupEventEmitter.getInstance().emit(eventName, rollupEvent);
         //Verify that the call method was called atleast once
         verify(kafkaServiceSpy, timeout(1000).atLeastOnce()).call(rollupEvent);
-
-        //Test whether executor got the task
-        Assert.assertEquals(kafkaServiceSpy.getKafkaExecutorsUnsafe().getTaskCount(), 1);
         //Verify that there were interactions with the mock producer
         verify(mockProducer, timeout(1000)).send(anyListOf(KeyedMessage.class));
 


### PR DESCRIPTION
This fixes the intermittent failures in the below tests:

1. `ElasticIOTest` : testDeDupMetrics was overriding the index names and causing interference with other tests depending on test run order. I am switching the index names back to default in the test.

2. `KafkaServiceTest` : we were asserting on the thread pool executor run which is system dependent. The previous call to verify whether the `call` method has been called is sufficient and inclusive of this assertion.