### PR TITLE
Ingestion server shutdown

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IngestionService.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/IngestionService.java
@@ -20,5 +20,6 @@ import com.rackspacecloud.blueflood.io.IMetricsWriter;
 
 public interface IngestionService {
     public void startService(ScheduleContext context, IMetricsWriter writer);
+    public void shutdownService();
 }
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
@@ -417,5 +417,9 @@ public class HttpHandlerIntegrationTest {
         if (vendor != null) {
             vendor.shutdown();
         }
+
+        if (httpIngestionService != null) {
+            httpIngestionService.shutdownService();
+        }
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
@@ -41,6 +41,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.net.ConnectException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Calendar;
@@ -88,9 +89,6 @@ public class HttpMetricsIngestionServerShutdownIntegrationTest {
         client = vendor.getClient();
     }
 
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
-
     @Test
     public void testHttpIngestionHappyCase() throws Exception {
 
@@ -110,8 +108,12 @@ public class HttpMetricsIngestionServerShutdownIntegrationTest {
         server.shutdownServer();
 
         // then
-        exception.expect(java.net.ConnectException.class);
-        HttpResponse response2 = client.execute(post2);
+        try {
+            HttpResponse response2 = client.execute(post2);
+            Assert.fail("We should have received a Connect exception");
+        } catch (ConnectException ex) {
+            Assert.assertEquals("Connection refused", ex.getMessage());
+        }
     }
 
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.inputs.handlers;
+
+
+import com.github.tlrx.elasticsearch.test.EsSetup;
+import com.rackspacecloud.blueflood.http.HttpClientVendor;
+import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainerTest;
+import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.rollup.Granularity;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.service.HttpConfig;
+import com.rackspacecloud.blueflood.service.ScheduleContext;
+import com.rackspacecloud.blueflood.types.*;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.HashSet;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.*;
+
+public class HttpMetricsIngestionServerShutdownIntegrationTest {
+
+    private static HttpMetricsIngestionServer server;
+    private static HttpClientVendor vendor;
+    private static DefaultHttpClient client;
+    private static Collection<Integer> manageShards = new HashSet<Integer>();
+    private static int httpPort;
+    private static ScheduleContext context;
+    private static EventsIO eventsSearchIO;
+    private static EsSetup esSetup;
+    //A time stamp 2 days ago
+    private final long baseMillis = Calendar.getInstance().getTimeInMillis() - 172800000;
+
+
+    @BeforeClass
+    public static void setUp() throws Exception{
+        System.setProperty(CoreConfig.EVENTS_MODULES.name(), "com.rackspacecloud.blueflood.io.EventElasticSearchIO");
+        Configuration.getInstance().init();
+        httpPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_INGESTION_PORT);
+        manageShards.add(1); manageShards.add(5); manageShards.add(6);
+        context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
+
+        esSetup = new EsSetup();
+        esSetup.execute(EsSetup.deleteAll());
+        esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
+                .withSettings(EsSetup.fromClassPath("index_settings.json"))
+                .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
+        eventsSearchIO = new EventElasticSearchIO(esSetup.client());
+        server = new HttpMetricsIngestionServer(context, new AstyanaxMetricsWriter());
+        server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
+
+        server.startServer();
+
+        vendor = new HttpClientVendor();
+        client = vendor.getClient();
+    }
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testHttpIngestionHappyCase() throws Exception {
+
+        // given
+        HttpPost post = new HttpPost(getMetricsURI());
+        HttpEntity entity = new StringEntity(JSONMetricsContainerTest.generateJSONMetricsData(),
+                ContentType.APPLICATION_JSON);
+        post.setEntity(entity);
+        HttpResponse response = client.execute(post);
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        HttpPost post2 = new HttpPost(getMetricsURI());
+        HttpEntity entity2 = new StringEntity(JSONMetricsContainerTest.generateJSONMetricsData(),
+                ContentType.APPLICATION_JSON);
+        post2.setEntity(entity2);
+
+        // when
+        server.shutdownServer();
+
+        // then
+        exception.expect(java.net.ConnectException.class);
+        HttpResponse response2 = client.execute(post2);
+    }
+
+
+    private URI getMetricsURI() throws URISyntaxException {
+        return getMetricsURIBuilder().build();
+    }
+
+    private URIBuilder getMetricsURIBuilder() throws URISyntaxException {
+        return new URIBuilder().setScheme("http").setHost("127.0.0.1")
+                .setPort(httpPort).setPath("/v2.0/acTEST/ingest");
+    }
+
+}

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -232,6 +232,10 @@ public class HttpMetricsIngestionServer {
 
     @VisibleForTesting
     public void shutdownServer() {
-        throw new UnsupportedOperationException("The method is not implemented");
+        try {
+            serverChannel.close().await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            // Pass
+        }
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -230,6 +230,7 @@ public class HttpMetricsIngestionServer {
         }
     }
 
+    @VisibleForTesting
     public void shutdownServer() {
         throw new UnsupportedOperationException("The method is not implemented");
     }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -72,6 +72,7 @@ public class HttpMetricsIngestionServer {
 
     private ServerBootstrap bootstrap;
     private Channel serverChannel;
+    private ChannelFactory channelFactory;
 
     public TrackerMBean tracker;
 
@@ -100,10 +101,11 @@ public class HttpMetricsIngestionServer {
         router.post("/v2.0/:tenantId/ingest/aggregated/multi", new HttpAggregatedMultiIngestionHandler(processor, timeout));
 
         log.info("Starting metrics listener HTTP server on port {}", httpIngestPort);
-        ServerBootstrap server = new ServerBootstrap(
+        channelFactory =
                 new NioServerSocketChannelFactory(
                         Executors.newFixedThreadPool(acceptThreads),
-                        Executors.newFixedThreadPool(workerThreads)));
+                        Executors.newFixedThreadPool(workerThreads));
+        ServerBootstrap server = new ServerBootstrap(channelFactory);
 
         server.setPipelineFactory(new MetricsHttpServerPipelineFactory(router));
         serverChannel = server.bind(new InetSocketAddress(httpIngestHost, httpIngestPort));

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -229,4 +229,8 @@ public class HttpMetricsIngestionServer {
             return batchWriter.apply(batches);
         }
     }
+
+    public void shutdownServer() {
+        throw new UnsupportedOperationException("The method is not implemented");
+    }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -31,7 +31,6 @@ import com.rackspacecloud.blueflood.inputs.processors.TypeAndUnitProcessor;
 import com.rackspacecloud.blueflood.io.EventsIO;
 import com.rackspacecloud.blueflood.io.IMetricsWriter;
 import com.rackspacecloud.blueflood.service.*;
-import com.rackspacecloud.blueflood.types.Event;
 import com.rackspacecloud.blueflood.tracker.Tracker;
 import com.rackspacecloud.blueflood.tracker.TrackerMBean;
 import com.rackspacecloud.blueflood.types.IMetric;
@@ -40,11 +39,7 @@ import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import com.rackspacecloud.blueflood.utils.Metrics;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import org.jboss.netty.bootstrap.ServerBootstrap;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.channel.ExceptionEvent;
+import org.jboss.netty.channel.*;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpChunkAggregator;
@@ -76,6 +71,7 @@ public class HttpMetricsIngestionServer {
     private static int MAX_CONTENT_LENGTH = 1048576; // 1 MB
 
     private ServerBootstrap bootstrap;
+    private Channel serverChannel;
 
     public TrackerMBean tracker;
 
@@ -110,7 +106,7 @@ public class HttpMetricsIngestionServer {
                         Executors.newFixedThreadPool(workerThreads)));
 
         server.setPipelineFactory(new MetricsHttpServerPipelineFactory(router));
-        server.bind(new InetSocketAddress(httpIngestHost, httpIngestPort));
+        serverChannel = server.bind(new InetSocketAddress(httpIngestHost, httpIngestPort));
 
         bootstrap = server;
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -72,8 +72,6 @@ public class HttpMetricsIngestionServer {
     private TimeValue timeout;
     private static int MAX_CONTENT_LENGTH = 1048576; // 1 MB
 
-    private ServerBootstrap bootstrap;
-    private ChannelFactory channelFactory;
     private ChannelGroup allOpenChannels = new DefaultChannelGroup("allOpenChannels");
 
     public TrackerMBean tracker;
@@ -103,7 +101,7 @@ public class HttpMetricsIngestionServer {
         router.post("/v2.0/:tenantId/ingest/aggregated/multi", new HttpAggregatedMultiIngestionHandler(processor, timeout));
 
         log.info("Starting metrics listener HTTP server on port {}", httpIngestPort);
-        channelFactory =
+        ChannelFactory channelFactory =
                 new NioServerSocketChannelFactory(
                         Executors.newFixedThreadPool(acceptThreads),
                         Executors.newFixedThreadPool(workerThreads));
@@ -112,8 +110,6 @@ public class HttpMetricsIngestionServer {
         server.setPipelineFactory(new MetricsHttpServerPipelineFactory(router));
         Channel serverChannel = server.bind(new InetSocketAddress(httpIngestHost, httpIngestPort));
         allOpenChannels.add(serverChannel);
-
-        bootstrap = server;
 
         log.info("Starting tracker service");
         tracker = new Tracker();

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -75,6 +75,8 @@ public class HttpMetricsIngestionServer {
     private TimeValue timeout;
     private static int MAX_CONTENT_LENGTH = 1048576; // 1 MB
 
+    private ServerBootstrap bootstrap;
+
     public TrackerMBean tracker;
 
     public HttpMetricsIngestionServer(ScheduleContext context, IMetricsWriter writer) {
@@ -109,6 +111,8 @@ public class HttpMetricsIngestionServer {
 
         server.setPipelineFactory(new MetricsHttpServerPipelineFactory(router));
         server.bind(new InetSocketAddress(httpIngestHost, httpIngestPort));
+
+        bootstrap = server;
 
         log.info("Starting tracker service");
         tracker = new Tracker();

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpIngestionService.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpIngestionService.java
@@ -47,4 +47,8 @@ public class HttpIngestionService implements IngestionService {
 
         return this.server;
     }
+
+    public void shutdownService() {
+        throw new UnsupportedOperationException("The method is not implemented");
+    }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpIngestionService.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpIngestionService.java
@@ -49,6 +49,8 @@ public class HttpIngestionService implements IngestionService {
     }
 
     public void shutdownService() {
-        throw new UnsupportedOperationException("The method is not implemented");
+        if (this.server != null) {
+            this.server.shutdownServer();
+        }
     }
 }


### PR DESCRIPTION
This PR adds a `shutdownService` method to the `HttpMetricsIngestionServer` class. This would allow us to shutdown the ingestion service during tests, so that we can run several tests separately, instead of trying to cram everything into one test class.