### PR TITLE
fix failing tests in inputs.handlers

### DIFF
--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>com.github.tlrx</groupId>
       <artifactId>elasticsearch-test</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.1</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -193,7 +193,7 @@
     <dependency>
       <groupId>com.github.tlrx</groupId>
       <artifactId>elasticsearch-test</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.1</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndTest.java
@@ -73,7 +73,7 @@ public class HttpAnnotationsEndToEndTest {
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("metrics", EsSetup.fromClassPath("events_mapping.json")));
+                .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
         eventsSearchIO = new EventElasticSearchIO(esSetup.client());
         HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context, new AstyanaxMetricsWriter());
         server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
@@ -153,7 +153,12 @@ public class HttpAnnotationsEndToEndTest {
     @AfterClass
     public static void tearDownClass() throws Exception{
         Configuration.getInstance().setProperty(CoreConfig.EVENTS_MODULES.name(), "");
-        esSetup.terminate();
-        httpQueryService.stopService();
+        if (esSetup != null) {
+            esSetup.terminate();
+        }
+
+        if (httpQueryService != null) {
+            httpQueryService.stopService();
+        }
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
@@ -71,7 +71,7 @@ public class HttpHandlerIntegrationTest {
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("metrics", EsSetup.fromClassPath("events_mapping.json")));
+                .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
         eventsSearchIO = new EventElasticSearchIO(esSetup.client());
         HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context, new AstyanaxMetricsWriter());
         server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
@@ -410,7 +410,12 @@ public class HttpHandlerIntegrationTest {
     
     @AfterClass
     public static void shutdown() {
-        esSetup.terminate();
-        vendor.shutdown();
+        if (esSetup != null) {
+            esSetup.terminate();
+        }
+
+        if (vendor != null) {
+            vendor.shutdown();
+        }
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpAnnotationsIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpAnnotationsIntegrationTest.java
@@ -53,7 +53,7 @@ public class HttpAnnotationsIntegrationTest {
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("annotations", EsSetup.fromClassPath("events_mapping.json")));
+                .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
         eventsIO = new EventElasticSearchIO(esSetup.client());
 
         httpQueryService = new HttpQueryService();
@@ -191,7 +191,13 @@ public class HttpAnnotationsIntegrationTest {
     @AfterClass
     public static void tearDownClass() throws Exception{
         Configuration.getInstance().setProperty(CoreConfig.EVENTS_MODULES.name(), "");
-        esSetup.terminate();
-        httpQueryService.stopService();
+
+        if (esSetup != null) {
+            esSetup.terminate();
+        }
+
+        if (httpQueryService != null) {
+            httpQueryService.stopService();
+        }
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
@@ -256,7 +256,12 @@ public class HttpRollupHandlerIntegrationTest extends IntegrationTestBase {
 
     @AfterClass
     public static void shutdown() {
-        vendor.shutdown();
-        httpQueryService.stopService();
+        if (vendor != null) {
+            vendor.shutdown();
+        }
+
+        if (httpQueryService != null) {
+            httpQueryService.stopService();
+        }
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -204,7 +204,13 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
     public static void tearDownClass() throws Exception{
         Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(), "");
         Configuration.getInstance().setProperty(CoreConfig.USE_ES_FOR_UNITS.name(), "false");
-        esSetup.terminate();
-        httpQueryService.stopService();
+
+        if (esSetup != null) {
+            esSetup.terminate();
+        }
+
+        if (httpQueryService != null) {
+            httpQueryService.stopService();
+        }
     }
 }


### PR DESCRIPTION
WHAT:  fix failing tests after ES upgrades to 1.7.1

HOW:  tests are broken because of invalid mappings and setups, which before was ok but now is not.
