### PR TITLE
Adding some tracking for delayed metrics using the JMX request tracker

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
@@ -20,6 +20,7 @@ import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Metric;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import org.codehaus.jackson.annotate.JsonIgnore;
+import org.joda.time.DateTime;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 public class JSONMetricsContainer {
     private final String tenantId;
     private final List<JSONMetric> jsonMetrics;
+    private List<Metric> delayedMetrics;
+    private static final long millisIn10Minutes = 10 * 60 * 1000;
 
     public JSONMetricsContainer(String tenantId, List<JSONMetric> metrics) {
         this.tenantId = tenantId;
@@ -50,6 +53,7 @@ public class JSONMetricsContainer {
         }
 
         final List<Metric> metrics = new ArrayList<Metric>();
+        delayedMetrics = new ArrayList<Metric>();
         for (JSONMetric jsonMetric : jsonMetrics) {
             Locator locator;
             if (jsonMetric instanceof ScopedJSONMetric) {
@@ -62,11 +66,19 @@ public class JSONMetricsContainer {
             if (jsonMetric.getMetricValue() != null) {
                 final Metric metric = new Metric(locator, jsonMetric.getMetricValue(), jsonMetric.getCollectionTime(),
                         new TimeValue(jsonMetric.getTtlInSeconds(), TimeUnit.SECONDS), jsonMetric.getUnit());
+                long nowMillis = new DateTime().getMillis();
+                if (nowMillis - metric.getCollectionTime() > millisIn10Minutes) {
+                    delayedMetrics.add(metric);
+                }
                 metrics.add(metric);
             }
         }
 
         return metrics;
+    }
+
+    public boolean areDelayedMetricsPresent() {
+        return delayedMetrics.size() > 0;
     }
 
     // Jackson compatible class. Jackson uses reflection to call these methods and so they have to match JSON keys.

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
@@ -16,6 +16,8 @@
 
 package com.rackspacecloud.blueflood.inputs.formats;
 
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Metric;
 import com.rackspacecloud.blueflood.utils.TimeValue;
@@ -30,7 +32,7 @@ public class JSONMetricsContainer {
     private final String tenantId;
     private final List<JSONMetric> jsonMetrics;
     private List<Metric> delayedMetrics;
-    private static final long millisIn10Minutes = 10 * 60 * 1000;
+    private static final long delayedMetricsMillis = Configuration.getInstance().getLongProperty(CoreConfig.DELAYED_METRICS_MILLIS);
 
     public JSONMetricsContainer(String tenantId, List<JSONMetric> metrics) {
         this.tenantId = tenantId;
@@ -67,7 +69,7 @@ public class JSONMetricsContainer {
                 final Metric metric = new Metric(locator, jsonMetric.getMetricValue(), jsonMetric.getCollectionTime(),
                         new TimeValue(jsonMetric.getTtlInSeconds(), TimeUnit.SECONDS), jsonMetric.getUnit());
                 long nowMillis = new DateTime().getMillis();
-                if (nowMillis - metric.getCollectionTime() > millisIn10Minutes) {
+                if (nowMillis - metric.getCollectionTime() > delayedMetricsMillis) {
                     delayedMetrics.add(metric);
                 }
                 metrics.add(metric);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -146,7 +146,9 @@ public enum CoreConfig implements ConfigDefaults {
     // Should at least be equal to the number of the netty worker threads, if http module is getting loaded
     ES_UNIT_THREADS("50"),
     ROLLUP_ON_READ_THREADS("50"),
-    TURN_OFF_RR_MPLOT("false");
+    TURN_OFF_RR_MPLOT("false"),
+
+    DELAYED_METRICS_MILLIS("300000");
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
@@ -95,6 +95,10 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
                 if (!jsonMetricsContainer.isValid()) {
                     throw new IOException("Invalid JSONMetricsContainer");
                 }
+
+                if (!jsonMetricsContainer.areDelayedMetricsPresent()) {
+                    Tracker.trackDelayedMetricsTenant(tenantId);
+                }
             } catch (JsonParseException e) {
                 log.warn("Exception parsing content", e);
                 DefaultHandler.sendResponse(ctx, request, "Cannot parse content", HttpResponseStatus.BAD_REQUEST);

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
@@ -95,10 +95,6 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
                 if (!jsonMetricsContainer.isValid()) {
                     throw new IOException("Invalid JSONMetricsContainer");
                 }
-
-                if (!jsonMetricsContainer.areDelayedMetricsPresent()) {
-                    Tracker.trackDelayedMetricsTenant(tenantId);
-                }
             } catch (JsonParseException e) {
                 log.warn("Exception parsing content", e);
                 DefaultHandler.sendResponse(ctx, request, "Cannot parse content", HttpResponseStatus.BAD_REQUEST);
@@ -127,6 +123,10 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
             try {
                 containerMetrics = jsonMetricsContainer.toMetrics();
                 forceTTLsIfConfigured(containerMetrics);
+
+                if (!jsonMetricsContainer.areDelayedMetricsPresent()) {
+                    Tracker.trackDelayedMetricsTenant(tenantId);
+                }
             } catch (InvalidDataException ex) {
                 // todo: we should measure these. if they spike, we track down the bad client.
                 // this is strictly a client problem. Someting wasn't right (data out of range, etc.)

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
@@ -36,7 +36,6 @@ public class PreaggregateConversions {
     // todo: punt on TTL
     private static final TimeValue DEFAULT_TTL = new TimeValue(48, TimeUnit.HOURS);
     private static final String NAME_DELIMITER = "//.";
-    private static final long millisIn10Minutes = 10 * 60 * 1000;
 
     // NOTE: when you create objects from gson-converted json, you need to make sure to resolve numbers that
     // are not accessed via `doubleValue()` or `longValue()`, i.e., they are treated as `Number` instances.
@@ -46,10 +45,6 @@ public class PreaggregateConversions {
     
     public static Collection<IMetric> buildMetricsCollection(AggregatedPayload payload) {
         Collection<IMetric> metrics = new ArrayList<IMetric>();
-        long nowMillis = new DateTime().getMillis();
-        if (nowMillis - payload.getTimestamp() > millisIn10Minutes) {
-            Tracker.trackDelayedMetricsTenant(payload.getTenantId());
-        }
         metrics.addAll(PreaggregateConversions.convertCounters(payload.getTenantId(), payload.getTimestamp(), payload.getFlushIntervalMillis(), payload.getCounters()));
         metrics.addAll(PreaggregateConversions.convertGauges(payload.getTenantId(), payload.getTimestamp(), payload.getGauges()));
         metrics.addAll(PreaggregateConversions.convertSets(payload.getTenantId(), payload.getTimestamp(), payload.getSets()));

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
@@ -38,6 +38,7 @@ public class Tracker implements TrackerMBean {
     private static final String trackerName = String.format("com.rackspacecloud.blueflood.tracker:type=%s", Tracker.class.getSimpleName());
 
     static Set tenantIds = new HashSet();
+    static boolean isTrackingDelayedMetrics = false;
 
     public Tracker() {
         registerMBean();
@@ -46,6 +47,14 @@ public class Tracker implements TrackerMBean {
     public void addTenant(String tenantId) {
         tenantIds.add(tenantId);
         log.info("[TRACKER] tenantId " + tenantId + " added.");
+    }
+
+    public void setIsTrackingDelayedMetrics() {
+        isTrackingDelayedMetrics = true;
+    }
+
+    public void resetIsTrackingDelayedMetrics() {
+        isTrackingDelayedMetrics = false;
     }
 
     public void removeTenant(String tenantId) {
@@ -108,6 +117,13 @@ public class Tracker implements TrackerMBean {
                     "HEADERS: " + headers +
                     requestContent;
 
+            log.info(logMessage);
+        }
+    }
+
+    public static void trackDelayedMetricsTenant(String tenantid) {
+        if (isTrackingDelayedMetrics) {
+            String logMessage = String.format("[TRACKER][DELAYED METRIC] Tenant sending delayed metric is %s",tenantid);
             log.info(logMessage);
         }
     }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainerTest.java
@@ -82,6 +82,40 @@ public class JSONMetricsContainerTest {
         }
     }
 
+    @Test
+    public void testDelayedMetric() throws Exception {
+        String jsonBody = "[{\"collectionTime\":1401302372775,\"ttlInSeconds\":172800,\"metricValue\":1844,\"metricName\":\"metricName1\",\"unit\":\"unknown\"}]";
+
+        JSONMetricsContainer container = null;
+
+        List<JSONMetricsContainer.JSONMetric> jsonMetrics =
+                mapper.readValue(
+                        jsonBody,
+                        typeFactory.constructCollectionType(List.class,
+                                JSONMetricsContainer.JSONMetric.class)
+                );
+        container = new JSONMetricsContainer("786659", jsonMetrics);
+        List<Metric> metrics = container.toMetrics();
+        Assert.assertTrue(container.areDelayedMetricsPresent());
+    }
+
+    @Test
+    public void testDelayedMetricFalseForRecentMetric() throws Exception {
+        String jsonBody = "[{\"collectionTime\":"+System.currentTimeMillis()+",\"ttlInSeconds\":172800,\"metricValue\":1844,\"metricName\":\"metricName1\",\"unit\":\"unknown\"}]";
+
+        JSONMetricsContainer container = null;
+
+        List<JSONMetricsContainer.JSONMetric> jsonMetrics =
+                mapper.readValue(
+                        jsonBody,
+                        typeFactory.constructCollectionType(List.class,
+                                JSONMetricsContainer.JSONMetric.class)
+                );
+        container = new JSONMetricsContainer("786659", jsonMetrics);
+        List<Metric> metrics = container.toMetrics();
+        Assert.assertFalse(container.areDelayedMetricsPresent());
+    }
+
     public static List<Map<String, Object>> generateMetricsData() throws Exception {
         List<Map<String, Object>> metricsList = new ArrayList<Map<String, Object>>();
 


### PR DESCRIPTION
What:
Using the Tracker class to track tenants that may be sending us delayed metrics. 

Why:
Currently, the re-roll metric tracks only the number of re-rolls. We need to add some on demand logging using JMX for tracking the tenants that may be sending us delayed metrics. 

How: 
Used @VinnyQ's request tracker and added another method to track delayed metrics if a flag is set. 


