### PR TITLE
Add TrackerMbean to track request and response 

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
@@ -25,6 +25,7 @@ import com.rackspacecloud.blueflood.http.HttpRequestHandler;
 import com.rackspacecloud.blueflood.http.HttpResponder;
 import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainer;
 import com.rackspacecloud.blueflood.io.Constants;
+import com.rackspacecloud.blueflood.tracker.Tracker;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.Metric;
 import com.rackspacecloud.blueflood.types.MetricsCollection;
@@ -60,7 +61,6 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
     private static final Timer persistingTimer = Metrics.timer(HttpMetricsIngestionHandler.class, "HTTP Ingestion persisting timer");
     private static final Timer sendResponseTimer = Metrics.timer(HttpMetricsIngestionHandler.class, "HTTP Ingestion response sending timer");
 
-
     public HttpMetricsIngestionHandler(HttpMetricsIngestionServer.Processor processor, TimeValue timeout) {
         this.mapper = new ObjectMapper();
         this.typeFactory = TypeFactory.defaultInstance();
@@ -81,6 +81,9 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
         try {
+
+            Tracker.track(request);
+
             requestCount.inc();
             final String tenantId = request.getHeader("tenantId");
             JSONMetricsContainer jsonMetricsContainer = null;
@@ -181,13 +184,17 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
     }
 
     public static void sendResponse(ChannelHandlerContext channel, HttpRequest request, String messageBody, HttpResponseStatus status) {
+
         HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
         final Timer.Context sendResponseTimerContext = sendResponseTimer.time();
 
         try {
+
             if (messageBody != null && !messageBody.isEmpty()) {
                 response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
             }
+
+            Tracker.trackResponse(request, response);
             HttpResponder.respond(channel, request, response);
         } finally {
             sendResponseTimerContext.stop();

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -29,6 +29,8 @@ import com.rackspacecloud.blueflood.inputs.processors.RollupTypeCacher;
 import com.rackspacecloud.blueflood.inputs.processors.TypeAndUnitProcessor;
 import com.rackspacecloud.blueflood.io.IMetricsWriter;
 import com.rackspacecloud.blueflood.service.*;
+import com.rackspacecloud.blueflood.tracker.Tracker;
+import com.rackspacecloud.blueflood.tracker.TrackerMBean;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.MetricsCollection;
 import com.rackspacecloud.blueflood.utils.Metrics;
@@ -67,7 +69,9 @@ public class HttpMetricsIngestionServer {
 
     private TimeValue timeout;
     private static int MAX_CONTENT_LENGTH = 1048576; // 1 MB
-    
+
+    public TrackerMBean tracker;
+
     public HttpMetricsIngestionServer(ScheduleContext context, IMetricsWriter writer) {
         this.httpIngestPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_INGESTION_PORT);
         this.httpIngestHost = Configuration.getInstance().getStringProperty(HttpConfig.HTTP_INGESTION_HOST);
@@ -95,6 +99,9 @@ public class HttpMetricsIngestionServer {
 
         server.setPipelineFactory(new MetricsHttpServerPipelineFactory(router));
         server.bind(new InetSocketAddress(httpIngestHost, httpIngestPort));
+
+        log.info("Starting tracker service");
+        tracker = new Tracker();
     }
 
     private class MetricsHttpServerPipelineFactory implements ChannelPipelineFactory {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpStatsDIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpStatsDIngestionHandler.java
@@ -28,6 +28,7 @@ import com.rackspacecloud.blueflood.inputs.handlers.wrappers.Bundle;
 import com.rackspacecloud.blueflood.io.AstyanaxWriter;
 import com.rackspacecloud.blueflood.io.CassandraModel;
 import com.rackspacecloud.blueflood.io.Constants;
+import com.rackspacecloud.blueflood.tracker.Tracker;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.MetricsCollection;
 import com.rackspacecloud.blueflood.utils.Metrics;
@@ -62,9 +63,11 @@ public class HttpStatsDIngestionHandler implements HttpRequestHandler {
     // our own stuff.
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
-        
+
+        Tracker.track(request);
+
         final Timer.Context timerContext = handlerTimer.time();
-        
+
         // this is all JSON.
         final String body = request.getContent().toString(Constants.DEFAULT_CHARSET);
         try {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpHistogramQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpHistogramQueryHandler.java
@@ -31,6 +31,7 @@ import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.outputs.serializers.JSONHistogramOutputSerializer;
 import com.rackspacecloud.blueflood.outputs.utils.PlotRequestParser;
 import com.rackspacecloud.blueflood.rollup.Granularity;
+import com.rackspacecloud.blueflood.tracker.Tracker;
 import com.rackspacecloud.blueflood.types.Resolution;
 import com.rackspacecloud.blueflood.outputs.utils.RollupsQueryParams;
 import com.rackspacecloud.blueflood.utils.Metrics;
@@ -84,6 +85,9 @@ public class HttpHistogramQueryHandler extends RollupHandler implements HttpRequ
 
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
+
+        Tracker.track(request);
+
         final String tenantId = request.getHeader("tenantId");
         final String metricName = request.getHeader("metricName");
 
@@ -125,11 +129,14 @@ public class HttpHistogramQueryHandler extends RollupHandler implements HttpRequ
 
     private void sendResponse(ChannelHandlerContext channel, HttpRequest request, String messageBody,
                               HttpResponseStatus status) {
+
         HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
 
         if (messageBody != null && !messageBody.isEmpty()) {
             response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
+
+        Tracker.trackResponse(request, response);
         HttpResponder.respond(channel, request, response);
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
@@ -6,6 +6,7 @@ import com.rackspacecloud.blueflood.http.HttpResponder;
 import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.io.DiscoveryIO;
 import com.rackspacecloud.blueflood.io.SearchResult;
+import com.rackspacecloud.blueflood.tracker.Tracker;
 import com.rackspacecloud.blueflood.utils.QueryDiscoveryModuleLoader;
 import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.node.JsonNodeFactory;
@@ -28,6 +29,9 @@ public class HttpMetricsIndexHandler implements HttpRequestHandler {
 
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
+
+        Tracker.track(request);
+
         final String tenantId = request.getHeader("tenantId");
 
         HTTPRequestWithDecodedQueryParams requestWithParams = (HTTPRequestWithDecodedQueryParams) request;
@@ -55,10 +59,14 @@ public class HttpMetricsIndexHandler implements HttpRequestHandler {
 
     private void sendResponse(ChannelHandlerContext channel, HttpRequest request, String messageBody,
                               HttpResponseStatus status) {
+
         HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+
         if (messageBody != null && !messageBody.isEmpty()) {
             response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
+
+        Tracker.trackResponse(request, response);
         HttpResponder.respond(channel, request, response);
     }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandler.java
@@ -30,6 +30,7 @@ import com.rackspacecloud.blueflood.outputs.serializers.BatchedMetricsOutputSeri
 import com.rackspacecloud.blueflood.outputs.utils.PlotRequestParser;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.HttpConfig;
+import com.rackspacecloud.blueflood.tracker.Tracker;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.outputs.utils.RollupsQueryParams;
 import com.rackspacecloud.blueflood.utils.TimeValue;
@@ -73,6 +74,9 @@ public class HttpMultiRollupsQueryHandler extends RollupHandler implements HttpR
 
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
+
+        Tracker.track(request);
+
         final String tenantId = request.getHeader("tenantId");
 
         if (!(request instanceof HTTPRequestWithDecodedQueryParams)) {
@@ -143,11 +147,14 @@ public class HttpMultiRollupsQueryHandler extends RollupHandler implements HttpR
 
     private void sendResponse(ChannelHandlerContext channel, HttpRequest request, String messageBody,
                               HttpResponseStatus status) {
+
         HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
 
         if (messageBody != null && !messageBody.isEmpty()) {
             response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
+
+        Tracker.trackResponse(request, response);
         HttpResponder.respond(channel, request, response);
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
@@ -32,6 +32,7 @@ import com.rackspacecloud.blueflood.outputs.serializers.JSONBasicRollupsOutputSe
 import com.rackspacecloud.blueflood.outputs.serializers.BasicRollupsOutputSerializer.MetricStat;
 import com.rackspacecloud.blueflood.outputs.utils.PlotRequestParser;
 import com.rackspacecloud.blueflood.rollup.Granularity;
+import com.rackspacecloud.blueflood.tracker.Tracker;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Resolution;
 import com.rackspacecloud.blueflood.outputs.utils.RollupsQueryParams;
@@ -108,6 +109,9 @@ public class HttpRollupsQueryHandler extends RollupHandler
 
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
+
+        Tracker.track(request);
+
         final String tenantId = request.getHeader("tenantId");
         final String metricName = request.getHeader("metricName");
 
@@ -154,11 +158,14 @@ public class HttpRollupsQueryHandler extends RollupHandler
 
     private void sendResponse(ChannelHandlerContext channel, HttpRequest request, String messageBody,
                              HttpResponseStatus status) {
+
         HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
 
         if (messageBody != null && !messageBody.isEmpty()) {
             response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
+
+        Tracker.trackResponse(request, response);
         HttpResponder.respond(channel, request, response);
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2013-2015 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.tracker;
+
+import com.rackspacecloud.blueflood.http.HTTPRequestWithDecodedQueryParams;
+import com.rackspacecloud.blueflood.io.Constants;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class Tracker implements TrackerMBean {
+
+    private static final Logger log = LoggerFactory.getLogger(Tracker.class);
+    private static final String trackerName = String.format("com.rackspacecloud.blueflood.tracker:type=%s", Tracker.class.getSimpleName());
+
+    static Set tenantIds = new HashSet();
+
+    public Tracker() {
+        registerMBean();
+    }
+
+    public void addTenant(String tenantId) {
+        tenantIds.add(tenantId);
+        log.info("[TRACKER] tenantId " + tenantId + " added.");
+    }
+
+    public void removeTenant(String tenantId) {
+        tenantIds.remove(tenantId);
+        log.info("[TRACKER] tenantId " + tenantId + " removed.");
+    }
+
+    public void removeAllTenants() {
+        tenantIds.clear();
+        log.info("[TRACKER] all tenants removed.");
+    }
+
+    public static boolean isTracking(String tenantId) {
+        return tenantIds.contains(tenantId);
+    }
+
+    public Set getTenants() {
+        return tenantIds;
+    }
+
+    public void registerMBean() {
+        try {
+            ObjectName objectName = new ObjectName(trackerName);
+
+            // register TrackerMBean only if not already registered
+            MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            if (!mBeanServer.isRegistered(objectName)) {
+                ManagementFactory.getPlatformMBeanServer().registerMBean(this, objectName);
+            }
+        } catch (Exception exc) {
+            log.error("Unable to register mbean for " + this.getClass().getSimpleName(), exc);
+        }
+    }
+
+    public static void track(HttpRequest request) {
+        // check if tenantId is being tracked by JMX TenantTrackerMBean and log the request if it is
+        if (request == null) return;
+
+        String tenantId = request.getHeader("tenantId");
+        if (isTracking(tenantId)) {
+
+            // get headers
+            String headers = "";
+            for (String headerName : request.getHeaderNames()) {
+                headers += "\n" + headerName + "\t" + request.getHeader(headerName);
+            }
+
+            // get parameters
+            String queryParams = getQueryParameters(request);
+
+            // get request content
+            String requestContent = request.getContent().toString(Constants.DEFAULT_CHARSET);
+            if ((requestContent != null) && (!requestContent.isEmpty())) {
+                requestContent = "\nREQUEST_CONTENT:\n" + requestContent;
+            }
+
+            // log request
+            String logMessage = "[TRACKER] " +
+                    request.getMethod().toString() + " request for tenantId " + tenantId + ": " + request.getUri() + queryParams + "\n" +
+                    "HEADERS: " + headers +
+                    requestContent;
+
+            log.info(logMessage);
+        }
+    }
+
+    public static void trackResponse(HttpRequest request, HttpResponse response) {
+        // check if tenantId is being tracked by JMX TenantTrackerMBean and log the response if it is
+        // HttpRequest is needed for original request uri and tenantId
+        if (request == null) return;
+        if (response == null) return;
+
+        String tenantId = request.getHeader("tenantId");
+        if (isTracking(tenantId)) {
+            HttpResponseStatus status = response.getStatus();
+            String messageBody = response.getContent().toString(Constants.DEFAULT_CHARSET);
+
+            // get parameters
+            String queryParams = getQueryParameters(request);
+
+            // get response content
+            String responseContent = "";
+            if ((messageBody != null) && (!messageBody.isEmpty())) {
+                responseContent = "\nRESPONSE_CONTENT:\n" + messageBody;
+            }
+
+            String logMessage = "[TRACKER] " +
+                    "Response for tenantId " + tenantId + " request " + request.getUri() + queryParams + "\n" +
+                    "RESPONSE_STATUS: " + status.getCode() +
+                    responseContent;
+
+            log.info(logMessage);
+        }
+
+    }
+
+    static String getQueryParameters(HttpRequest httpRequest) {
+        String params = "";
+        Map<String, List<String>> parameters = ((HTTPRequestWithDecodedQueryParams) httpRequest).getQueryParams();
+
+        for (Map.Entry<String, List<String>> param : parameters.entrySet()) {
+            String paramName = param.getKey();
+            List<String> paramValues = param.getValue();
+
+            for (String paramValue : paramValues) {
+                if (!params.equals("")) {
+                    params += "&";
+                }
+                params += paramName + "=" + paramValue;
+            }
+        }
+
+        if (!params.equals("")) params = "?" + params;
+        return params;
+    }
+
+}

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/TrackerMBean.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/TrackerMBean.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2015 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.tracker;
+
+import java.util.Set;
+
+public interface TrackerMBean {
+
+    public void addTenant(String tenantId);
+    public void removeTenant(String tenantId);
+    public void removeAllTenants();
+    public Set getTenants();
+
+}

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
@@ -1,0 +1,65 @@
+package com.rackspacecloud.blueflood.tracker;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.Set;
+
+public class TrackerTest {
+    Tracker tracker;
+    String testTenant1 = "tenant1";
+    String testTenant2 = "tenant2";
+
+    @Before
+    public void setUp() {
+        tracker = new Tracker();
+    }
+
+    @Test
+    public void testAddTenant() {
+        tracker.addTenant(testTenant1);
+
+        Set tenants = tracker.getTenants();
+        Assert.assertTrue("tenant " + testTenant1 + " not added", tracker.isTracking(testTenant1));
+        Assert.assertTrue("tenants.size not 1", tenants.size() == 1);
+        Assert.assertTrue("tenants does not contain " + testTenant1, tenants.contains(testTenant1));
+    }
+
+    @Test
+    public void testDoesNotAddTenantTwice() {
+        tracker.addTenant(testTenant1);
+        tracker.addTenant(testTenant1);
+
+        Set tenants = tracker.getTenants();
+        Assert.assertTrue("tenant " + testTenant1 + " not added", tracker.isTracking(testTenant1));
+        Assert.assertTrue("tenants.size not 1", tenants.size() == 1);
+    }
+
+    @Test
+    public void testRemoveTenant() {
+        tracker.addTenant(testTenant1);
+        Assert.assertTrue("tenant " + testTenant1 + " not added", tracker.isTracking(testTenant1));
+
+        tracker.removeTenant(testTenant1);
+
+        Set tenants = tracker.getTenants();
+        Assert.assertFalse("tenant " + testTenant1 + " not removed", tracker.isTracking(testTenant1));
+        Assert.assertEquals("tenants.size not 0", tenants.size(), 0);
+        Assert.assertFalse("tenants contains " + testTenant1, tenants.contains(testTenant1));
+    }
+
+    @Test
+    public void testRemoveAllTenant() {
+        tracker.addTenant(testTenant1);
+        tracker.addTenant(testTenant2);
+        Assert.assertTrue("tenant " + testTenant1 + " not added", tracker.isTracking(testTenant1));
+        Assert.assertTrue("tenant " + testTenant2 + " not added", tracker.isTracking(testTenant2));
+
+        tracker.removeAllTenants();
+        Assert.assertFalse("tenant " + testTenant1 + " not removed", tracker.isTracking(testTenant1));
+        Assert.assertFalse("tenant " + testTenant2 + " not removed", tracker.isTracking(testTenant2));
+
+        Set tenants = tracker.getTenants();
+        Assert.assertEquals("tenants.size not 0", tenants.size(), 0);
+    }
+}


### PR DESCRIPTION
Track request and response for specific tenants, configurable via JMX.  Multiple tenants allowed.

A new JMX MBean is added (accessible via jolokia, JConsole, VisualVM, etc) called:
com.rackspacecloud.blueflood.tracker, with class Tracker containing the attributes "Tenants", which is a Set of Strings for the tenantIds being tracked (readonly with property accessor method getTenants()), and the Operations "addTenant", "removeTenant", "removeAllTenants", and "isTracking" to manage the Tenants list.

Below are examples of the output dump to the log:

```
2015-07-27 16:30:48 INFO  Tracker             :51  - [TRACKER] tenantId 112358 added.
2015-07-27 16:45:53 INFO  Tracker             :56  - [TRACKER] tenantId 1123 removed.
2015-07-27 16:45:57 INFO  Tracker             :61  - [TRACKER] all tenants removed.
2015-07-27 16:46:42 INFO  Tracker             :51  - [TRACKER] tenantId 112358 added.

2015-07-27 16:31:02 INFO  Tracker             :152 - [TRACKER] POST request for tenantId 112358: /v1.0/112358/experimental/metrics
HEADERS: 
Accept	*/*
Content-Length	164
Content-Type	application/x-www-form-urlencoded
Host	localhost:19000
tenantId	112358
User-Agent	curl/7.30.0
REQUEST_CONTENT:
[
      {
        "collectionTime": 1376509892612,
        "ttlInSeconds": 172800,
        "metricValue": 66,
        "metricName": "test.tracker.one"
      }
    ]
2015-07-27 16:31:02 INFO  Tracker             :174 - [TRACKER] Response for tenantId 112358 request /v1.0/112358/experimental/metrics
RESPONSE_STATUS: 200
```

```
2015-07-27 16:31:24 INFO  Tracker             :152 - [TRACKER] POST request for tenantId 112358: /v2.0/112358/ingest
HEADERS: 
Accept	*/*
Content-Length	164
Content-Type	application/x-www-form-urlencoded
Host	localhost:19000
tenantId	112358
User-Agent	curl/7.30.0
REQUEST_CONTENT:
[
      {
        "collectionTime": 1376509892612,
        "ttlInSeconds": 172800,
        "metricValue": 66,
        "metricName": "test.tracker.one"
      }
    ]
2015-07-27 16:31:24 INFO  Tracker             :174 - [TRACKER] Response for tenantId 112358 request /v2.0/112358/ingest
RESPONSE_STATUS: 200
```

```
2015-07-27 16:31:32 INFO  Tracker             :152 - [TRACKER] GET request for tenantId 112358: /v1.0/112358/experimental/views/metric_data/test.tracker.one?from=1376509892611&to=1376509892613&points=200
HEADERS: 
Accept	*/*
Host	localhost:20000
metricName	test.tracker.one
tenantId	112358
User-Agent	curl/7.30.0
2015-07-27 16:31:32 INFO  Tracker             :174 - [TRACKER] Response for tenantId 112358 request /v1.0/112358/experimental/views/metric_data/test.tracker.one?from=1376509892611&to=1376509892613&points=200
RESPONSE_STATUS: 200
RESPONSE_CONTENT:
{
  "unit": "unknown",
  "values": [
    {
      "numPoints": 1,
      "timestamp": 1376438400000,
      "average": 66
    }
  ],
  "metadata": {
    "limit": null,
    "next_href": null,
    "count": 1,
    "marker": null
  }
}
```

```
2015-07-27 16:31:42 INFO  Tracker             :152 - [TRACKER] GET request for tenantId 112358: /v1.0/112358/experimental/views/histograms/test.tracker.one?from=1376509892611&to=1376509892613&points=200
HEADERS: 
Accept	*/*
Host	localhost:20000
metricName	test.tracker.one
tenantId	112358
User-Agent	curl/7.30.0
2015-07-27 16:31:42 INFO  Tracker             :174 - [TRACKER] Response for tenantId 112358 request /v1.0/112358/experimental/views/histograms/test.tracker.one?from=1376509892611&to=1376509892613&points=200
RESPONSE_STATUS: 200
RESPONSE_CONTENT:
{
  "values": [],
  "metadata": {
    "limit": null,
    "next_href": null,
    "count": 0,
    "marker": null
  }
}
```

```
2015-07-27 16:31:48 INFO  Tracker             :152 - [TRACKER] GET request for tenantId 112358: /v2.0/112358/views/test.tracker.one?from=1376509892611&to=1376509892613&points=200
HEADERS: 
Accept	*/*
Host	localhost:20000
metricName	test.tracker.one
tenantId	112358
User-Agent	curl/7.30.0
2015-07-27 16:31:48 INFO  Tracker             :174 - [TRACKER] Response for tenantId 112358 request /v2.0/112358/views/test.tracker.one?from=1376509892611&to=1376509892613&points=200
RESPONSE_STATUS: 200
RESPONSE_CONTENT:
{
  "unit": "unknown",
  "values": [
    {
      "numPoints": 1,
      "timestamp": 1376438400000,
      "average": 66
    }
  ],
  "metadata": {
    "limit": null,
    "next_href": null,
    "count": 1,
    "marker": null
  }
}
```

```
2015-07-27 16:32:03 INFO  Tracker             :152 - [TRACKER] GET request for tenantId 112358: /v2.0/112358/views/test.tracker.one?from=1376509892611
HEADERS: 
Accept	*/*
Host	localhost:20000
metricName	test.tracker.one
tenantId	112358
User-Agent	curl/7.30.0
015-07-27 16:32:03 INFO  Tracker             :174 - [TRACKER] Response for tenantId 112358 request /v2.0/112358/views/test.tracker.one?from=1376509892611
RESPONSE_STATUS: 400
RESPONSE_CONTENT:
Either 'points' or 'resolution' is required.
```

```
015-07-27 16:32:16 INFO  Tracker             :152 - [TRACKER] GET request for tenantId 112358: /v2.0/112358/views/histograms/test.tracker.one
HEADERS: 
Accept	*/*
Host	localhost:20000
metricName	test.tracker.one
tenantId	112358
User-Agent	curl/7.30.0
2015-07-27 16:32:16 INFO  Tracker             :174 - [TRACKER] Response for tenantId 112358 request /v2.0/112358/views/histograms/test.tracker.one
RESPONSE_STATUS: 400
RESPONSE_CONTENT:
No query parameters present.
```

```
2015-07-27 16:32:22 INFO  Tracker             :152 - [TRACKER] GET request for tenantId 112358: /v2.0/112358/views/histograms/test.tracker.one?from=1376509892611&to=1376509892613&points=200
HEADERS: 
Accept	*/*
Host	localhost:20000
metricName	test.tracker.one
tenantId	112358
User-Agent	curl/7.30.0
2015-07-27 16:32:22 INFO  Tracker             :174 - [TRACKER] Response for tenantId 112358 request /v2.0/112358/views/histograms/test.tracker.one?from=1376509892611&to=1376509892613&points=200
RESPONSE_STATUS: 200
RESPONSE_CONTENT:
{
  "values": [],
  "metadata": {
    "limit": null,
    "next_href": null,
    "count": 0,
    "marker": null
  }
}
```

```
2015-07-27 16:32:27 INFO  Tracker             :152 - [TRACKER] GET request for tenantId 112358: /v2.0/112358/metrics/search?query=search00.iad.diamond.interrupts.IR-PCI-MSI-edge_p9p2-TxRx-21.*
HEADERS: 
Accept	*/*
Host	localhost:20000
tenantId	112358
User-Agent	curl/7.30.0
2015-07-27 16:32:27 INFO  Tracker             :174 - [TRACKER] Response for tenantId 112358 request /v2.0/112358/metrics/search?query=search00.iad.diamond.interrupts.IR-PCI-MSI-edge_p9p2-TxRx-21.*
RESPONSE_STATUS: 500
RESPONSE_CONTENT:
Error getting metrics index
```
