### PR TITLE
Check for bad enum metrics during rollup

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxReaderIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxReaderIntegrationTest.java
@@ -77,13 +77,11 @@ public class AstyanaxReaderIntegrationTest extends IntegrationTestBase {
         Locator loc2 = Locator.createLocatorFromPathComponents("acTwo", "ent", "ch", "mz", "met");
         AstyanaxWriter writer = AstyanaxWriter.getInstance();
         AstyanaxReader reader = AstyanaxReader.getInstance();
-        Long timestamp1 = 1L;
-        Long timestamp2 = 2L;
         Set<Locator> excessEnumList = new HashSet<Locator>();
         excessEnumList.add(loc1);
         excessEnumList.add(loc2);
-        writer.writeExcessEnumMetric(loc1, timestamp1);
-        writer.writeExcessEnumMetric(loc2, timestamp2);
+        writer.writeExcessEnumMetric(loc1);
+        writer.writeExcessEnumMetric(loc2);
         Set<Locator> newExcessEnumList = reader.getExcessEnumMetrics();
         Assert.assertEquals(excessEnumList, newExcessEnumList);
     }

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxWriterIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxWriterIntegrationTest.java
@@ -83,14 +83,33 @@ public class AstyanaxWriterIntegrationTest extends IntegrationTestBase {
         Locator loc1 = Locator.createLocatorFromPathComponents("acONE", "entityId", "checkId", "mz", "metric");
         Locator loc2 = Locator.createLocatorFromPathComponents("acTWO", "entityId", "checkId", "mz", "metric");
         AstyanaxWriter writer = AstyanaxWriter.getInstance();
-        Long timestamp1 = 1L;
-        Long timestamp2 = 2L;
 
-        writer.writeExcessEnumMetric(loc1, timestamp1);
+        writer.writeExcessEnumMetric(loc1);
         assertNumberOfRows("metrics_excess_enums", 1);
 
         // new locator means new row.
-        writer.writeExcessEnumMetric(loc2, timestamp2);
+        writer.writeExcessEnumMetric(loc2);
+        assertNumberOfRows("metrics_excess_enums", 2);
+    }
+
+    @Test
+    public void testExcessEnumMetricDoesNotDuplicates() throws Exception {
+        assertNumberOfRows("metrics_excess_enums", 0);
+
+        Locator loc1 = Locator.createLocatorFromPathComponents("ac", "entityId", "checkId", "mz", "metric");
+        Locator loc2 = Locator.createLocatorFromPathComponents("ac", "entityId", "checkId", "mz", "metric");
+        Locator loc3 = Locator.createLocatorFromPathComponents("ac", "entityId", "checkId", "mz", "metric");
+        Locator loc4 = Locator.createLocatorFromPathComponents("acNEW", "entityId", "checkId", "mz", "metric");
+        AstyanaxWriter writer = AstyanaxWriter.getInstance();
+
+        // same locator means same row.
+        writer.writeExcessEnumMetric(loc1);
+        writer.writeExcessEnumMetric(loc2);
+        writer.writeExcessEnumMetric(loc3);
+        assertNumberOfRows("metrics_excess_enums", 1);
+
+        // new locator means new row.
+        writer.writeExcessEnumMetric(loc4);
         assertNumberOfRows("metrics_excess_enums", 2);
     }
 

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/ExcessEnumsReaderIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/ExcessEnumsReaderIntegrationTest.java
@@ -31,7 +31,7 @@ public class ExcessEnumsReaderIntegrationTest extends IntegrationTestBase {
 
     @Before
     public void setUp() throws Exception {
-        AstyanaxWriter.getInstance().writeExcessEnumMetric(dummyLocator, 0L);
+        AstyanaxWriter.getInstance().writeExcessEnumMetric(dummyLocator);
     }
 
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
@@ -209,10 +209,10 @@ public class AstyanaxWriter extends AstyanaxIO {
         }
     }
 
-    public void writeExcessEnumMetric(Locator locator, Long timestamp) throws ConnectionException {
+    public void writeExcessEnumMetric(Locator locator) throws ConnectionException {
         Timer.Context ctx = Instrumentation.getWriteTimerContext(CassandraModel.CF_METRICS_EXCESS_ENUMS);
         try {
-            keyspace.prepareColumnMutation(CassandraModel.CF_METRICS_EXCESS_ENUMS, locator, timestamp)
+            keyspace.prepareColumnMutation(CassandraModel.CF_METRICS_EXCESS_ENUMS, locator, 0L)
                     .putEmptyColumn(null).execute();
         } catch (ConnectionException e) {
             Instrumentation.markWriteError(e);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/DiscoveryIO.java
@@ -4,6 +4,7 @@ import com.rackspacecloud.blueflood.types.IMetric;
 import java.util.List;
 
 public interface DiscoveryIO {
+    public void insertDiscovery(IMetric metric) throws Exception;
     public void insertDiscovery(List<IMetric> metrics) throws Exception;
     public List<SearchResult> search(String tenant, String query) throws Exception;
     public List<SearchResult> search(String tenant, List<String> queries) throws Exception;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -150,6 +150,8 @@ public enum CoreConfig implements ConfigDefaults {
     ROLLUP_ON_READ_THREADS("50"),
     TURN_OFF_RR_MPLOT("false"),
 
+    ENUM_VALIDATOR_THREADS("20"),
+    ENUM_UNIQUE_VALUES_THRESHOLD("100"),
     EXCESS_ENUM_READER_SLEEP("600000");
 
     static {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/EnumValidator.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/EnumValidator.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2015 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.service;
+
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.netflix.astyanax.model.ColumnList;
+import com.rackspacecloud.blueflood.concurrent.ThreadPoolBuilder;
+import com.rackspacecloud.blueflood.io.AstyanaxReader;
+import com.rackspacecloud.blueflood.io.AstyanaxWriter;
+import com.rackspacecloud.blueflood.io.DiscoveryIO;
+import com.rackspacecloud.blueflood.io.SearchResult;
+import com.rackspacecloud.blueflood.types.BluefloodEnumRollup;
+import com.rackspacecloud.blueflood.types.IMetric;
+import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.types.PreaggregatedMetric;
+import com.rackspacecloud.blueflood.utils.ModuleLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+/** This class handles collecting enum values for specific metrics, via their locators, and checking whether
+    a uniqueness count of the enum values have reached a certain threshold.  If it has, the class mark the metric
+    as bad by inserting its locator into the metrics_excess_enums table.  If it hasn't reached the threshold, then the class
+    will create/update the elastic search "enums" index for the metric, which will contain a list of all unique
+    enum values that has been ingested for it.
+**/
+public class EnumValidator implements Runnable {
+
+    private static final Logger log = LoggerFactory.getLogger(EnumValidator.class);
+    private static final Configuration config = Configuration.getInstance();
+    private static final DiscoveryIO discoveryIO = (DiscoveryIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.ENUMS_DISCOVERY_MODULES);
+    private static final int ENUM_UNIQUE_VALUES_THRESHOLD = config.getIntegerProperty(CoreConfig.ENUM_UNIQUE_VALUES_THRESHOLD);
+    private static final int ENUM_VALIDATOR_THREADS = Configuration.getInstance().getIntegerProperty(CoreConfig.ENUM_VALIDATOR_THREADS);
+
+    HashSet<Locator> locators;
+
+    public EnumValidator(Set<Locator> locators) {
+        this.locators = (HashSet<Locator>) locators;
+    }
+
+    @Override
+    public void run() {
+
+        ExecutorService taskExecutor = new ThreadPoolBuilder().withUnboundedQueue()
+                .withCorePoolSize(ENUM_VALIDATOR_THREADS)
+                .withMaxPoolSize(ENUM_VALIDATOR_THREADS)
+                .withName("Enum Validator Task Executor")
+                .build();
+
+        for (final Locator locator : locators) {
+            // start async read for enum values of locator from cassandra
+            Future<ColumnList<Long>> enumHashValuesFuture = taskExecutor.submit(new Callable() {
+                @Override
+                public ColumnList<Long> call() throws Exception {
+                    return AstyanaxReader.getInstance().getColumnsFromEnumCF(locator);
+                }
+
+            });
+
+            // start async read for enum values of locator from elastic search
+            Future<List<SearchResult>> esEnumValuesFuture = taskExecutor.submit(new Callable() {
+                @Override
+                public List<SearchResult> call() throws Exception {
+                    return discoveryIO.search(locator.getTenantId(), locator.getMetricName());
+                }
+            });
+
+
+            Map<Long, String> enumStringValues = null;
+            List<SearchResult> esEnumValues = null;
+            try {
+                // values from cassandra db
+                ColumnList<Long> enumHashValues = enumHashValuesFuture.get();
+                if ((enumHashValues != null) && (enumHashValues.size() > 0)) {
+                    enumStringValues = AstyanaxReader.getInstance().getEnumValueFromHash(enumHashValues);
+                    log.debug(String.format("Enum values for metric %s: %s", locator.toString(), enumStringValues.toString()));
+                }
+                else {
+                    log.debug(String.format("No enum values found for metric %s", locator.toString()));
+                }
+
+                // values from elasticsearch
+                esEnumValues = esEnumValuesFuture.get();
+
+                validateThresholdAndIndex(locator, enumStringValues, esEnumValues);
+
+            } catch (InterruptedException e) {
+                log.error("Interrupted Exception during query of Enum metrics in EnumValidator", e);
+            } catch (ExecutionException e) {
+                log.error("Execution Exception during query of Enum metrics in EnumValidator", e);
+            }
+            finally {
+                taskExecutor.shutdown();
+            }
+        }
+    }
+
+    private void validateThresholdAndIndex(Locator locator, Map<Long, String> enumStringValues, List<SearchResult> esEnumValues) {
+
+        if ((enumStringValues != null) && (enumStringValues.size() > ENUM_UNIQUE_VALUES_THRESHOLD)) {
+            // if values_from_cassandra.count > threshold,
+            // write locator to bad metric table
+            try {
+                AstyanaxWriter.getInstance().writeExcessEnumMetric(locator);
+            } catch (ConnectionException e) {
+                log.error("Failed to write bad metric {} to table; {}", locator.toString(), e.getMessage());
+            }
+        }
+        else {
+            // create or update index of metric with enum values if cassandra and elasticsearch values are different
+            // get arraylist of cassandra enum values
+            ArrayList<String> dbValues = null;
+            if ((enumStringValues != null) && (enumStringValues.size() > 0)) {
+                dbValues = new ArrayList<String>(enumStringValues.values());
+            }
+
+            // get arraylist of elasticsearch enum values
+            ArrayList<String> esValues = null;
+            if ((esEnumValues != null) && (esEnumValues.get(0) != null)) {
+                esValues = esEnumValues.get(0).getEnumValues();
+            }
+
+            // sort the two array lists of enum values
+            if (dbValues != null) Collections.sort(dbValues);
+            if (esValues != null) Collections.sort(esValues);
+
+            // verify equals
+            if (((dbValues != null) && (!dbValues.equals(esValues))) ||
+                ((dbValues == null) && (esValues != null) && (esValues.size() > 0)))
+            {
+                // not equal, create or update enums index in elastic search
+                BluefloodEnumRollup rollupWithEnumValues = createRollupWithEnumValues(dbValues);
+                IMetric enumMetric = new PreaggregatedMetric(0, locator, null, rollupWithEnumValues);
+                try {
+                    discoveryIO.insertDiscovery(enumMetric);
+                }
+                catch (Exception e) {
+                    log.error("Failed to write update elasticsearch enums index for {}; {}", locator.toString(), e.getMessage());
+                }
+            }
+        }
+    }
+
+    private BluefloodEnumRollup createRollupWithEnumValues(ArrayList<String> enumValues) {
+        BluefloodEnumRollup rollup = new BluefloodEnumRollup();
+        for (String val : enumValues) {
+            rollup = rollup.withEnumValue(val);
+        }
+        return rollup;
+    }
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/EnumValidator.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/EnumValidator.java
@@ -18,7 +18,6 @@ package com.rackspacecloud.blueflood.service;
 
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.netflix.astyanax.model.ColumnList;
-import com.rackspacecloud.blueflood.concurrent.ThreadPoolBuilder;
 import com.rackspacecloud.blueflood.io.AstyanaxReader;
 import com.rackspacecloud.blueflood.io.AstyanaxWriter;
 import com.rackspacecloud.blueflood.io.DiscoveryIO;
@@ -30,15 +29,12 @@ import com.rackspacecloud.blueflood.types.PreaggregatedMetric;
 import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.util.*;
-import java.util.concurrent.*;
 
 /** This class handles collecting enum values for specific metrics, via their locators, and checking whether
     a uniqueness count of the enum values have reached a certain threshold.  If it has, the class mark the metric
-    as bad by inserting its locator into the metrics_excess_enums table.  If it hasn't reached the threshold, then the class
-    will create/update the elastic search "enums" index for the metric, which will contain a list of all unique
-    enum values that has been ingested for it.
+    as bad by inserting its locator into the proper cassandra column family.  If it hasn't reached the threshold, then it
+    will create or update the elasticsearch "enums" index for the metric.
 **/
 public class EnumValidator implements Runnable {
 
@@ -46,112 +42,95 @@ public class EnumValidator implements Runnable {
     private static final Configuration config = Configuration.getInstance();
     private static final DiscoveryIO discoveryIO = (DiscoveryIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.ENUMS_DISCOVERY_MODULES);
     private static final int ENUM_UNIQUE_VALUES_THRESHOLD = config.getIntegerProperty(CoreConfig.ENUM_UNIQUE_VALUES_THRESHOLD);
-    private static final int ENUM_VALIDATOR_THREADS = Configuration.getInstance().getIntegerProperty(CoreConfig.ENUM_VALIDATOR_THREADS);
-
-    HashSet<Locator> locators;
+    private Set<Locator> locators;
 
     public EnumValidator(Set<Locator> locators) {
-        this.locators = (HashSet<Locator>) locators;
+        this.locators = locators;
     }
 
     @Override
     public void run() {
 
-        ExecutorService taskExecutor = new ThreadPoolBuilder().withUnboundedQueue()
-                .withCorePoolSize(ENUM_VALIDATOR_THREADS)
-                .withMaxPoolSize(ENUM_VALIDATOR_THREADS)
-                .withName("Enum Validator Task Executor")
-                .build();
+        if (locators == null) return;
+        Map<Locator, ColumnList<Long>> cfMetrics = AstyanaxReader.getInstance().getEnumHashMappings(new ArrayList(locators));
 
-        for (final Locator locator : locators) {
-            // start async read for enum values of locator from cassandra
-            Future<ColumnList<Long>> enumHashValuesFuture = taskExecutor.submit(new Callable() {
-                @Override
-                public ColumnList<Long> call() throws Exception {
-                    return AstyanaxReader.getInstance().getColumnsFromEnumCF(locator);
-                }
-
-            });
-
-            // start async read for enum values of locator from elastic search
-            Future<List<SearchResult>> esEnumValuesFuture = taskExecutor.submit(new Callable() {
-                @Override
-                public List<SearchResult> call() throws Exception {
-                    return discoveryIO.search(locator.getTenantId(), locator.getMetricName());
-                }
-            });
-
-
-            Map<Long, String> enumStringValues = null;
-            List<SearchResult> esEnumValues = null;
+        for (final Locator locator : cfMetrics.keySet()) {
+            // for each locator from CF results, get enum values
             try {
                 // values from cassandra db
-                ColumnList<Long> enumHashValues = enumHashValuesFuture.get();
-                if ((enumHashValues != null) && (enumHashValues.size() > 0)) {
-                    enumStringValues = AstyanaxReader.getInstance().getEnumValueFromHash(enumHashValues);
-                    log.debug(String.format("Enum values for metric %s: %s", locator.toString(), enumStringValues.toString()));
+                Map<Long, String> enumStringValuesFromCF = null;
+                ColumnList<Long> enumHashValuesFromCF = cfMetrics.get(locator);
+                if ((enumHashValuesFromCF != null) && (enumHashValuesFromCF.size() > 0)) {
+                    enumStringValuesFromCF = AstyanaxReader.getInstance().getEnumValueFromHashes(enumHashValuesFromCF);
                 }
                 else {
                     log.debug(String.format("No enum values found for metric %s", locator.toString()));
+                    // metric has no enum values, skip processing this locator and proceed to next one
+                    continue;
                 }
 
-                // values from elasticsearch
-                esEnumValues = esEnumValuesFuture.get();
+                // convert enum values to array list
+                ArrayList<String> currentEnumValues = null;
+                if ((enumStringValuesFromCF != null) && (enumStringValuesFromCF.size() > 0)) {
+                    currentEnumValues = new ArrayList<String>(enumStringValuesFromCF.values());
+                }
 
-                validateThresholdAndIndex(locator, enumStringValues, esEnumValues);
+                // validate enum values count and write to index or bad metric
+                validateThresholdAndWrite(locator, currentEnumValues);
 
-            } catch (InterruptedException e) {
-                log.error("Interrupted Exception during query of Enum metrics in EnumValidator", e);
-            } catch (ExecutionException e) {
-                log.error("Execution Exception during query of Enum metrics in EnumValidator", e);
-            }
-            finally {
-                taskExecutor.shutdown();
+            } catch (Exception e) {
+                log.error(String.format("Exception validating locator %s: %s", locator.toString(), e.getMessage()), e);
             }
         }
     }
 
-    private void validateThresholdAndIndex(Locator locator, Map<Long, String> enumStringValues, List<SearchResult> esEnumValues) {
+    private void validateThresholdAndWrite(Locator locator, ArrayList<String> currentEnumValues) {
+        // check if count of current enum values for the metric exceed a configurable threshold number
+        log.debug(String.format("EnumValidator validating locator %s", locator.toString()));
 
-        if ((enumStringValues != null) && (enumStringValues.size() > ENUM_UNIQUE_VALUES_THRESHOLD)) {
-            // if values_from_cassandra.count > threshold,
+        // if exceeded, mark metric as bad, else index enum values in elasticsearch
+        if ((currentEnumValues != null) && (currentEnumValues.size() > ENUM_UNIQUE_VALUES_THRESHOLD)) {
+            // count of current enum values of metric exceeded threshold, bad metric
             // write locator to bad metric table
             try {
                 AstyanaxWriter.getInstance().writeExcessEnumMetric(locator);
             } catch (ConnectionException e) {
-                log.error("Failed to write bad metric {} to table; {}", locator.toString(), e.getMessage());
+                log.error(String.format("Exception writing bad metric %s: %s", locator.toString(), e.getMessage()), e);
             }
         }
         else {
-            // create or update index of metric with enum values if cassandra and elasticsearch values are different
-            // get arraylist of cassandra enum values
-            ArrayList<String> dbValues = null;
-            if ((enumStringValues != null) && (enumStringValues.size() > 0)) {
-                dbValues = new ArrayList<String>(enumStringValues.values());
+            // not bad metric, create or update enums index of metric in elasticsearch if different from cassandra
+            // search for metric from elastic search
+            List<SearchResult> esSearchResult = null;
+            try {
+                esSearchResult = discoveryIO.search(locator.getTenantId(), locator.getMetricName());
+            }
+            catch (Exception e) {
+                log.error(String.format("Exception retrieving enum values from elasticsearch for %s: %s", locator.toString(), e.getMessage()), e);
             }
 
-            // get arraylist of elasticsearch enum values
-            ArrayList<String> esValues = null;
-            if ((esEnumValues != null) && (esEnumValues.get(0) != null)) {
-                esValues = esEnumValues.get(0).getEnumValues();
+            // get elasticsearch enum values from top search results of exact match
+            ArrayList<String> elasticsearchEnumValues = null;
+            if ((esSearchResult != null) && (esSearchResult.get(0) != null)) {
+                elasticsearchEnumValues = esSearchResult.get(0).getEnumValues();
             }
 
             // sort the two array lists of enum values
-            if (dbValues != null) Collections.sort(dbValues);
-            if (esValues != null) Collections.sort(esValues);
+            if (currentEnumValues != null) Collections.sort(currentEnumValues);
+            if (elasticsearchEnumValues != null) Collections.sort(elasticsearchEnumValues);
 
-            // verify equals
-            if (((dbValues != null) && (!dbValues.equals(esValues))) ||
-                ((dbValues == null) && (esValues != null) && (esValues.size() > 0)))
+            // compare two list of enum values
+            if (((currentEnumValues != null) && (!currentEnumValues.equals(elasticsearchEnumValues))) ||
+                ((currentEnumValues == null) && (elasticsearchEnumValues != null) && (elasticsearchEnumValues.size() > 0)))
             {
-                // not equal, create or update enums index in elastic search
-                BluefloodEnumRollup rollupWithEnumValues = createRollupWithEnumValues(dbValues);
+                // if not equal, create or update enums index in elastic search
+                BluefloodEnumRollup rollupWithEnumValues = createRollupWithEnumValues(currentEnumValues);
                 IMetric enumMetric = new PreaggregatedMetric(0, locator, null, rollupWithEnumValues);
                 try {
                     discoveryIO.insertDiscovery(enumMetric);
                 }
                 catch (Exception e) {
-                    log.error("Failed to write update elasticsearch enums index for {}; {}", locator.toString(), e.getMessage());
+                    log.error(String.format("Exception writing enums index to elasticsearch for %s: %s", locator.toString(), e.getMessage()), e);
                 }
             }
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ExcessEnumReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ExcessEnumReader.java
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-
 package com.rackspacecloud.blueflood.service;
 
 import java.util.Collections;
@@ -30,7 +29,7 @@ import com.rackspacecloud.blueflood.utils.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ExcessEnumReader implements Runnable{
+public class ExcessEnumReader implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(ExcessEnumReader.class);
     private final Meter readMeter = Metrics.meter(ExcessEnumReader.class, 
                                                     "reads", "Cassandra Reads");

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -96,12 +96,14 @@ class LocatorFetchRunnable implements Runnable {
             log.error("Failed reading locators for slot: " + parentSlot, e);
         }
 
-        // start a thread with EnumValidator runnable to validate enum values for this set of locators
-        try {
-            enumValidatorExecutor.execute(new EnumValidator(locators));
-        } catch (Throwable any) {
-            executionContext.markUnsuccessful(any);
-            log.error("EnumValidator failed for locators: " +  Arrays.toString(locators.toArray()), any.getMessage());
+        // if gran 5 minutes rollup, start a thread with EnumValidator runnable to validate enum values for this set of locators
+        if (gran.equals(Granularity.MIN_5)) {
+            try {
+                log.debug(String.format("Starting an EnumValidator thread at granularity %s for locators: %s", gran, Arrays.toString(locators.toArray())));
+                enumValidatorExecutor.execute(new EnumValidator(locators));
+            } catch (Exception e) {
+                log.error(String.format("Exception in EnumValidator for locators %s: %s", Arrays.toString(locators.toArray()), e.getMessage()), e);
+            }
         }
 
         for (Locator locator : locators) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -26,6 +26,7 @@ import com.rackspacecloud.blueflood.utils.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
@@ -41,6 +42,7 @@ class LocatorFetchRunnable implements Runnable {
     
     private final ThreadPoolExecutor rollupReadExecutor;
     private final ThreadPoolExecutor rollupWriteExecutor;
+    private final ThreadPoolExecutor enumValidatorExecutor;
     private final SlotKey parentSlotKey;
     private final ScheduleContext scheduleCtx;
     private final long serverTime;
@@ -48,12 +50,18 @@ class LocatorFetchRunnable implements Runnable {
     private static final boolean enableHistograms = Configuration.getInstance().
             getBooleanProperty(CoreConfig.ENABLE_HISTOGRAMS);
 
-    LocatorFetchRunnable(ScheduleContext scheduleCtx, SlotKey destSlotKey, ThreadPoolExecutor rollupReadExecutor, ThreadPoolExecutor rollupWriteExecutor) {
+    LocatorFetchRunnable(ScheduleContext scheduleCtx,
+                         SlotKey destSlotKey,
+                         ThreadPoolExecutor rollupReadExecutor,
+                         ThreadPoolExecutor rollupWriteExecutor,
+                         ThreadPoolExecutor enumValidatorExecutor) {
+
         this.rollupReadExecutor = rollupReadExecutor;
         this.rollupWriteExecutor = rollupWriteExecutor;
         this.parentSlotKey = destSlotKey;
         this.scheduleCtx = scheduleCtx;
         this.serverTime = scheduleCtx.getCurrentTimeMillis();
+        this.enumValidatorExecutor = enumValidatorExecutor;
     }
     
     public void run() {
@@ -81,11 +89,21 @@ class LocatorFetchRunnable implements Runnable {
         Set<Locator> locators = new HashSet<Locator>();
 
         try {
+            // get a list of all locators to rollup for a shard
             locators.addAll(AstyanaxReader.getInstance().getLocatorsToRollup(shard));
         } catch (RuntimeException e) {
             executionContext.markUnsuccessful(e);
             log.error("Failed reading locators for slot: " + parentSlot, e);
         }
+
+        // start a thread with EnumValidator runnable to validate enum values for this set of locators
+        try {
+            enumValidatorExecutor.execute(new EnumValidator(locators));
+        } catch (Throwable any) {
+            executionContext.markUnsuccessful(any);
+            log.error("EnumValidator failed for locators: " +  Arrays.toString(locators.toArray()), any.getMessage());
+        }
+
         for (Locator locator : locators) {
             if (log.isTraceEnabled())
                 log.trace("Rolling up (check,metric,dimension) {} for (gran,slot,shard) {}", locator, parentSlotKey);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/BluefloodEnumRollup.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/BluefloodEnumRollup.java
@@ -7,6 +7,10 @@ public class BluefloodEnumRollup implements Rollup {
     private Map<String, Long> stringEnumValues2Count = new HashMap<String, Long>();
     private Map<Long,Long> hashedEnumValues2Count = new HashMap<Long, Long>();
 
+    public BluefloodEnumRollup withEnumValue(String valueName) {
+        return this.withEnumValue(valueName, 1L);
+    }
+
     public BluefloodEnumRollup withEnumValue(String valueName, Long incomingCount) {
         long existingCount = 0;
         if (this.stringEnumValues2Count.containsKey(valueName)) {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/EnumValidatorTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/EnumValidatorTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2015 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.service;
+
+import com.rackspacecloud.blueflood.io.AstyanaxReader;
+import com.rackspacecloud.blueflood.io.AstyanaxWriter;
+import com.rackspacecloud.blueflood.io.DiscoveryIO;
+import com.rackspacecloud.blueflood.io.SearchResult;
+import com.rackspacecloud.blueflood.types.IMetric;
+import com.rackspacecloud.blueflood.types.Locator;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.*;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class EnumValidatorTest {
+
+    AstyanaxReader readerMock = mock(AstyanaxReader.class);
+    AstyanaxWriter writerMock = mock(AstyanaxWriter.class);
+    DiscoveryIO discoveryIOMock = mock(DiscoveryIO.class);
+
+    String tenant_id = "tenant1";
+    String metric_name = "metric1";
+    Locator locator1 = Locator.createLocatorFromPathComponents(tenant_id, metric_name);
+    HashSet<Locator> locators;
+
+    @Before
+    public void setup() {
+        // set threshold
+        System.setProperty(CoreConfig.ENUM_UNIQUE_VALUES_THRESHOLD.name(), "3");
+
+        // set locators
+        locators = new HashSet<Locator>();
+        locators.add(locator1);
+    }
+
+    private EnumValidator setupEnumValidatorWithMock(Set<Locator> locators) {
+        EnumValidator enumValidator = new EnumValidator(locators);
+        enumValidator.setReader(readerMock);
+        enumValidator.setWriter(writerMock);
+        enumValidator.setDiscoveryIO(discoveryIOMock);
+        return enumValidator;
+    }
+
+    @Test
+    public void testNullLocators() throws Exception {
+        // create EnumValidator with locators set = null
+        EnumValidator validator = setupEnumValidatorWithMock(null);
+
+        // execute validator
+        validator.run();
+
+        // verify no writes to cassandra and elasticsearch
+        verify(readerMock, never()).getEnumStringMappings(anyList());
+        verify(writerMock, never()).writeExcessEnumMetric(locator1);
+        verify(discoveryIOMock, never()).search(tenant_id, metric_name);
+        verify(discoveryIOMock, never()).insertDiscovery(any(IMetric.class));
+    }
+
+    @Test
+    public void testEmptyLocatorList() throws Exception {
+        // mock returned empty list of enum hash values from cassandra
+        Map<Locator, ArrayList<String>> locatorEnumsMock = new HashMap<Locator, ArrayList<String>>();
+        when(readerMock.getEnumStringMappings(anyList())).thenReturn(locatorEnumsMock);
+
+        // execute validator with locators
+        EnumValidator validator = setupEnumValidatorWithMock(locators);
+        validator.run();
+
+        // verify no writes to cassandra and elasticsearch
+        verify(readerMock, times(1)).getEnumStringMappings(anyList());
+        verify(writerMock, never()).writeExcessEnumMetric(locator1);
+        verify(discoveryIOMock, never()).search(tenant_id, metric_name);
+        verify(discoveryIOMock, never()).insertDiscovery(any(IMetric.class));
+    }
+
+    @Test
+    public void testEnumsExceedThreshold() throws Exception {
+        // mock returned list of enum hash values from cassandra
+        Map<Locator, ArrayList<String>> locatorEnumsMock = new HashMap<Locator, ArrayList<String>>();
+        ArrayList<String> enumValues = new ArrayList<String>();
+        enumValues.add("value1");
+        enumValues.add("value2");
+        enumValues.add("value3");
+        enumValues.add("value4");
+        locatorEnumsMock.put(locator1, enumValues);
+        when(readerMock.getEnumStringMappings(anyList())).thenReturn(locatorEnumsMock);
+
+        // execute validator with locators
+        EnumValidator validator = setupEnumValidatorWithMock(locators);
+        validator.run();
+
+        // verify writes to CF_METRICS_EXCESS_ENUMS and no writes elasticsearch
+        verify(writerMock, times(1)).writeExcessEnumMetric(locator1);
+        verify(discoveryIOMock, never()).search(tenant_id, metric_name);
+        verify(discoveryIOMock, never()).insertDiscovery(any(IMetric.class));
+    }
+
+    @Test
+    public void testEnumsValidatedWithSameValues() throws Exception {
+        // mock returned list of enum hash values from cassandra
+        Map<Locator, ArrayList<String>> locatorEnumsMock = new HashMap<Locator, ArrayList<String>>();
+        ArrayList<String> enumValues = new ArrayList<String>();
+        enumValues.add("value1");
+        enumValues.add("value2");
+        enumValues.add("value3");
+        locatorEnumsMock.put(locator1, enumValues);
+        when(readerMock.getEnumStringMappings(anyList())).thenReturn(locatorEnumsMock);
+
+        List<SearchResult> esSearchResultMock = new ArrayList<SearchResult>();
+        SearchResult result = new SearchResult(tenant_id, metric_name, null, enumValues);
+        esSearchResultMock.add(result);
+        when(discoveryIOMock.search(tenant_id, metric_name)).thenReturn(esSearchResultMock);
+
+        // execute validator with locators
+        EnumValidator validator = setupEnumValidatorWithMock(locators);
+        validator.run();
+
+        // verify no writes to CF_METRICS_EXCESS_ENUMS and no writes elasticsearch
+        // because CF and ES enum values are equals
+        verify(writerMock, never()).writeExcessEnumMetric(locator1);
+        verify(discoveryIOMock, times(1)).search(tenant_id, metric_name);
+        verify(discoveryIOMock, never()).insertDiscovery(any(IMetric.class));
+    }
+
+    @Test
+    public void testEnumsValidatedWithNewValues() throws Exception {
+        // mock returned list of enum hash values from cassandra
+        Map<Locator, ArrayList<String>> locatorEnumsMock = new HashMap<Locator, ArrayList<String>>();
+        ArrayList<String> enumValues = new ArrayList<String>();
+        enumValues.add("value1");
+        enumValues.add("value2");
+        enumValues.add("value3");
+        locatorEnumsMock.put(locator1, enumValues);
+        when(readerMock.getEnumStringMappings(anyList())).thenReturn(locatorEnumsMock);
+
+        List<SearchResult> esSearchResultMock = new ArrayList<SearchResult>();
+        SearchResult result = new SearchResult(tenant_id, metric_name, null, null);
+        esSearchResultMock.add(result);
+        when(discoveryIOMock.search(tenant_id, metric_name)).thenReturn(esSearchResultMock);
+
+        // execute validator with locators
+        EnumValidator validator = setupEnumValidatorWithMock(locators);
+        validator.run();
+
+        // verify no writes to CF_METRICS_EXCESS_ENUMS and writes elasticsearch with new indexes
+        verify(writerMock, never()).writeExcessEnumMetric(locator1);
+        verify(discoveryIOMock, times(1)).search(tenant_id, metric_name);
+        verify(discoveryIOMock, times(1)).insertDiscovery(any(IMetric.class));
+    }
+}

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticIO.java
@@ -82,6 +82,12 @@ public class ElasticIO implements DiscoveryIO {
         return result;
     }
 
+    public void insertDiscovery(IMetric metric) throws IOException {
+        List<IMetric> batch = new ArrayList<IMetric>();
+        batch.add(metric);
+        insertDiscovery(batch);
+    }
+
     public void insertDiscovery(List<IMetric> batch) throws IOException {
         batchHistogram.update(batch.size());
         if (batch.size() == 0) {

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/EnumElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/EnumElasticIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Rackspace
+ * Copyright 2015 Rackspace
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -66,6 +66,12 @@ public class EnumElasticIO implements DiscoveryIO {
         this(manager.getClient());
     }
 
+    public void insertDiscovery(IMetric metric) throws IOException {
+        List<IMetric> batch = new ArrayList<IMetric>();
+        batch.add(metric);
+        insertDiscovery(batch);
+    }
+
     public void insertDiscovery(List<IMetric> batch) throws IOException {
         batchHistogram.update(batch.size());
         if (batch.size() == 0) {
@@ -117,7 +123,6 @@ public class EnumElasticIO implements DiscoveryIO {
         return client.prepareIndex(ENUMS_INDEX_NAME_WRITE, ENUMS_DOCUMENT_TYPE)
                 .setId(metricDiscovery.getDocumentId())
                 .setSource(metricDiscovery.createSourceContent())
-                .setCreate(true)
                 .setRouting(metricDiscovery.getTenantId());
     }
 

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/EnumElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/EnumElasticIO.java
@@ -44,7 +44,8 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 public class EnumElasticIO implements DiscoveryIO {
 
     public static String ENUMS_INDEX_NAME_WRITE = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_ENUMS_INDEX_NAME_WRITE);
-    public static String ENUMS_INDEX_NAME_READ = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_READ);
+    public static String ENUMS_INDEX_NAME_READ = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_ENUMS_INDEX_NAME_READ);
+    public static String ELASTICSEARCH_INDEX_NAME_READ = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_READ);
     public static final String ENUMS_DOCUMENT_TYPE = "metrics";
 
     private Client client;
@@ -150,7 +151,8 @@ public class EnumElasticIO implements DiscoveryIO {
             );
         }
 
-        SearchResponse response = client.prepareSearch(ENUMS_INDEX_NAME_READ)
+        // search both ENUMS_INDEX_NAME_READ and ELASTICSEARCH_INDEX_NAME_READ
+        SearchResponse response = client.prepareSearch(ENUMS_INDEX_NAME_READ, ELASTICSEARCH_INDEX_NAME_READ)
                 .setRouting(tenant)
                 .setSize(100000)
                 .setVersion(true)

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/ElasticIOConfig.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/ElasticIOConfig.java
@@ -21,7 +21,8 @@ public enum ElasticIOConfig implements ConfigDefaults {
     ELASTICSEARCH_CLUSTERNAME("elasticsearch"),
     ELASTICSEARCH_INDEX_NAME_WRITE("metric_metadata"),
     ELASTICSEARCH_INDEX_NAME_READ("metric_metadata"),
-    ELASTICSEARCH_ENUMS_INDEX_NAME_WRITE("enums");
+    ELASTICSEARCH_ENUMS_INDEX_NAME_WRITE("enums"),
+    ELASTICSEARCH_ENUMS_INDEX_NAME_READ("enums");
 
     static {
         Configuration.getInstance().loadDefaults(ElasticIOConfig.values());

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/EnumElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/EnumElasticIOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Rackspace
+ * Copyright 2015 Rackspace
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ public class EnumElasticIOTest {
     private EsSetup esSetup;
     private Client esClientMock = mock(Client.class);
     private BulkRequestBuilder bulkRequestBuilderMock = mock(BulkRequestBuilder.class);
+    private ListenableActionFuture listenableActionFutureMock = mock(ListenableActionFuture.class);
+    private IndexRequestBuilder indexRequestBuilderMock = mock(IndexRequestBuilder.class);
 
     private static final String TENANT_1 = "100000";
     private static final String TENANT_2 = "200000";
@@ -52,6 +54,9 @@ public class EnumElasticIOTest {
     private static final String METRIC_NAME_B1 = "b.m1";
     private static final String METRIC_NAME_B2 = "b.m2";
     private static final String METRIC_NAME_B3 = "b.m3";
+
+    long collectionTime = 0;
+    TimeValue ttl = new TimeValue(1, TimeUnit.DAYS);
 
     BluefloodEnumRollup rollupWithEnumValues = new BluefloodEnumRollup()
             .withEnumValue("v1", 1L)
@@ -70,6 +75,16 @@ public class EnumElasticIOTest {
         enumElasticIO = new EnumElasticIO(esSetup.client());
         enumElasticIO.setINDEX_NAME_READ(EnumElasticIO.ENUMS_INDEX_NAME_WRITE);
         enumElasticIO.setINDEX_NAME_WRITE(EnumElasticIO.ENUMS_INDEX_NAME_WRITE);
+
+        // setup mock for ElasticSearch Client
+        when(bulkRequestBuilderMock.execute()).thenReturn(listenableActionFutureMock);
+        when(esClientMock.prepareBulk()).thenReturn(bulkRequestBuilderMock);
+        when(esClientMock.prepareIndex(EnumElasticIO.ENUMS_INDEX_NAME_WRITE, EnumElasticIO.ENUMS_DOCUMENT_TYPE))
+                .thenReturn(indexRequestBuilderMock);
+        when(indexRequestBuilderMock.setId(anyString())).thenReturn(indexRequestBuilderMock);
+        when(indexRequestBuilderMock.setSource(any(XContentBuilder.class))).thenReturn(indexRequestBuilderMock);
+        when(indexRequestBuilderMock.setCreate(anyBoolean())).thenReturn(indexRequestBuilderMock);
+        when(indexRequestBuilderMock.setRouting(anyString())).thenReturn(indexRequestBuilderMock);
     }
 
     @After
@@ -148,47 +163,41 @@ public class EnumElasticIOTest {
     }
 
     @Test
-    public void testInsertDiscovery() throws IOException {
-        // setup mock for BulkRequestBuilder
-        ListenableActionFuture listenableActionFutureMock = mock(ListenableActionFuture.class);
-        when(bulkRequestBuilderMock.execute()).thenReturn(listenableActionFutureMock);
+    public void testInsertDiscoverySingle() throws IOException {
+        enumElasticIO.setClient(esClientMock);
 
-        // setup mock for ElasticSearch Client
-        IndexRequestBuilder indexRequestBuilderMock = mock(IndexRequestBuilder.class);
-        when(esClientMock.prepareBulk()).thenReturn(bulkRequestBuilderMock);
-        when(esClientMock.prepareIndex(EnumElasticIO.ENUMS_INDEX_NAME_WRITE, EnumElasticIO.ENUMS_DOCUMENT_TYPE))
-                .thenReturn(indexRequestBuilderMock);
-        when(indexRequestBuilderMock.setId(anyString())).thenReturn(indexRequestBuilderMock);
-        when(indexRequestBuilderMock.setSource(any(XContentBuilder.class))).thenReturn(indexRequestBuilderMock);
-        when(indexRequestBuilderMock.setCreate(anyBoolean())).thenReturn(indexRequestBuilderMock);
-        when(indexRequestBuilderMock.setRouting(anyString())).thenReturn(indexRequestBuilderMock);
+        // test single metric insert
+        Locator locator = Locator.createLocatorFromPathComponents(TENANT_1, METRIC_NAME_A1);
+        IMetric metric = new PreaggregatedMetric(collectionTime, locator, ttl, rollupWithEnumValues);
+        enumElasticIO.insertDiscovery(metric);
+        // verify
+        verify(esClientMock, times(1)).prepareIndex(EnumElasticIO.ENUMS_INDEX_NAME_WRITE, EnumElasticIO.ENUMS_DOCUMENT_TYPE);
+        verify(indexRequestBuilderMock).setId(TENANT_1 + ":" + METRIC_NAME_A1);
+        verify(bulkRequestBuilderMock, times(1)).execute();
+    }
+
+    @Test
+    public void testInsertDiscoveryBatch() throws IOException {
         enumElasticIO.setClient(esClientMock);
 
         // create PreaggregatedMetric metrics list and call insertDiscovery with it
         List<IMetric> metrics = new ArrayList<IMetric>();
-        long collectionTime = 0;
         Locator locator1 = Locator.createLocatorFromPathComponents(TENANT_1, METRIC_NAME_A1);
         Locator locator2 = Locator.createLocatorFromPathComponents(TENANT_2, METRIC_NAME_B1);
-        TimeValue ttl = new TimeValue(1, TimeUnit.DAYS);
         metrics.add(new PreaggregatedMetric(collectionTime, locator1, ttl, rollupWithEnumValues));
         metrics.add(new PreaggregatedMetric(collectionTime, locator2, ttl, rollupWithEnumValues));
         enumElasticIO.insertDiscovery(metrics);
 
-        // verify client and bulk
-        verify(esClientMock, times(1)).prepareBulk();
-        verify(bulkRequestBuilderMock, times(2)).add(any(IndexRequestBuilder.class));
+        // verify client execute with right params
         verify(esClientMock, times(2)).prepareIndex(EnumElasticIO.ENUMS_INDEX_NAME_WRITE, EnumElasticIO.ENUMS_DOCUMENT_TYPE);
-        verify(bulkRequestBuilderMock, times(1)).execute();
-
-        // verify indexRequestBuilder
         verify(indexRequestBuilderMock, times(2)).setId(anyString());
         verify(indexRequestBuilderMock).setId(TENANT_1 + ":" + METRIC_NAME_A1);
         verify(indexRequestBuilderMock).setId(TENANT_2 + ":" + METRIC_NAME_B1);
         verify(indexRequestBuilderMock, times(2)).setSource(any(XContentBuilder.class));
-        verify(indexRequestBuilderMock, times(2)).setCreate(true);
         verify(indexRequestBuilderMock, times(2)).setRouting(anyString());
         verify(indexRequestBuilderMock).setRouting(TENANT_1);
         verify(indexRequestBuilderMock).setRouting(TENANT_2);
+        verify(bulkRequestBuilderMock, times(1)).execute();
     }
 
     @Test

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/EnumElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/EnumElasticIOTest.java
@@ -68,6 +68,9 @@ public class EnumElasticIOTest {
     public void setup() throws IOException {
         esSetup = new EsSetup();
         esSetup.execute(EsSetup.deleteAll());
+        esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
+                .withSettings(EsSetup.fromClassPath("index_settings.json"))
+                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
         esSetup.execute(EsSetup.createIndex(EnumElasticIO.ENUMS_INDEX_NAME_WRITE)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
                 .withMapping(EnumElasticIO.ENUMS_DOCUMENT_TYPE, EsSetup.fromClassPath("metrics_mapping_enums.json")));

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2013-2015 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.http;
+
+import com.github.tlrx.elasticsearch.test.EsSetup;
+import com.rackspacecloud.blueflood.inputs.handlers.HttpEventsIngestionHandler;
+import com.rackspacecloud.blueflood.inputs.handlers.HttpMetricsIngestionServer;
+import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.service.*;
+import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.utils.ModuleLoader;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.junit.*;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.Mockito.spy;
+
+public class HttpEnumIntegrationTest {
+
+    private static HttpIngestionService httpIngestionService;
+    private static HttpQueryService httpQueryService;
+    private static HttpClientVendor vendor;
+    private static DefaultHttpClient client;
+    private static Collection<Integer> manageShards = new HashSet<Integer>();
+    private static int httpPortIngest;
+    private static int httpPortQuery;
+    private static ScheduleContext context;
+    private static EventsIO eventsSearchIO;
+    private static EsSetup esSetup;
+
+    @BeforeClass
+    public static void setUp() throws Exception{
+        Configuration.getInstance().init();
+        System.setProperty(CoreConfig.DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.ElasticIO");
+        System.setProperty(CoreConfig.ENUMS_DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.EnumElasticIO");
+        System.setProperty(CoreConfig.EVENTS_MODULES.name(), "com.rackspacecloud.blueflood.io.EventElasticSearchIO");
+
+        // setup servers
+        httpPortIngest = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_INGESTION_PORT);
+        httpPortQuery = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT);
+        manageShards.add(1); manageShards.add(5); manageShards.add(6);
+        context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
+
+        // setup elasticsearch
+        esSetup = new EsSetup();
+        esSetup.execute(EsSetup.deleteAll());
+        esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
+                .withSettings(EsSetup.fromClassPath("index_settings.json"))
+                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
+        esSetup.execute(EsSetup.createIndex(EnumElasticIO.ENUMS_INDEX_NAME_WRITE)
+                .withSettings(EsSetup.fromClassPath("index_settings.json"))
+                .withMapping(EnumElasticIO.ENUMS_DOCUMENT_TYPE, EsSetup.fromClassPath("metrics_mapping_enums.json")));
+        esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
+                .withSettings(EsSetup.fromClassPath("index_settings.json"))
+                .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
+        eventsSearchIO = new EventElasticSearchIO(esSetup.client());
+        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(esSetup.client());
+        ((EnumElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.ENUMS_DISCOVERY_MODULES)).setClient(esSetup.client());
+
+        // setup ingestion server
+        HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context, new AstyanaxMetricsWriter());
+        server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
+        httpIngestionService = new HttpIngestionService();
+        httpIngestionService.setMetricsIngestionServer(server);
+        httpIngestionService.startService(context, new AstyanaxMetricsWriter());
+
+        // setup query server
+        httpQueryService = new HttpQueryService();
+        httpQueryService.startService();
+
+        vendor = new HttpClientVendor();
+        client = vendor.getClient();
+    }
+
+    @Test
+    public void testMetricIngestionWithEnum() throws Exception {
+        // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
+        final String tenant_id = "333333";
+        final String metric_name = "enum_metric_test";
+        Set<Locator> locators = new HashSet<Locator>();
+        locators.add(Locator.createLocatorFromPathComponents(tenant_id, metric_name));
+
+        // post enum metric for ingestion and verify
+        HttpResponse response = postAggregatedMetric(tenant_id, "src/test/resources/sample_enums_payload.json");
+        Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
+        EntityUtils.consume(response.getEntity());
+
+        // execute EnumValidator
+        EnumValidator enumValidator = new EnumValidator(locators);
+        enumValidator.run();
+
+        //Sleep for a while
+        Thread.sleep(3000);
+
+        // query for metric and assert results
+        HttpResponse query_response = queryMetricIncludeEnum(tenant_id, metric_name);
+        Assert.assertEquals("Should get status 200 from query server for GET", 200, query_response.getStatusLine().getStatusCode());
+
+        // assert response content
+        String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
+        Assert.assertEquals(String.format("[{\"metric\":\"%s\",\"enum_values\":[\"v1\",\"v2\",\"v3\"]}]", metric_name), responseContent);
+        EntityUtils.consume(query_response.getEntity());
+    }
+
+    private HttpResponse postAggregatedMetric(String tenantId, String payloadFilePath) throws URISyntaxException, IOException {
+        // get payload
+        StringBuilder sb = new StringBuilder();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(payloadFilePath)));
+        String curLine = reader.readLine();
+        while (curLine != null) {
+            sb = sb.append(curLine);
+            curLine = reader.readLine();
+        }
+        String json = sb.toString();
+
+        // build url to aggregated ingestion endpoint
+        URIBuilder builder = getMetricsURIBuilder()
+                .setPath(String.format("/v2.0/%s/ingest/aggregated", tenantId));
+        HttpPost post = new HttpPost(builder.build());
+        HttpEntity entity = new StringEntity(json, ContentType.APPLICATION_JSON);
+        post.setEntity(entity);
+
+        // post and return response
+        return client.execute(post);
+    }
+
+    private HttpResponse queryMetricIncludeEnum(String tenantId, String metricName) throws URISyntaxException, IOException {
+        URIBuilder query_builder = getMetricDataQueryURIBuilder()
+                .setPath(String.format("/v2.0/%s/metrics/search", tenantId));
+        query_builder.setParameter("query", metricName);
+        query_builder.setParameter("include_enum_values", "true");
+        HttpGet query_get = new HttpGet(query_builder.build());
+        return client.execute(query_get);
+    }
+
+    private URIBuilder getMetricsURIBuilder() throws URISyntaxException {
+        return new URIBuilder().setScheme("http").setHost("127.0.0.1")
+                .setPort(httpPortIngest).setPath("/v2.0/acTEST/ingest");
+    }
+
+    private URIBuilder getMetricDataQueryURIBuilder() throws URISyntaxException {
+        return new URIBuilder().setScheme("http").setHost("127.0.0.1")
+                .setPort(httpPortQuery).setPath("/v2.0/acTEST/metrics/search")
+                .setParameter("query", "call*");
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(), "");
+        Configuration.getInstance().setProperty(CoreConfig.ENUMS_DISCOVERY_MODULES.name(), "");
+        Configuration.getInstance().setProperty(CoreConfig.EVENTS_MODULES.name(), "");
+        Configuration.getInstance().setProperty(CoreConfig.ENUM_UNIQUE_VALUES_THRESHOLD.name(), "100");
+
+        if (esSetup != null) {
+            esSetup.terminate();
+        }
+
+        if (vendor != null) {
+            vendor.shutdown();
+        }
+
+        if (httpQueryService != null) {
+            httpQueryService.stopService();
+        }
+
+        if (httpIngestionService != null) {
+            httpIngestionService.shutdownService();
+        }
+    }
+}

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndTest.java
@@ -157,6 +157,14 @@ public class HttpAnnotationsEndToEndTest {
             esSetup.terminate();
         }
 
+        if (vendor != null) {
+            vendor.shutdown();
+        }
+
+        if (httpIngestionService != null) {
+            httpIngestionService.shutdownService();
+        }
+
         if (httpQueryService != null) {
             httpQueryService.stopService();
         }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
@@ -17,10 +17,6 @@
 package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.github.tlrx.elasticsearch.test.EsSetup;
-import com.netflix.astyanax.connectionpool.OperationResult;
-import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
-import com.netflix.astyanax.connectionpool.exceptions.NotFoundException;
-import com.netflix.astyanax.model.*;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
 import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainerTest;
 import com.rackspacecloud.blueflood.io.*;

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
@@ -35,10 +35,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.ExpectedException;
 
 import java.net.ConnectException;
@@ -125,7 +122,6 @@ public class HttpMetricsIngestionServerShutdownIntegrationTest {
         }
     }
 
-
     private URI getMetricsURI() throws URISyntaxException {
         return getMetricsURIBuilder().build();
     }
@@ -133,6 +129,18 @@ public class HttpMetricsIngestionServerShutdownIntegrationTest {
     private URIBuilder getMetricsURIBuilder() throws URISyntaxException {
         return new URIBuilder().setScheme("http").setHost("127.0.0.1")
                 .setPort(httpPort).setPath("/v2.0/acTEST/ingest");
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        Configuration.getInstance().setProperty(CoreConfig.EVENTS_MODULES.name(), "");
+        if (esSetup != null) {
+            esSetup.terminate();
+        }
+
+        if (vendor != null) {
+            vendor.shutdown();
+        }
     }
 
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpAnnotationsIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpAnnotationsIntegrationTest.java
@@ -196,6 +196,10 @@ public class HttpAnnotationsIntegrationTest {
             esSetup.terminate();
         }
 
+        if (vendor != null) {
+            vendor.shutdown();
+        }
+
         if (httpQueryService != null) {
             httpQueryService.stopService();
         }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -227,6 +227,10 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
             esSetup.terminate();
         }
 
+        if (vendor != null) {
+            vendor.shutdown();
+        }
+
         if (httpQueryService != null) {
             httpQueryService.stopService();
         }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class HttpMetricsIndexHandler implements HttpRequestHandler {
@@ -97,6 +98,8 @@ public class HttpMetricsIndexHandler implements HttpRequestHandler {
             // get enum values and add if applicable
             ArrayList<String> enumValues = result.getEnumValues();
             if (enumValues != null) {
+                // sort for consistent result ordering
+                Collections.sort(enumValues);
                 ArrayNode enumValuesArray = JsonNodeFactory.instance.arrayNode();
                 for (String val : enumValues) {
                     enumValuesArray.add(val);

--- a/blueflood-http/src/test/resources/sample_enums_payload.json
+++ b/blueflood-http/src/test/resources/sample_enums_payload.json
@@ -1,0 +1,26 @@
+{
+    "tenantId":"333333",
+    "timestamp":1439231324000,
+    "enums": [
+        {
+            "name": "enum_metric_test",
+            "value": "v3"
+        },
+        {
+            "name": "enum_metric_test",
+            "value": "v1"
+        },
+        {
+            "name": "enum_metric_test",
+            "value": "v1"
+        },
+        {
+            "name": "enum_metric_test",
+            "value": "v2"
+        },
+        {
+            "name": "enum_metric_test",
+            "value": "v3"
+        }
+    ]
+}


### PR DESCRIPTION
WHAT:  "Check for bad enum metrics" story (https://jira.rax.io/browse/CMD-749)

Create a threadpool of threads, which can be kicked off by RollupService everytime it is activated, that will run in parallel to validate enum metrics and check for bad metrics.  Enum metrics are consider "bad" when the number of unique enum values ingested for the metric exceeded a certain configurable threshold (e.g. 100).  

The thread will also write new enums indexes to elastic search, which will contains all enum values for the metric -- if it is not a bad metric.  This allows users to query blueflood with the include_enum_values param and retrieve metric names along with all enum values in the result.

WHY:  prevent blueflood from ingesting enum metrics with too many unique values, which isn't useful and an incorrect usage of enum metrics.  Also allow users to see a list of all enum values ingested for  metrics by creating the "enums" indexes in elasticsearch.

HOW: 
Add thread EnumValidator, which valid enum metrics and
- mark metrics as bad if exceeds threshold, or
- write elastic search enums index of values for querying.

This is done via a runnable thread EnumValidator that is stared by the RollupService, for any batch of metrics that are involved in the rollup.  The EnumValidator threads process the metrics in parallel to rollup, and does not depend on data from the rollup, except for the locators of the metrics affected.

EnumValidator threads are manage by a threadpool executor enumValidatorExecutor, added to the RollupService.
