### PR TITLE
cassandra_connection_fix

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxIO.java
@@ -94,7 +94,6 @@ public class AstyanaxIO {
         final ConnectionPoolConfigurationImpl connectionPoolConfiguration = new ConnectionPoolConfigurationImpl("MyConnectionPool")
                 .setPort(port)
                 .setSocketTimeout(timeout)
-                .setInitConnsPerHost(connsPerHost)
                 .setMaxConnsPerHost(connsPerHost)
                 .setMaxBlockedThreadsPerHost(5)
                 .setMaxTimeoutWhenExhausted(timeoutWhenExhausted)


### PR DESCRIPTION
.setInitConnsPerHost() was used twice 
First time as .setInitConnsPerHost(connsPerHost)
Second time as .setInitConnsPerHost(connsPerHost / 2).

So, remove the first one, as second one was overriding.