### PR TITLE
Add enums to the finder

### DIFF
--- a/contrib/graphite/blueflood.py
+++ b/contrib/graphite/blueflood.py
@@ -10,6 +10,10 @@ import traceback
 import os.path
 import fnmatch
 
+import Queue
+import threading
+
+
 try:
     from graphite_api.intervals import Interval, IntervalSet
     from graphite_api.node import LeafNode, BranchNode
@@ -49,10 +53,11 @@ def calc_res(start, stop):
     res = 'MIN1440'
   return res
 
-class TenantBluefloodFinder(object):
+class TenantBluefloodFinder(threading.Thread):
   __fetch_multi__ = 'tenant_blueflood'
   def __init__(self, config=None):
-    print("Blueflood Finder v28")
+    print("Blueflood Finder v31")
+    threading.Thread.__init__(self)
     if os.path.isfile("/root/pdb-flag"):
       import remote_pdb
       remote_pdb.RemotePdb('127.0.0.1', 4444).set_trace()
@@ -79,23 +84,33 @@ class TenantBluefloodFinder(object):
       bfauth = class_(config)
       auth.set_auth(bfauth)
 
+    self.exit_flag = 0
+    self.metrics_q = Queue.Queue(1)
+    self.data_q = Queue.Queue(1)
+
     self.tenant = tenant
     self.bf_query_endpoint = urls[0]
     self.enable_submetrics = enable_submetrics
     self.submetric_aliases = submetric_aliases
     self.client = BluefloodClient(self.bf_query_endpoint, self.tenant, 
                                   self.enable_submetrics, self.submetric_aliases)
+    self.daemon = True
+    self.start()
     print("BF finder submetrics enabled: ", enable_submetrics)
 
-  def complete(self, metric, query_depth):
+  
+  def run(self):
+    #This separate thread allows queued reads to happen in the background
+    print("BF enum thread started: ")
+    while not self.exit_flag:
+      metric = self.metrics_q.get()
+      self.data_q.put(self.find_metrics_with_enum_values(metric))
+        
+
+  def complete(self, metric, complete_len):
+    #returns true if metric is a complete metric name wrt the query
     metric_parts = metric.split('.')
-    if self.enable_submetrics:
-      complete_len = query_depth - 1
-    else:
-      complete_len = query_depth 
     return (len(metric_parts) == complete_len)
-
-
 
   def make_request(self, url, payload, headers):
     if auth.is_active():
@@ -107,19 +122,30 @@ class TenantBluefloodFinder(object):
     return r
 
   def find_metrics_endpoint(self, endpoint, tenant):
-    return "%s/v2.0/%s/metrics/search" % (endpoint, tenant)
+    return "%s/v2.0/%s/metrics/search?include_enum_values=true" % (endpoint, tenant)
 
-  def find_metrics(self, query):
+  def find_metrics_with_enum_values(self, query):
+    #BF search command that returns enum values as well as metric names
     print "BluefloodClient.find_metrics: " + str(query)
     payload = {'query': query}
     headers = auth.headers()
     endpoint = self.find_metrics_endpoint(self.bf_query_endpoint, self.tenant)
     r = self.make_request(endpoint, payload, headers)
-
+    ret_dict = {}
     if r.status_code == 200:
-        return [m['metric'] for m in r.json()]
+      for m in r.json():
+        if 'enum_values' in m:
+          v = m['enum_values']
+        else:
+          v = None
+        ret_dict[m['metric']] = v
+      return ret_dict
     else:
-      return []
+      return {}
+
+  def find_metrics(self, query):
+    #BF search command that returns metric names without enum values
+    return self.find_metrics_with_enum_values(query).keys()
 
   def find_nodes_with_submetrics(self, query):
     # By definition, when using submetrics, the names of all Leafnodes must end in a submetric alias
@@ -134,13 +160,27 @@ class TenantBluefloodFinder(object):
     # Every submetric leaf node is covered by one of the above two cases.  Everything else is a 
     # branch node.
 
+    def submetric_is_enum_value(submetric_alias):
+      return self.submetric_aliases[submetric_alias] == 'enum'
+
     query_parts = query.pattern.split('.')
     query_depth = len(query_parts)
-
+    submetric_alias = query_parts[-1]
+    complete_len = query_depth - 1
     # The pattern which all complete metrics will match
-    complete_pattern = '.'.join(query_parts[0:-1])
-
-    if (query_depth > 1) and (query_parts[-1] == '*'):
+    complete_pattern = '.'.join(query_parts[:-1])
+    
+    #handle enums 
+    # enums are required to have an "enum" submetric alias so 
+    # this is the only read required, (no background read.)
+    if (query_depth > 2) and (submetric_alias in self.submetric_aliases):
+      if (submetric_is_enum_value(submetric_alias)):
+        enum_name = '.'.join(query_parts[:-2])
+        for metric, enums in self.find_metrics_with_enum_values(enum_name).items():
+          for n in self.make_enum_nodes(metric, enums, complete_pattern):
+            yield n
+        return
+    if (query_depth > 1) and (submetric_alias == '*'):
       #  In this if clause we are searching for complete metric names
       #  followed by a ".*". If so, we are requesting a list of submetric
       #  names, so return leaf nodes for each submetric alias that is
@@ -151,13 +191,13 @@ class TenantBluefloodFinder(object):
       new_pattern = complete_pattern + '*'
       for metric in self.find_metrics(new_pattern):
         metric_parts = metric.split('.')
-        if self.complete(metric, query_depth) and fnmatch.fnmatchcase(metric, complete_pattern):
+        if self.complete(metric, complete_len) and fnmatch.fnmatchcase(metric, complete_pattern):
           for alias, _ in self.submetric_aliases.items():
             yield TenantBluefloodLeafNode('.'.join(metric_parts + [alias]),
                                           TenantBluefloodReader(metric, self.tenant, 
                                                                 self.bf_query_endpoint, 
                                                                 self.enable_submetrics, 
-                                                                self.submetric_aliases))
+                                                                self.submetric_aliases, None))
         else:
           # Make sure the branch nodes match the original pattern
           if fnmatch.fnmatchcase(metric, query.pattern):
@@ -165,29 +205,56 @@ class TenantBluefloodFinder(object):
 
 
     #if searching for a particular submetric alias, create a leaf node for it
-    elif (query_depth > 1) and (query_parts[-1] in self.submetric_aliases):
+    elif (query_depth > 1) and (submetric_alias in self.submetric_aliases):
       for metric in self.find_metrics(complete_pattern):
-        if self.complete(metric, query_depth):
-          yield TenantBluefloodLeafNode('.'.join([metric, query_parts[-1]]), TenantBluefloodReader(metric, self.tenant, self.bf_query_endpoint, self.enable_submetrics, self.submetric_aliases))
+        if self.complete(metric, complete_len):
+          yield TenantBluefloodLeafNode('.'.join([metric, submetric_alias]), TenantBluefloodReader(metric, self.tenant, self.bf_query_endpoint, self.enable_submetrics, self.submetric_aliases, None))
 
     #everything else is a branch node
     else: 
       for metric in self.find_metrics(query.pattern):
         metric_parts = metric.split('.')
-        if not self.complete(metric, query_depth):
+        if not self.complete(metric, complete_len):
           yield BranchNode('.'.join(metric_parts[:query_depth]))
+
+
+  def make_non_enum_node(self, metric, complete_len):
+    if not self.complete(metric, complete_len):
+      metric_parts = metric.split('.')
+      yield BranchNode('.'.join(metric_parts[:complete_len]))
+    else:
+      yield TenantBluefloodLeafNode(metric, TenantBluefloodReader(metric, self.tenant, self.bf_query_endpoint, self.enable_submetrics, self.submetric_aliases, None))
+
+  def make_enum_nodes(self, metric, enums, pattern):
+    for e in enums:
+      metric_with_enum = metric + '.' + e
+      if fnmatch.fnmatchcase(metric_with_enum, pattern):
+        yield TenantBluefloodLeafNode(metric_with_enum, TenantBluefloodReader(metric_with_enum, self.tenant, self.bf_query_endpoint, self.enable_submetrics, self.submetric_aliases, e))
+
+
 
   def find_nodes_without_submetrics(self, query):
     query_parts = query.pattern.split('.')
-    query_depth = len(query_parts)
+    complete_len = len(query_parts)
 
+    # do a background read to see if this is an enum metric
+    if complete_len > 1:
+      enum_name = ".".join(query_parts[:-1])
+      self.metrics_q.put(enum_name)
+
+    # find non enum nodes
     for metric in self.find_metrics(query.pattern):
-      metric_parts = metric.split('.')
-      if not self.complete(metric, query_depth):
-        yield BranchNode('.'.join(metric_parts[:query_depth]))
-      else:
-        yield TenantBluefloodLeafNode(metric, TenantBluefloodReader(metric, self.tenant, self.bf_query_endpoint, self.enable_submetrics, self.submetric_aliases))
+      for n in self.make_non_enum_node(metric, complete_len):
+        yield n
 
+    # get the results of the background read to add enums
+    if complete_len > 1:
+      d = self.data_q.get()
+      for metric, enums in d.items():
+        metric_len = len(metric.split('.'))
+        if enums and (metric_len + 1 == complete_len):
+          for n in self.make_enum_nodes(metric, enums, query.pattern):
+            yield n
 
   def find_nodes(self, query):
     #yields all valid metric names matching glob based query
@@ -213,10 +280,10 @@ class TenantBluefloodFinder(object):
 
 class TenantBluefloodReader(object):
   __slots__ = ('metric', 'tenant', 'bf_query_endpoint', 
-               'enable_submetrics', 'submetric_aliases')
+               'enable_submetrics', 'submetric_aliases', 'enum_value')
   supported = True
 
-  def __init__(self, metric, tenant, endpoint, enable_submetrics, submetric_aliases):
+  def __init__(self, metric, tenant, endpoint, enable_submetrics, submetric_aliases, enum_value):
 
     # print 'READER ' + tenant + ' ' + metric
     self.metric = metric
@@ -224,6 +291,7 @@ class TenantBluefloodReader(object):
     self.bf_query_endpoint = endpoint
     self.enable_submetrics = enable_submetrics
     self.submetric_aliases = submetric_aliases
+    self.enum_value = enum_value
 
   def get_intervals(self):
     # todo: make this a lot smarter.
@@ -231,21 +299,6 @@ class TenantBluefloodReader(object):
     millis = int(round(time.time() * 1000))
     intervals.append(Interval(0, millis))
     return IntervalSet(intervals)
-
-  def fetch(self, start_time, end_time):
-    # remember, graphite treats time as seconds-since-epoch. BF treats time as millis-since-epoch.
-    if not self.metric:
-      return ((start_time, end_time, 1), [])
-    else:
-      client = BluefloodClient(self.bf_query_endpoint, self.tenant,
-                                  self.enable_submetrics, self.submetric_aliases)
-      reader = TenantBluefloodReader(self.metric, self.tenant, self.bf_query_endpoint, 
-                                     self.enable_submetrics, self.submetric_aliases)
-      node = TenantBluefloodLeafNode(self.metric, reader)
-
-      time_info, dictionary = client.fetch_multi([node], start_time, end_time)
-      
-      return (time_info, dictionary[self.metric])
 
 class BluefloodClient(object):
   def __init__(self, host, tenant, enable_submetrics, submetric_aliases):
@@ -265,13 +318,13 @@ class BluefloodClient(object):
   def gen_data_key(self, values):
     # Determines which key to use for the data
     if not len(values):
-      return None
+      return NonNestedDataKey(None)
     value_res_order = ['average', 'latest', 'numPoints']
     present_keys = [v for v in value_res_order if v in values[0]]
     if present_keys:
-      return present_keys[0]
+      return NonNestedDataKey(present_keys[0])
     else:
-      return None
+      return NonNestedDataKey(None)
 
   def current_datapoint_passed(self, v_iter, ts):
     # Determines if the current datapoint is too old to be considered
@@ -285,7 +338,7 @@ class BluefloodClient(object):
   def current_datapoint_valid(self, v_iter, data_key, ts, step):
     # Determines if the current datapoint be included in the current step
     #assumes current_datapoint_passed() is true
-    if (not len(v_iter)) or not (data_key in v_iter[0]):
+    if (not len(v_iter)) or not data_key.exists(v_iter[0]):
       return False
     datapoint_ts = v_iter[0]['timestamp']/1000
     if (datapoint_ts < (ts + step)):
@@ -331,7 +384,7 @@ class BluefloodClient(object):
       while self.current_datapoint_passed(v_iter, ts):
         v_iter = v_iter[1:]
       if self.current_datapoint_valid(v_iter, data_key, ts, step):
-        ret_arr.append(v_iter[0][data_key])
+        ret_arr.append(data_key.get_datapoints(v_iter[0]))
         if current_fixup != None:
           # we have found the end of the current fixup, so
           #  add the start and end of the current fixup into fixup list
@@ -360,7 +413,7 @@ class BluefloodClient(object):
       headers['X-Auth-Token'] = auth.get_token(True)
       r = requests.post(url, params=payload, data=json.dumps(metric_list), headers=headers)
     if r.status_code != 200:
-      print("get_metric_data failed; response: ", r.status_code, tenant, metric_list)
+      print("get_metric_data failed; response: ", endpoint, r.status_code, tenant, metric_list)
       return None
     else:
       return r.json()['metrics']
@@ -380,15 +433,19 @@ class BluefloodClient(object):
     #  metrics_key, (the name of the metric, which varies
     #   depending on if submetric aliases are used.)
     #  data_key, (the name of the key to use for the individual datapoint
-    #   returned by BF
+    #   returned by BF)
     metrics_key = None
-    data_key = None
-    if self.enable_submetrics:
+    data_key = NonNestedDataKey(None)
+    if node.reader.enum_value != None:
+      evalue = node.reader.enum_value
+      metrics_key = node.path[:-(len(evalue) + 1)]
+      data_key = NestedDataKey('enum_values', evalue)
+    elif self.enable_submetrics:
       path_parts = node.path.split('.')
-      test_key = '.'.join(path_parts[0:-1])
+      test_key = '.'.join(path_parts[:-1])
       if test_key in metrics:
         metrics_key = test_key
-        data_key = self.submetric_aliases[path_parts[-1]]
+        data_key = NonNestedDataKey(self.submetric_aliases[path_parts[-1]])
     elif node.path in metrics:
       metrics_key = node.path
       data_key = self.gen_data_key(metrics[metrics_key])
@@ -422,14 +479,34 @@ class BluefloodClient(object):
       tot_len += len(remaining_paths[cur_path]) + 2 # for the ", "
       cur_metric += 1
       cur_path += 1
-    return remaining_paths[cur_path:], groups + [remaining_paths[0:cur_path]]
+    return remaining_paths[cur_path:], groups + [remaining_paths[:cur_path]]
+
+  def gen_paths(self, nodes):
+    #This modifies the metrics names used by graphite to match
+    # the input expected by the BF mplot api.
+    # These differ when submetrics are used because the submetric alias
+    # is included in the graphite path but the BF metric name.
+    # Also, if enums are used, the enum_value is included in the 
+    # graphite path, but not the BF metric name
+    path_set = set()
+    paths = []
+    for n in nodes:
+      if n.reader.enum_value != None:
+        #add to a "set" here because some of the names may be dupes
+        path_set.add(n.path[:-(len(n.reader.enum_value) + 1)])
+      else:
+        if self.enable_submetrics:
+          path_set.add('.'.join(n.path.split('.')[:-1]))
+        else:
+          paths.append(n.path)
+    for p in path_set:
+      paths.append(p)
+    return paths
 
   def gen_groups(self, nodes):
     # creates groups of metrics none of which exceed limits
     groups = []
-    remaining_paths = [node.path for node in nodes]
-    if self.enable_submetrics:
-      remaining_paths = ['.'.join(p.split('.')[0:-1]) for p in remaining_paths]
+    remaining_paths = self.gen_paths(nodes)
     while remaining_paths:
       new_remaining_paths, groups = self.gen_next_group(remaining_paths, groups)
       #check for infinite loops/should never happen
@@ -473,3 +550,33 @@ class BluefloodClient(object):
 
 class TenantBluefloodLeafNode(LeafNode):
   __fetch_multi__ = 'tenant_blueflood'
+
+class NonNestedDataKey(object):
+  def __init__(self, key1):
+    self.key1 = key1
+
+  def exists(self, value):
+    return self.key1 in value
+
+  def get_datapoints(self, value):
+    if not self.exists(value):
+      return None
+    else:
+      return value[self.key1]
+    
+class NestedDataKey(object):
+  #as the name implies a "NestedDataKey is used to deref
+  # a nested value
+  def __init__(self, key1, key2):
+    self.key1 = key1
+    self.key2 = key2
+
+  def exists(self, value):
+    return self.key1 in value and self.key2 in value[self.key1]
+    
+  def get_datapoints(self, value):
+    if not self.exists(value):
+      return None
+    else:
+      return value[self.key1][self.key2]
+

--- a/contrib/graphite/tests.py
+++ b/contrib/graphite/tests.py
@@ -3,8 +3,11 @@ import unittest
 import os
 import datetime
 import requests_mock
+import sys
+import urllib
+import threading
 from blueflood import TenantBluefloodFinder, TenantBluefloodReader, TenantBluefloodLeafNode, \
-     BluefloodClient, auth, calc_res, secs_per_res
+     BluefloodClient, auth, calc_res, secs_per_res, NonNestedDataKey, NestedDataKey
 
 #To run these test you need to set up the environment vars below
 try:
@@ -53,25 +56,44 @@ def exc_callback(request, context):
   raise ValueError("Test exceptions")
 
 class BluefloodTests(TestCase):
+  # The "requests_mock" mocking framework we use is not thread-safe.
+  # This mock inserts a lock to fix that
+  fm_lock = threading.Lock()
+  orig_find_metrics_with_enum_values = TenantBluefloodFinder.find_metrics_with_enum_values
+  def mock_find_metrics_with_enum_values(s, query):
+    with BluefloodTests.fm_lock:
+      return BluefloodTests.orig_find_metrics_with_enum_values(s,query)
+  TenantBluefloodFinder.find_metrics_with_enum_values = mock_find_metrics_with_enum_values
+
   def setUp(self):
     self.alias_key = '_avg'
     config = {'blueflood':
               {'urls':["http://dummy.com"],
                'tenant':'dummyTenant',
-               'submetric_aliases': {self.alias_key:'average'}}}
+               'submetric_aliases': {self.alias_key:'average',
+                                     "_enum": 'enum'  }}}
     self.finder = TenantBluefloodFinder(config)
     self.metric1 = "a.b.c"
     self.metric2 = "e.f.g"
+    self.metric3 = "x.y.z"
     self.reader = TenantBluefloodReader(self.metric1, self.finder.tenant, self.finder.bf_query_endpoint,
-                                     self.finder.enable_submetrics, self.finder.submetric_aliases)
+                                        self.finder.enable_submetrics, self.finder.submetric_aliases, None)
+    metric_with_enum1 = self.metric3 + '.' + 'v1'
+    metric_with_enum2 = self.metric3 + '.' + 'v2'
+    self.enum_reader1 = TenantBluefloodReader(metric_with_enum1, self.finder.tenant, self.finder.bf_query_endpoint,
+                                             self.finder.enable_submetrics, self.finder.submetric_aliases, "v1")
+    self.enum_reader2 = TenantBluefloodReader(metric_with_enum2, self.finder.tenant, self.finder.bf_query_endpoint,
+                                             self.finder.enable_submetrics, self.finder.submetric_aliases, "v2")
     self.node1 = TenantBluefloodLeafNode(self.metric1, self.reader)
     self.node2 = TenantBluefloodLeafNode(self.metric2, self.reader)
+    self.node3 = TenantBluefloodLeafNode(metric_with_enum1, self.enum_reader1)
+    self.node4 = TenantBluefloodLeafNode(metric_with_enum2, self.enum_reader2)
     self.bfc = BluefloodClient(self.finder.bf_query_endpoint, self.finder.tenant,
                                self.finder.enable_submetrics, self.finder.submetric_aliases)
     auth.set_auth(None)
 
   def run_find(self, finder):
-    nodes = list(finder.find_nodes(FindQuery('rackspace.*', 0, 100)))
+    nodes = list(finder.find_nodes(FindQuery('*', 0, 100)))
     self.assertTrue(len(nodes) > 0)
 
   def setup_UTC_mock(self):
@@ -81,7 +103,7 @@ class BluefloodTests(TestCase):
     this = self
     self.authCount = 0
     def mock_get_current_UTC(self):
-      return this.orig_get_current_UTC(self) + datetime.timedelta(days=1)
+      return auth.auth.expiration_UTC + datetime.timedelta(days=1)
     def mock_do_auth(self):
       this.authCount += 1
       this.orig_do_auth(self)
@@ -121,17 +143,23 @@ class BluefloodTests(TestCase):
     self.bfc.maxmetrics_per_req = 1
     self.bfc.maxlen_per_req = 20
     groups = self.bfc.gen_groups([self.node1, self.node2])
-    self.assertTrue(groups == [['a.b.c'], ['e.f.g']])
+    self.assertSequenceEqual(groups,[['a.b.c'], ['e.f.g']])
+
+    #check that enum values get reduced to single metric name
+    self.bfc.maxmetrics_per_req = 1
+    self.bfc.maxlen_per_req = 20
+    groups = self.bfc.gen_groups([self.node3, self.node4])
+    self.assertSequenceEqual(groups,[['x.y.z']])
 
     #allow 2 metrics per group
     self.bfc.maxmetrics_per_req = 2
     groups = self.bfc.gen_groups([self.node1, self.node2])
-    self.assertTrue(groups == [['a.b.c', 'e.f.g']])
+    self.assertSequenceEqual(groups,[['a.b.c', 'e.f.g']])
 
     #now only room for 1 per group
     self.bfc.maxlen_per_req = 12
     groups = self.bfc.gen_groups([self.node1, self.node2])
-    self.assertTrue(groups == [['a.b.c'], ['e.f.g']])
+    self.assertSequenceEqual(groups,[['a.b.c'], ['e.f.g']])
 
     #no room for metric in a group
     self.bfc.maxlen_per_req = 11
@@ -145,17 +173,19 @@ class BluefloodTests(TestCase):
     self.bfc.maxmetrics_per_req = 1
     self.bfc.maxlen_per_req = 15
     groups = self.bfc.gen_groups([self.node1, self.node2])
-    self.assertTrue(groups == [['a.b'], ['e.f']])
+    self.assertSetEqual(set(tuple(map(tuple, groups))),set([('e.f',), ('a.b',)]))
 
     #allow 2 metrics per group
     self.bfc.maxmetrics_per_req = 2
     groups = self.bfc.gen_groups([self.node1, self.node2])
-    self.assertTrue(groups == [['a.b', 'e.f']])
+    self.assertSetEqual(set(tuple(map(tuple, groups))),set([('e.f', 'a.b',)]))
+
 
     #now only room for 1 per group
     self.bfc.maxlen_per_req = 10
     groups = self.bfc.gen_groups([self.node1, self.node2])
-    self.assertTrue(groups == [['a.b'], ['e.f']])
+    self.assertSetEqual(set(tuple(map(tuple, groups))),set([('e.f',), ('a.b',)]))
+
 
     #no room for metric in a group
     self.bfc.maxlen_per_req = 9
@@ -190,6 +220,26 @@ class BluefloodTests(TestCase):
                {u'timestamp': second_timestamp, u'average': 26421.18, u'numPoints': 1}], 
               u'metric': self.metric2, u'type': u'number', u'unit': u'unknown'}])
     
+  def make_enum_data(self, start, step):
+    # should be 0th element in response
+    first_timestamp = start * 1000
+    # should be skipped because it overlaps first_timestamp + 1000*step
+    second_timestamp = first_timestamp + (1000 * step - 1)
+    # should be 4th element
+    third_timestamp = first_timestamp + (5000 * step - 1)
+    # should be 7th element
+    fourth_timestamp = first_timestamp + (7000 * step + 1)
+
+    return ([self.node3, self.node4],
+            [{u'data':
+              [{u'timestamp': third_timestamp, u'average': 4449.97, u'numPoints': 1},
+               {u'timestamp': fourth_timestamp, u'average': 14449.97, u'numPoints': 1}],
+              u'metric': self.metric1, u'type': u'number', u'unit': u'unknown'},
+             {u'data':
+              [{u'timestamp': third_timestamp, u'enum_values': {u'v1': 13, u'v2': 7}, u'numPoints': 20},
+               {u'timestamp': fourth_timestamp, u'enum_values': {u'v1': 11, u'v2': 3}, u'numPoints': 14}], 
+              u'metric': self.metric3, u'type': u'number', u'unit': u'unknown'}])
+
   def test_gen_dict(self):
     step = 3000
     start = 1426120000
@@ -204,18 +254,33 @@ class BluefloodTests(TestCase):
     # check that it handles unfound metric correctly
     nodes[1].path += '.dummy'
     dictionary = self.bfc.gen_dict(nodes, responses, start, end, step)
-    self.assertTrue(dictionary == 
+    self.assertDictEqual(dictionary,
                     {nodes[0].path: [None, None, None, None, 4449.97, 7783.303333333333, 
                                      11116.636666666667, 14449.97, None]})
+
+    # check enums
+    nodes, responses = self.make_enum_data(start, step)
+    dictionary = self.bfc.gen_dict(nodes, responses, start, end, step)
+    self.assertDictEqual(dictionary,
+                    {nodes[1].path: [None, None, None, None, 7, 5, 4, 3, None], 
+                     nodes[0].path: [None, None, None, None, 13, 12, 11, 11, None]})
 
     # now with submetrics
     self.bfc.enable_submetrics = True
     nodes, responses = self.make_data(start, step)
     dictionary = self.bfc.gen_dict(nodes, responses, start, end, step)
-    self.assertTrue(dictionary == 
+    self.assertDictEqual(dictionary,
                     {nodes[1].path: [6421.18, None, None, None, None, None, None, None, None], 
                      nodes[0].path: [None, None, None, None, 4449.97, 7783.303333333333, 
                                      11116.636666666667, 14449.97, None]})
+
+    # check enums with submetrics
+    nodes, responses = self.make_enum_data(start, step)
+    dictionary = self.bfc.gen_dict(nodes, responses, start, end, step)
+    self.assertDictEqual(dictionary,
+                    {nodes[1].path: [None, None, None, None, 7, 5, 4, 3, None], 
+                     nodes[0].path: [None, None, None, None, 13, 12, 11, 11, None]})
+
 
   def test_gen_responses(self):
     step = 3000
@@ -228,20 +293,20 @@ class BluefloodTests(TestCase):
     with requests_mock.mock() as m:
       m.post(endpoint, json={}, status_code=401)
       responses = self.bfc.gen_responses(groups1, payload)
-      self.assertTrue(responses == [])
+      self.assertSequenceEqual(responses,[])
     
     #test single group
     _, responses = self.make_data(start, step)
     with requests_mock.mock() as m:
       m.post(endpoint, json={'metrics':responses}, status_code=200)
       new_responses = self.bfc.gen_responses(groups1, payload)
-      self.assertTrue(responses == new_responses)
+      self.assertSequenceEqual(responses,new_responses)
 
     #test multiple groups
     groups2 = [[self.metric1], [self.metric2]]
     with requests_mock.mock() as m:
       global json_data
-      json_data = [{'metrics':responses[0:1]},{'metrics':responses[1:]}]
+      json_data = [{'metrics':responses[:1]},{'metrics':responses[1:]}]
       def json_callback(request, context):
         global json_data
         response = json_data[0]
@@ -250,7 +315,7 @@ class BluefloodTests(TestCase):
 
       m.post(endpoint, json=json_callback, status_code=200)
       new_responses = self.bfc.gen_responses(groups2, payload)
-      self.assertTrue(responses == new_responses)
+      self.assertSequenceEqual(responses,new_responses)
 
   
   def test_find_nodes(self):
@@ -272,62 +337,132 @@ class BluefloodTests(TestCase):
         list(self.finder.find_nodes(query))
 
     def get_start(x):
-      return lambda y: '.'.join(y.split('.')[0:x])
+      return lambda y: '.'.join(y.split('.')[:x])
 
     get_path = lambda x: x.path
-    def query_test(query_pattern, jdata, qlen, search_results):
+
+    def query_test(query_pattern, fg_data, search_results, bg_data=[]):
+      # query_pattern is the pattern to search for
+      # fg_data is the data returned by the "mainthread" call to find metrics
+      # search_results are the expected results
+      # bg_data - non submetric calls do 2 calls to find_metrics, (one in a background thread,)
+      #   bg_data simulates what gets returnd by the background thread
+      def json_callback(request, context):
+        print("json thread callback" + threading.current_thread().name)
+        full_query = "include_enum_values=true&" + urllib.urlencode({'query':query_pattern}).lower()
+        if not self.finder.enable_submetrics:
+          if request.query == full_query:
+            return fg_data
+          else:
+            return bg_data
+        else:
+          return fg_data
+      qlen = len(query_pattern.split("."))
       with requests_mock.mock() as m:
         query = FindQuery(query_pattern, 1, 2)
-        m.get(endpoint, json=jdata, status_code=200)
+        m.get(endpoint, json=json_callback, status_code=200)
         metrics = self.finder.find_nodes(query)
-        self.assertSequenceEqual(map(get_path, list(metrics)),
-                                 map(get_start(qlen), search_results))
+        self.assertSetEqual(set(map(get_path, list(metrics))),
+                                 set(map(get_start(qlen), search_results)))
 
-    query_test("*", 
-               [{u'metric': self.metric1, u'unit': u'percent'}, 
+    enum_vals = ['v1', 'v2']
+
+    query_test("*",
+               [{u'metric': self.metric1, u'unit': u'percent'},
                 {u'metric': self.metric2, u'unit': u'percent'}],
-               1, [self.metric1, self.metric2])
+               [self.metric1, self.metric2])
 
-    query_test("a.*", 
+    query_test("a.*",
                [{u'metric': self.metric1, u'unit': u'percent'}],
-               2, [self.metric1])
+               [self.metric1])
 
-    query_test("a.b.*", 
-               [{u'metric': self.metric1, u'unit': u'percent'}],
-               3, [self.metric1])
+    query_test("a.*",
+               [{u'metric': self.metric1 + 'd', u'unit': u'percent'}],
+               [self.metric1],
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals}])
 
-    query_test("a.b.c", 
+    query_test("a.b.*",
                [{u'metric': self.metric1, u'unit': u'percent'}],
-               3, [self.metric1])
+               [self.metric1])
+
+    query_test("a.b.c",
+               [{u'metric': self.metric1, u'unit': u'percent'}],
+               [self.metric1])
+
+    query_test("a.b.c.*",
+               [{u'metric': self.metric1 + '.d.e', u'unit': u'percent'}],
+               [self.metric1 + '.' + v for v in enum_vals] + [self.metric1 + '.d.e'],
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals}])
+
+    query_test("a.b.*.v*",
+               [{u'metric': self.metric1 + '.v.e', u'unit': u'percent'}],
+               [self.metric1 + '.' + v for v in enum_vals] + [self.metric1 + '.v.e'],
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals}])
+
+    query_test("a.b.*.v*.*",
+               [{u'metric': self.metric1 + '.v.e.f', u'unit': u'percent'}],
+               [self.metric1 + '.v.e.f'],
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals}])
+
 
     # now again, with submetrics
     self.finder.enable_submetrics = True
     query_test("*", 
                [{u'metric': self.metric1, u'unit': u'percent'}, 
-                {u'metric': self.metric2, u'unit': u'percent'}],
-               1, [self.metric1, self.metric2])
+               {u'metric': self.metric2, u'unit': u'percent'}],
+               [self.metric1, self.metric2])
 
     query_test("a.*", 
                [{u'metric': self.metric1, u'unit': u'percent'}],
-               2, [self.metric1])
+               [self.metric1])
+
+    query_test("a.*",
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals}],
+               [self.metric1])
 
     query_test("a.b.*", 
                [{u'metric': self.metric1, u'unit': u'percent'},
                 {u'metric': 'a.bb.c', u'unit': u'percent'}],
-               3, [self.metric1])
+               [self.metric1])
 
     query_test("a.b.c", 
                [{u'metric': self.metric1, u'unit': u'percent'}],
-               3, [self.metric1])
+               [self.metric1])
 
     query_test("a.b.c.*", 
                [{u'metric': self.metric1, u'unit': u'percent'},
-                {u'metric': (self.metric1 + 'd'), u'unit': u'percent'}],
-               4, [self.metric1 + '.' + self.alias_key])
+               {u'metric': (self.metric1 + 'd'), u'unit': u'percent'}],
+               [self.metric1 + '.' + k for k in self.finder.submetric_aliases])
+
+    query_test("a.b.c.*", 
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals},
+               {u'metric': (self.metric1 + 'd'), u'unit': u'percent'}],
+               [self.metric1 + '.' + k for k in self.finder.submetric_aliases])
 
     query_test("a.b.c._avg", 
                [{u'metric': self.metric1, u'unit': u'percent'}],
-               4, [self.metric1 + '.' + self.alias_key])
+               [self.metric1 + '.' + self.alias_key])
+
+    query_test("a.b.c._avg", 
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals}],
+               [self.metric1 + '.' + self.alias_key])
+
+    query_test("a.b.c.v1._enum", 
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals}],
+               [self.metric1 + '.v1'])
+
+    query_test("a.b.c.*._enum", 
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals}],
+               [self.metric1 + '.' + v for v in enum_vals])
+
+    query_test("a.b.*.*._enum", 
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals}],
+               [self.metric1 + '.' + v for v in enum_vals])
+
+    query_test("a.b.c.v*._enum", 
+               [{u'metric': self.metric1, u'unit': u'percent', u'enum_values': enum_vals}],
+               [self.metric1 + '.' + v for v in enum_vals])
+
 
   def test_fetch(self):
     step = 3000
@@ -345,15 +480,10 @@ class BluefloodTests(TestCase):
                             'a.b.c': 
                             [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 4449.97, 4926.160476190476, 5402.350952380953, 5878.541428571429, 6354.731904761905, 6830.922380952381, 7307.112857142857, 7783.303333333333, 8259.49380952381, 8735.684285714287, 9211.874761904764, 9688.065238095242, 10164.255714285719, 10640.446190476196, 11116.636666666673, 11592.82714285715, 12069.017619047627, 12545.208095238104, 13021.39857142858, 13497.589047619058, 13973.779523809535, 14449.97, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]})
 
-      time2, seq = self.reader.fetch(start, end)
-      self.assertSequenceEqual(time2, (1426120000, 1426147300, 300))
-      self.assertSequenceEqual(seq, dictionary[self.metric1])
-
     with requests_mock.mock() as m:
       m.post(endpoint, json=exc_callback, status_code=200)
       with self.assertRaises(ValueError):
-        self.reader.fetch(start, end)
-
+        time_info, dictionary = self.finder.fetch_multi(nodes, start, end)
 
   def test_calc_res(self):
     start = 0
@@ -373,10 +503,15 @@ class BluefloodTests(TestCase):
     second_val = first_val + val_step
     third_time = second_time + big_step
     third_val = second_val + val_step
-    data_key = u'average'
+    data_key = NonNestedDataKey(u'average')
     values = [{u'timestamp': first_time, u'average': first_val, u'numPoints': 97},
               {u'timestamp': second_time, u'average': second_val, u'numPoints': 3},
               {u'timestamp': third_time, u'average': third_val, u'numPoints': 3}]
+
+    enum_values = [{u'timestamp': first_time, u'enum_values': {u'v1': first_val}, u'numPoints': 97},
+                   {u'timestamp': second_time, u'enum_values': {u'v1': second_val}, u'numPoints': 3},
+                   {u'timestamp': third_time, u'enum_values': {u'v1': third_val}, u'numPoints': 3}]
+    enum_data_key = NestedDataKey('enum_values', 'v1')
 
     start_time = first_time/1000
     end_time = third_time/1000 + 1
@@ -385,9 +520,21 @@ class BluefloodTests(TestCase):
     ret = b.process_path(values, start_time, end_time, step, data_key)
     self.assertSequenceEqual(ret, (first_val, second_val, third_val))
 
+    ret = b.process_path(enum_values, start_time, end_time, step, enum_data_key)
+    self.assertSequenceEqual(ret, (first_val, second_val, third_val))
+
+    ret = b.process_path(values, start_time, end_time, step, data_key)
+    self.assertSequenceEqual(ret, (first_val, second_val, third_val))
+
+    ret = b.process_path(enum_values, start_time, end_time, step, enum_data_key)
+    self.assertSequenceEqual(ret, (first_val, second_val, third_val))
+
     #test end time past end of data
     end_time += 2 * step
     ret = b.process_path(values, start_time, end_time, step, data_key)
+    self.assertSequenceEqual(ret, (first_val, second_val, third_val, None, None))
+
+    ret = b.process_path(enum_values, start_time, end_time, step, enum_data_key)
     self.assertSequenceEqual(ret, (first_val, second_val, third_val, None, None))
 
     #test start time before beginning of data
@@ -396,10 +543,16 @@ class BluefloodTests(TestCase):
     ret = b.process_path(values, start_time, end_time, step, data_key)
     self.assertSequenceEqual(ret, (None, None, first_val, second_val, third_val))
 
+    ret = b.process_path(enum_values, start_time, end_time, step, enum_data_key)
+    self.assertSequenceEqual(ret, (None, None, first_val, second_val, third_val))
+
     #test end time before beginning of data
     end_time -= 3 * step
     start_time -= 3 * step
     ret = b.process_path(values, start_time, end_time, step, data_key)
+    self.assertSequenceEqual(ret, (None, None, None, None, None))
+
+    ret = b.process_path(enum_values, start_time, end_time, step, enum_data_key)
     self.assertSequenceEqual(ret, (None, None, None, None, None))
 
 
@@ -415,7 +568,14 @@ class BluefloodTests(TestCase):
               {u'timestamp': second_time, u'average': second_val, u'numPoints': 3},
               {u'timestamp': third_time, u'average': third_val, u'numPoints': 3}]
 
+    enum_values = [{u'timestamp': first_time, u'enum_values': {u'v1': first_val}, u'numPoints': 97},
+                   {u'timestamp': second_time, u'enum_values': {u'v1': second_val}, u'numPoints': 3},
+                   {u'timestamp': third_time, u'enum_values': {u'v1': third_val}, u'numPoints': 3}]
+
     ret = b.process_path(values, start_time, end_time, step, data_key)
+    self.assertSequenceEqual(ret, (None, None, first_val, first_val + 4, first_val + 8, second_val, second_val + 4, second_val + 8, third_val , None, None))
+
+    ret = b.process_path(enum_values, start_time, end_time, step, enum_data_key)
     self.assertSequenceEqual(ret, (None, None, first_val, first_val + 4, first_val + 8, second_val, second_val + 4, second_val + 8, third_val , None, None))
 
 if __name__ == '__main__':


### PR DESCRIPTION
## INTRO:
There are two parts to the finder api:
1. find_metrics() which returns a list of metric names based on a glob pattern
2. fetch_multi() with returns the data for a list of metrics

Both support submetrics_aliases.  Without submetric_aliases configured in, the data returned uses the default submetric, which is usually "average".  If the user wants to use something other than the default submetric, he creates an alias for that submetric in the finder config.  Then he appends the alias to the end of the metric name in the grafana dashboard.  So for example if he wants to use the "max" submetric for metric "x.y", he creates an alias like "_max" in the config and specifies the metric name "x.y._max" in the dashboard.

Note: Currently submetrics have to be entirely enabled or disabled in grafana server.  If they are enabled then every metric in the dashboard needs to be appended with a submetric alias, or they wont be found.

## CHANGES IN THIS PR:
Adding enums effects both find_metrics() and fetch_multi().

In find_metrics(), without submetrics, it has to do two reads.  For example, if the pattern requested is "x.y", then there are two possibilities, either "y" is an enum_value or not.  So find metric has to read both "x" and "x.y".   It does the enum read, "x", in a separate thread in an attempt to reduce the IO time.

In find_metrics(), with submetrics, the assumption is that the metric name of an enum metric will end with a submetric alias for ".enum".  So only one read is necessary.

In fetch_multi(), each enum value is treated as a separate metric, (which allows Grafana to graph them separately.)  So now the code needs to massage the incoming data to merge the values with the metric names, and create separate metrics for each enum_value.

