### PR TITLE
Multi-tenant enums ingestion

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/CassandraModel.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/CassandraModel.java
@@ -155,7 +155,7 @@ public class CassandraModel {
         } else if (type.equals(HistogramRollup.class)) {
             return HIST_GRAN_TO_CF.get(granularity);
         } else if (type.equals(BluefloodSetRollup.class) || type.equals(BluefloodTimerRollup.class) || type.equals(BluefloodGaugeRollup.class) ||
-                type.equals(BluefloodCounterRollup.class) || type.equals(EnumRollup.class)) {
+                type.equals(BluefloodCounterRollup.class) || type.equals(BluefloodEnumRollup.class)) {
             return PREAG_GRAN_TO_CF.get(granularity);
         } else {
             throw new RuntimeException("Unsupported rollup type.");

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/BluefloodEnumRollup.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/BluefloodEnumRollup.java
@@ -3,10 +3,10 @@ package com.rackspacecloud.blueflood.types;
 import java.util.HashMap;
 import java.util.Map;
 
-public class EnumRollup implements Rollup {
+public class BluefloodEnumRollup implements Rollup {
     private Map<String, Long> en2Value = new HashMap<String, Long>();
 
-    public EnumRollup withEnumValue(String valueName, Long value) {
+    public BluefloodEnumRollup withEnumValue(String valueName, Long value) {
         this.en2Value.put(valueName, value);
         return this;
     }
@@ -31,10 +31,10 @@ public class EnumRollup implements Rollup {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof EnumRollup)) {
+        if (obj == null || !(obj instanceof BluefloodEnumRollup)) {
             return false;
         }
-        EnumRollup other = (EnumRollup)obj;
+        BluefloodEnumRollup other = (BluefloodEnumRollup)obj;
         return en2Value.equals(other.en2Value);
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/RollupType.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/RollupType.java
@@ -40,7 +40,7 @@ public enum RollupType {
             return RollupType.BF_HISTOGRAMS;
         else if (value instanceof SimpleNumber)
             return RollupType.NOT_A_ROLLUP;
-        else if (value instanceof EnumRollup) {
+        else if (value instanceof BluefloodEnumRollup) {
             return RollupType.ENUM;
         }
         else
@@ -64,7 +64,7 @@ public enum RollupType {
         else if (type == RollupType.BF_HISTOGRAMS)
             return HistogramRollup.class;
         else if(type == RollupType.ENUM)
-            return EnumRollup.class;
+            return BluefloodEnumRollup.class;
         else
             throw new IllegalArgumentException(String.format("Unexpected type/gran combination: %s, %s", type, gran));
     }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/EnumRollupSerializationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/EnumRollupSerializationTest.java
@@ -19,7 +19,7 @@
 package com.rackspacecloud.blueflood.io.serializers;
 
 import com.rackspacecloud.blueflood.io.Constants;
-import com.rackspacecloud.blueflood.types.EnumRollup;
+import com.rackspacecloud.blueflood.types.BluefloodEnumRollup;
 import junit.framework.Assert;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
@@ -31,8 +31,8 @@ public class EnumRollupSerializationTest {
 
     @Test
     public void testEnumV1RoundTrip() throws IOException {
-        EnumRollup e0 = new EnumRollup().withEnumValue("enumValue1", (long) 1).withEnumValue("enumValuu2", 5L);
-        EnumRollup e1 = new EnumRollup().withEnumValue("t4.enum.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met", 34454722343L)
+        BluefloodEnumRollup e0 = new BluefloodEnumRollup().withEnumValue("enumValue1", (long) 1).withEnumValue("enumValuu2", 5L);
+        BluefloodEnumRollup e1 = new BluefloodEnumRollup().withEnumValue("t4.enum.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met", 34454722343L)
                             .withEnumValue("t5.enum.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met", 34454722343L);
 
         if (System.getProperty("GENERATE_ENUM_SERIALIZATION") != null) {
@@ -53,11 +53,11 @@ public class EnumRollupSerializationTest {
             BufferedReader reader = new BufferedReader(new FileReader("src/test/resources/serializations/enum_version_" + version + ".bin"));
 
             ByteBuffer bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
-            EnumRollup ee0 = NumericSerializer.serializerFor(EnumRollup.class).fromByteBuffer(bb);
+            BluefloodEnumRollup ee0 = NumericSerializer.serializerFor(BluefloodEnumRollup.class).fromByteBuffer(bb);
             Assert.assertEquals(e0, ee0);
 
             bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
-            EnumRollup ee1 = NumericSerializer.serializerFor(EnumRollup.class).fromByteBuffer(bb);
+            BluefloodEnumRollup ee1 = NumericSerializer.serializerFor(BluefloodEnumRollup.class).fromByteBuffer(bb);
             Assert.assertEquals(e1, ee1);
 
             Assert.assertFalse(ee0.equals(ee1));

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/IMetricSerializerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/IMetricSerializerTest.java
@@ -52,13 +52,13 @@ public class IMetricSerializerTest {
 
     @Test
     public void testEnumSerialization() throws IOException {
-        String enumRollupString = "{\"type\":\"EnumRollup\",\"count\":2,\"en2Value\":{\"-1365468863\":2,\"233047280\":5},\"hashes\":{\"-1365468863\":2,\"233047280\":5}}";
+        String enumRollupString = "{\"type\":\"BluefloodEnumRollup\",\"count\":2,\"en2Value\":{\"-1365468863\":2,\"233047280\":5},\"hashes\":{\"-1365468863\":2,\"233047280\":5}}";
 
-        EnumRollup enumDeserialized = mapper.readValue(enumRollupString, EnumRollup.class);
+        BluefloodEnumRollup enumDeserialized = mapper.readValue(enumRollupString, BluefloodEnumRollup.class);
         String enumSerialized = mapper.writeValueAsString(enumDeserialized);
         Assert.assertEquals(enumRollupString, enumSerialized);
 
-        EnumRollup enumReDeserialized = mapper.readValue(enumSerialized, EnumRollup.class);
+        BluefloodEnumRollup enumReDeserialized = mapper.readValue(enumSerialized, BluefloodEnumRollup.class);
         Assert.assertEquals(enumDeserialized,enumReDeserialized);
 
         PreaggregatedMetric m = new PreaggregatedMetric(12345l, goneIn, sixtySeconds, enumReDeserialized);

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
@@ -240,7 +240,7 @@ public class HttpHandlerIntegrationTest {
     @Test
     public void testHttpAggregatedMultiIngestionHappyCase() throws Exception {
         StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/test/resources/sample_multi_bundle.json")));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/test/resources/sample_multi_aggregated_payload.json")));
         String curLine = reader.readLine();
         while (curLine != null) {
             sb = sb.append(curLine);

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
@@ -129,7 +129,7 @@ public class PreaggregateConversions {
         List<PreaggregatedMetric> list = new ArrayList<PreaggregatedMetric>(enums.size());
         for (BluefloodEnum en : enums) {
             Locator locator = Locator.createLocatorFromPathComponents(tenant, en.getName().split(NAME_DELIMITER, -1));
-            EnumRollup rollup = new EnumRollup();
+            BluefloodEnumRollup rollup = new BluefloodEnumRollup();
             rollup = rollup.withEnumValue(en.getValue(), 1L);
             PreaggregatedMetric metric = new PreaggregatedMetric(timestamp, locator, DEFAULT_TTL, rollup);
             list.add(metric);

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionTests.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionTests.java
@@ -39,7 +39,7 @@ public class HttpAggregatedMultiIngestionTests {
     @Before
     public void buildBundle() throws IOException {
         StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/test/resources/sample_multi_bundle.json")));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/test/resources/sample_multi_aggregated_payload.json")));
         String curLine = reader.readLine();
         while (curLine != null) {
             sb = sb.append(curLine);
@@ -103,6 +103,15 @@ public class HttpAggregatedMultiIngestionTests {
             Collection<PreaggregatedMetric> timers = PreaggregateConversions.convertTimers("1", 1, bundle.getTimers());
             Assert.assertEquals(1, timers.size());
             ensureSerializability(timers);
+        }
+    }
+
+    @Test
+    public void testEnums() {
+        for (AggregatedPayload bundle : bundleList) {
+            Collection<PreaggregatedMetric> enums = PreaggregateConversions.convertEnums("1", 1, bundle.getEnums());
+            Assert.assertEquals(1, enums.size());
+            ensureSerializability(enums);
         }
     }
     

--- a/blueflood-http/src/test/resources/sample_multi_aggregated_payload.json
+++ b/blueflood-http/src/test/resources/sample_multi_aggregated_payload.json
@@ -27,6 +27,12 @@
                 "name":"S500ms",
                 "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
             }
+        ],
+        "enums": [
+            {
+                "name": "call_xyz_api",
+                "value": "500"
+            }
         ]
     },
     {
@@ -57,6 +63,12 @@
                 "name":"S500ms",
                 "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
             }
+        ],
+        "enums": [
+            {
+                "name": "call_xyz_api",
+                "value": "500"
+            }
         ]
     },
     {
@@ -86,6 +98,12 @@
             {
                 "name":"S500ms",
                 "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
+            }
+        ],
+        "enums": [
+            {
+                "name": "call_xyz_api",
+                "value": "500"
             }
         ]
     }


### PR DESCRIPTION
*what:*
test and renaming to check that enums can be ingested using multi-tenant endpoint

*why:*
multi-tenant aggregated endpoint was developed almost in parallel with the enums-ingestion. Making sure that the twain can meet. 

*how:*
Renamed EnumRollup to BluefloodEnumRollup
Renamed sample_multi_bundle.json to sample_multi_aggregated_payload.json
Added enums payload to it.
Added a test to check enums serializability with the multi endpoint