### PR TITLE
add http integration tests for single and multiplot queries

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -489,7 +489,7 @@ public class AstyanaxReader extends AstyanaxIO {
             metricDataMap = pointsFuture.get();
             for (Locator l : metricDataMap.keySet()) {
                 Points p = transformEnumValueHashesToStrings(metricDataMap.get(l), enumValues.get(l));
-                MetricData m = new MetricData(p, getUnitString(l), MetricData.Type.NUMBER);
+                MetricData m = new MetricData(p, getUnitString(l), MetricData.Type.ENUM);
                 resultMap.put(l,m);
             }
         } catch (InterruptedException e) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/MetricData.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/MetricData.java
@@ -49,7 +49,8 @@ public class MetricData {
         NUMBER("number"),
         BOOLEAN("boolean"),
         STRING("string"),
-        HISTOGRAM("histogram");
+        HISTOGRAM("histogram"),
+        ENUM("enum");
 
         private Type(String s) {
             this.name = s;

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
@@ -37,7 +37,7 @@ public class HttpEnumIntegrationTest extends HttpIntegrationTestBase {
         locators.add(Locator.createLocatorFromPathComponents(tenant_id, metric_name));
 
         // post enum metric for ingestion and verify
-        HttpResponse response = postAggregatedMetric(tenant_id, "src/test/resources/sample_enums_payload.json");
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "src/test/resources/sample_enums_payload.json");
         Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
         EntityUtils.consume(response.getEntity());
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
@@ -16,91 +16,17 @@
 
 package com.rackspacecloud.blueflood.http;
 
-import com.github.tlrx.elasticsearch.test.EsSetup;
-import com.rackspacecloud.blueflood.inputs.handlers.HttpEventsIngestionHandler;
-import com.rackspacecloud.blueflood.inputs.handlers.HttpMetricsIngestionServer;
-import com.rackspacecloud.blueflood.io.*;
-import com.rackspacecloud.blueflood.service.*;
+import com.rackspacecloud.blueflood.service.EnumValidator;
 import com.rackspacecloud.blueflood.types.Locator;
-import com.rackspacecloud.blueflood.utils.ModuleLoader;
-import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Test;
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URISyntaxException;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.mockito.Mockito.spy;
-
-public class HttpEnumIntegrationTest {
-
-    private static HttpIngestionService httpIngestionService;
-    private static HttpQueryService httpQueryService;
-    private static HttpClientVendor vendor;
-    private static DefaultHttpClient client;
-    private static Collection<Integer> manageShards = new HashSet<Integer>();
-    private static int httpPortIngest;
-    private static int httpPortQuery;
-    private static ScheduleContext context;
-    private static EventsIO eventsSearchIO;
-    private static EsSetup esSetup;
-
-    @BeforeClass
-    public static void setUp() throws Exception{
-        Configuration.getInstance().init();
-        System.setProperty(CoreConfig.DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.ElasticIO");
-        System.setProperty(CoreConfig.ENUMS_DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.EnumElasticIO");
-        System.setProperty(CoreConfig.EVENTS_MODULES.name(), "com.rackspacecloud.blueflood.io.EventElasticSearchIO");
-
-        // setup servers
-        httpPortIngest = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_INGESTION_PORT);
-        httpPortQuery = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT);
-        manageShards.add(1); manageShards.add(5); manageShards.add(6);
-        context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
-
-        // setup elasticsearch
-        esSetup = new EsSetup();
-        esSetup.execute(EsSetup.deleteAll());
-        esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
-                .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
-        esSetup.execute(EsSetup.createIndex(EnumElasticIO.ENUMS_INDEX_NAME_WRITE)
-                .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping(EnumElasticIO.ENUMS_DOCUMENT_TYPE, EsSetup.fromClassPath("metrics_mapping_enums.json")));
-        esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
-                .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
-        eventsSearchIO = new EventElasticSearchIO(esSetup.client());
-        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(esSetup.client());
-        ((EnumElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.ENUMS_DISCOVERY_MODULES)).setClient(esSetup.client());
-
-        // setup ingestion server
-        HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context, new AstyanaxMetricsWriter());
-        server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
-        httpIngestionService = new HttpIngestionService();
-        httpIngestionService.setMetricsIngestionServer(server);
-        httpIngestionService.startService(context, new AstyanaxMetricsWriter());
-
-        // setup query server
-        httpQueryService = new HttpQueryService();
-        httpQueryService.startService();
-
-        vendor = new HttpClientVendor();
-        client = vendor.getClient();
-    }
+public class HttpEnumIntegrationTest extends HttpIntegrationTestBase {
 
     @Test
     public void testMetricIngestionWithEnum() throws Exception {
@@ -132,69 +58,4 @@ public class HttpEnumIntegrationTest {
         EntityUtils.consume(query_response.getEntity());
     }
 
-    private HttpResponse postAggregatedMetric(String tenantId, String payloadFilePath) throws URISyntaxException, IOException {
-        // get payload
-        StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(payloadFilePath)));
-        String curLine = reader.readLine();
-        while (curLine != null) {
-            sb = sb.append(curLine);
-            curLine = reader.readLine();
-        }
-        String json = sb.toString();
-
-        // build url to aggregated ingestion endpoint
-        URIBuilder builder = getMetricsURIBuilder()
-                .setPath(String.format("/v2.0/%s/ingest/aggregated", tenantId));
-        HttpPost post = new HttpPost(builder.build());
-        HttpEntity entity = new StringEntity(json, ContentType.APPLICATION_JSON);
-        post.setEntity(entity);
-
-        // post and return response
-        return client.execute(post);
-    }
-
-    private HttpResponse queryMetricIncludeEnum(String tenantId, String metricName) throws URISyntaxException, IOException {
-        URIBuilder query_builder = getMetricDataQueryURIBuilder()
-                .setPath(String.format("/v2.0/%s/metrics/search", tenantId));
-        query_builder.setParameter("query", metricName);
-        query_builder.setParameter("include_enum_values", "true");
-        HttpGet query_get = new HttpGet(query_builder.build());
-        return client.execute(query_get);
-    }
-
-    private URIBuilder getMetricsURIBuilder() throws URISyntaxException {
-        return new URIBuilder().setScheme("http").setHost("127.0.0.1")
-                .setPort(httpPortIngest).setPath("/v2.0/acTEST/ingest");
-    }
-
-    private URIBuilder getMetricDataQueryURIBuilder() throws URISyntaxException {
-        return new URIBuilder().setScheme("http").setHost("127.0.0.1")
-                .setPort(httpPortQuery).setPath("/v2.0/acTEST/metrics/search")
-                .setParameter("query", "call*");
-    }
-
-    @AfterClass
-    public static void shutdown() {
-        Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(), "");
-        Configuration.getInstance().setProperty(CoreConfig.ENUMS_DISCOVERY_MODULES.name(), "");
-        Configuration.getInstance().setProperty(CoreConfig.EVENTS_MODULES.name(), "");
-        Configuration.getInstance().setProperty(CoreConfig.ENUM_UNIQUE_VALUES_THRESHOLD.name(), "100");
-
-        if (esSetup != null) {
-            esSetup.terminate();
-        }
-
-        if (vendor != null) {
-            vendor.shutdown();
-        }
-
-        if (httpQueryService != null) {
-            httpQueryService.stopService();
-        }
-
-        if (httpIngestionService != null) {
-            httpIngestionService.shutdownService();
-        }
-    }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2013-2015 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.http;
+
+import com.github.tlrx.elasticsearch.test.EsSetup;
+import com.rackspacecloud.blueflood.inputs.handlers.HttpEventsIngestionHandler;
+import com.rackspacecloud.blueflood.inputs.handlers.HttpMetricsIngestionServer;
+import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.service.*;
+import com.rackspacecloud.blueflood.utils.ModuleLoader;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.HashSet;
+
+import static org.mockito.Mockito.spy;
+
+public class HttpIntegrationTestBase {
+    private static HttpIngestionService httpIngestionService;
+    private static HttpQueryService httpQueryService;
+    private static HttpClientVendor vendor;
+    private static DefaultHttpClient client;
+    private static Collection<Integer> manageShards = new HashSet<Integer>();
+    private static int httpPortIngest;
+    private static int httpPortQuery;
+    private static ScheduleContext context;
+    private static EventsIO eventsSearchIO;
+    private static EsSetup esSetup;
+
+    @BeforeClass
+    public static void setUp() throws Exception{
+        Configuration.getInstance().init();
+        System.setProperty(CoreConfig.DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.ElasticIO");
+        System.setProperty(CoreConfig.ENUMS_DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.EnumElasticIO");
+        System.setProperty(CoreConfig.EVENTS_MODULES.name(), "com.rackspacecloud.blueflood.io.EventElasticSearchIO");
+
+        // setup servers
+        httpPortIngest = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_INGESTION_PORT);
+        httpPortQuery = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT);
+        manageShards.add(1); manageShards.add(5); manageShards.add(6);
+        context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
+
+        // setup elasticsearch
+        esSetup = new EsSetup();
+        esSetup.execute(EsSetup.deleteAll());
+        esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
+                .withSettings(EsSetup.fromClassPath("index_settings.json"))
+                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
+        esSetup.execute(EsSetup.createIndex(EnumElasticIO.ENUMS_INDEX_NAME_WRITE)
+                .withSettings(EsSetup.fromClassPath("index_settings.json"))
+                .withMapping(EnumElasticIO.ENUMS_DOCUMENT_TYPE, EsSetup.fromClassPath("metrics_mapping_enums.json")));
+        esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
+                .withSettings(EsSetup.fromClassPath("index_settings.json"))
+                .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
+        eventsSearchIO = new EventElasticSearchIO(esSetup.client());
+        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(esSetup.client());
+        ((EnumElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.ENUMS_DISCOVERY_MODULES)).setClient(esSetup.client());
+
+        // setup ingestion server
+        HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context, new AstyanaxMetricsWriter());
+        server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
+        httpIngestionService = new HttpIngestionService();
+        httpIngestionService.setMetricsIngestionServer(server);
+        httpIngestionService.startService(context, new AstyanaxMetricsWriter());
+
+        // setup query server
+        httpQueryService = new HttpQueryService();
+        httpQueryService.startService();
+
+        vendor = new HttpClientVendor();
+        client = vendor.getClient();
+    }
+
+
+    @AfterClass
+    public static void shutdown() {
+        Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(), "");
+        Configuration.getInstance().setProperty(CoreConfig.ENUMS_DISCOVERY_MODULES.name(), "");
+        Configuration.getInstance().setProperty(CoreConfig.EVENTS_MODULES.name(), "");
+
+        if (esSetup != null) {
+            esSetup.terminate();
+        }
+
+        if (vendor != null) {
+            vendor.shutdown();
+        }
+
+        if (httpQueryService != null) {
+            httpQueryService.stopService();
+        }
+
+        if (httpIngestionService != null) {
+            httpIngestionService.shutdownService();
+        }
+    }
+
+    public HttpResponse postAggregatedMetric(String tenantId, String payloadFilePath) throws URISyntaxException, IOException {
+        // get payload
+        StringBuilder sb = new StringBuilder();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(payloadFilePath)));
+        String curLine = reader.readLine();
+        while (curLine != null) {
+            sb = sb.append(curLine);
+            curLine = reader.readLine();
+        }
+        String json = sb.toString();
+
+        // build url to aggregated ingestion endpoint
+        URIBuilder builder = getMetricsURIBuilder()
+                .setPath(String.format("/v2.0/%s/ingest/aggregated", tenantId));
+        HttpPost post = new HttpPost(builder.build());
+        HttpEntity entity = new StringEntity(json, ContentType.APPLICATION_JSON);
+        post.setEntity(entity);
+
+        // post and return response
+        return client.execute(post);
+    }
+
+    public HttpResponse queryMetricIncludeEnum(String tenantId, String metricName) throws URISyntaxException, IOException {
+        URIBuilder query_builder = getMetricDataQueryURIBuilder()
+                .setPath(String.format("/v2.0/%s/metrics/search", tenantId));
+        query_builder.setParameter("query", metricName);
+        query_builder.setParameter("include_enum_values", "true");
+        HttpGet query_get = new HttpGet(query_builder.build());
+        return client.execute(query_get);
+    }
+
+    public HttpResponse querySingleplot(String tenantId, String metricName, long fromTime, long toTime, String points, String resolution, String select)
+            throws URISyntaxException, IOException {
+        URIBuilder query_builder = getRollupsQueryURIBuilder()
+                .setPath(String.format("/v2.0/%s/views/%s", tenantId, metricName));
+        query_builder.setParameter("from", Long.toString(fromTime));
+        query_builder.setParameter("to", Long.toString(toTime));
+
+        if (!points.isEmpty()) {
+            query_builder.setParameter("points", points);
+        }
+
+        if (!resolution.isEmpty()) {
+            query_builder.setParameter("resolution", resolution);
+        }
+
+        if (!select.isEmpty()) {
+            query_builder.setParameter("select", select);
+        }
+
+        HttpGet query_get = new HttpGet(query_builder.build());
+        return client.execute(query_get);
+    }
+
+    public HttpResponse queryMultiplot(String tenantId, long fromTime, long toTime, String points, String resolution, String select, String metricNames)
+            throws URISyntaxException, IOException {
+        URIBuilder query_builder = getRollupsQueryURIBuilder()
+                .setPath(String.format("/v2.0/%s/views", tenantId));
+        query_builder.setParameter("from", Long.toString(fromTime));
+        query_builder.setParameter("to", Long.toString(toTime));
+
+        if (!points.isEmpty()) {
+            query_builder.setParameter("points", points);
+        }
+
+        if (!resolution.isEmpty()) {
+            query_builder.setParameter("resolution", resolution);
+        }
+
+        if (!select.isEmpty()) {
+            query_builder.setParameter("select", select);
+        }
+
+        HttpPost query_post = new HttpPost(query_builder.build());
+        HttpEntity entity = new StringEntity(metricNames);
+        query_post.setEntity(entity);
+
+        return client.execute(query_post);
+    }
+
+    public URIBuilder getMetricsURIBuilder() throws URISyntaxException {
+        return new URIBuilder().setScheme("http").setHost("127.0.0.1")
+                .setPort(httpPortIngest).setPath("/v2.0/tenantId/ingest");
+    }
+
+    public URIBuilder getMetricDataQueryURIBuilder() throws URISyntaxException {
+        return new URIBuilder().setScheme("http").setHost("127.0.0.1")
+                .setPort(httpPortQuery).setPath("/v2.0/tenantId/metrics/search")
+                .setParameter("query", "call*");
+    }
+
+    public URIBuilder getRollupsQueryURIBuilder() throws URISyntaxException {
+        return new URIBuilder().setScheme("http").setHost("127.0.0.1")
+                .setPort(httpPortQuery).setPath("/v2.0/tenantId/views")
+                .setParameter("from", "100000000")
+                .setParameter("to", "200000000");
+    }
+
+}

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
@@ -55,6 +55,9 @@ public class HttpIntegrationTestBase {
     private static EventsIO eventsSearchIO;
     private static EsSetup esSetup;
 
+    public final String postAggregatedPath = "/v2.0/%s/ingest/aggregated";
+    public final String postAggregatedMultiPath = "/v2.0/%s/ingest/aggregated/multi";
+
     @BeforeClass
     public static void setUp() throws Exception{
         Configuration.getInstance().init();
@@ -123,7 +126,11 @@ public class HttpIntegrationTestBase {
         }
     }
 
-    public HttpResponse postAggregatedMetric(String tenantId, String payloadFilePath) throws URISyntaxException, IOException {
+    public HttpResponse postMetric(String tenantId, String urlPath, String payloadFilePath) throws URISyntaxException, IOException {
+        // post metric to ingestion server for a tenantId
+        // urlPath is path for url ingestion after the hostname
+        // payloadFilepath is location of the payload for the POST content entity
+
         // get payload
         StringBuilder sb = new StringBuilder();
         BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(payloadFilePath)));
@@ -136,7 +143,7 @@ public class HttpIntegrationTestBase {
 
         // build url to aggregated ingestion endpoint
         URIBuilder builder = getMetricsURIBuilder()
-                .setPath(String.format("/v2.0/%s/ingest/aggregated", tenantId));
+                .setPath(String.format(urlPath, tenantId));
         HttpPost post = new HttpPost(builder.build());
         HttpEntity entity = new StringEntity(json, ContentType.APPLICATION_JSON);
         post.setEntity(entity);

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013-2015 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.outputs.handlers;
+
+import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestBase {
+    private final long fromTime = 1389124830L;
+    private final long toTime = 1389211230L;
+
+    @Test
+    public void testMultiplotQuery() throws Exception {
+        // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
+        final String tenant_id = "333333";
+
+        // post multi metrics for ingestion and verify
+        HttpResponse response = postAggregatedMetric(tenant_id, "src/test/resources/sample_payload.json");
+        Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
+        EntityUtils.consume(response.getEntity());
+
+        // query for multiplot metric and assert results
+        HttpResponse query_response = queryMultiplot(tenant_id, fromTime, toTime, "", "FULL", "enum_values", "['3333333.G1s','3333333.G10s']");
+        Assert.assertEquals("Should get status 200 from query server for multiplot POST", 200, query_response.getStatusLine().getStatusCode());
+
+        // assert response content
+        String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
+        String expectedResponse = "{\n" +
+                "  \"metrics\": [\n" +
+                "    {\n" +
+                "      \"unit\": \"unknown\",\n" +
+                "      \"metric\": \"3333333.G1s\",\n" +
+                "      \"data\": [\n" +
+                "        {\n" +
+                "          \"timestamp\": 1389211230\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"type\": \"number\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"unit\": \"unknown\",\n" +
+                "      \"metric\": \"3333333.G10s\",\n" +
+                "      \"data\": [\n" +
+                "        {\n" +
+                "          \"timestamp\": 1389211230\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"type\": \"number\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+
+        Assert.assertEquals(expectedResponse, responseContent);
+        EntityUtils.consume(query_response.getEntity());
+    }
+
+    @Test
+    public void testMultiplotQueryWithEnum() throws Exception {
+        // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
+        final String tenant_id = "333333";
+
+        // post multi metrics for ingestion and verify
+        HttpResponse response = postAggregatedMetric(tenant_id, "src/test/resources/sample_enums_payload.json");
+        Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
+        EntityUtils.consume(response.getEntity());
+
+        // query for multiplot metric and assert results
+        HttpResponse query_response = queryMultiplot(tenant_id, fromTime, toTime, "", "FULL", "enum_values", "['enum_metric_test']");
+        Assert.assertEquals("Should get status 200 from query server for multiplot POST", 200, query_response.getStatusLine().getStatusCode());
+
+        // assert response content
+        String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
+        String expectedResponse = "{\n" +
+                "  \"metrics\": [\n" +
+                "    {\n" +
+                "      \"unit\": \"unknown\",\n" +
+                "      \"metric\": \"enum_metric_test\",\n" +
+                "      \"data\": [\n" +
+                "        {\n" +
+                "          \"timestamp\": 1389211230,\n" +
+                "          \"enum_values\": {\n" +
+                "            \"v3\": 1\n" +
+                "          }\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"type\": \"number\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+
+        Assert.assertEquals(expectedResponse, responseContent);
+        EntityUtils.consume(query_response.getEntity());
+    }
+}

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -122,7 +122,7 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
         String responseString = EntityUtils.toString(response.getEntity());
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());
         Assert.assertTrue(responseString.contains("enumValue")); //Verifying that the payload has string values and not hashcodes
-        Assert.assertTrue(responseString.contains("\"type\": \"ENUM\"")); //Verifying that the payload has an enum type
+        Assert.assertTrue(responseString.contains("\"type\": \"enum\"")); //Verifying that the payload has an enum type
     }
 
     @Test

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2013-2015 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.outputs.handlers;
+
+import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestBase {
+    private final long fromTime = 1389124830L;
+    private final long toTime = 1389211230L;
+
+    @Test
+    public void testSingleplotQuery() throws Exception {
+        // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
+        final String tenant_id = "333333";
+        final String metric_name = "3333333.G1s";
+
+        // post multi metrics for ingestion and verify
+        HttpResponse response = postAggregatedMetric(tenant_id, "src/test/resources/sample_payload.json");
+        Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
+        EntityUtils.consume(response.getEntity());
+
+        // query for multiplot metric and assert results
+        HttpResponse query_response = querySingleplot(tenant_id, metric_name, fromTime, toTime, "", "FULL", "");
+        Assert.assertEquals("Should get status 200 from query server for single view GET", 200, query_response.getStatusLine().getStatusCode());
+
+        // assert response content
+        String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
+        String expectedResponse = "{\n" +
+                "  \"unit\": \"unknown\",\n" +
+                "  \"values\": [\n" +
+                "    {\n" +
+                "      \"numPoints\": 1,\n" +
+                "      \"timestamp\": 1389211230,\n" +
+                "      \"latest\": 397\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"metadata\": {\n" +
+                "    \"limit\": null,\n" +
+                "    \"next_href\": null,\n" +
+                "    \"count\": 1,\n" +
+                "    \"marker\": null\n" +
+                "  }\n" +
+                "}";
+
+        Assert.assertEquals(expectedResponse, responseContent);
+        EntityUtils.consume(query_response.getEntity());
+    }
+
+    @Test
+    public void testSingleplotQueryWithEnum() throws Exception {
+        // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
+        final String tenant_id = "333333";
+        final String metric_name = "enum_metric_test";
+
+        // post multi metrics for ingestion and verify
+        HttpResponse response = postAggregatedMetric(tenant_id, "src/test/resources/sample_enums_payload.json");
+        Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
+        EntityUtils.consume(response.getEntity());
+
+        // query for multiplot metric and assert results
+        HttpResponse query_response = querySingleplot(tenant_id, metric_name, fromTime, toTime, "", "FULL", "");
+        Assert.assertEquals("Should get status 200 from query server for single view GET", 200, query_response.getStatusLine().getStatusCode());
+
+        // assert response content
+        String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
+        String expectedResponse = "{\n" +
+                "  \"unit\": \"unknown\",\n" +
+                "  \"values\": [\n" +
+                "    {\n" +
+                "      \"numPoints\": 1,\n" +
+                "      \"timestamp\": 1389211230,\n" +
+                "      \"enum_values\": {\n" +
+                "        \"v3\": 1\n" +
+                "      },\n" +
+                "      \"type\": \"ENUM\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"metadata\": {\n" +
+                "    \"limit\": null,\n" +
+                "    \"next_href\": null,\n" +
+                "    \"count\": 1,\n" +
+                "    \"marker\": null\n" +
+                "  }\n" +
+                "}";
+
+        Assert.assertEquals(expectedResponse, responseContent);
+        EntityUtils.consume(query_response.getEntity());
+    }
+}

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
@@ -33,7 +33,7 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
         final String metric_name = "3333333.G1s";
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postAggregatedMetric(tenant_id, "src/test/resources/sample_payload.json");
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "src/test/resources/sample_payload.json");
         Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
         EntityUtils.consume(response.getEntity());
 
@@ -71,7 +71,7 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
         final String metric_name = "enum_metric_test";
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postAggregatedMetric(tenant_id, "src/test/resources/sample_enums_payload.json");
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "src/test/resources/sample_enums_payload.json");
         Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
         EntityUtils.consume(response.getEntity());
 
@@ -90,7 +90,7 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
                 "      \"enum_values\": {\n" +
                 "        \"v3\": 1\n" +
                 "      },\n" +
-                "      \"type\": \"ENUM\"\n" +
+                "      \"type\": \"enum\"\n" +
                 "    }\n" +
                 "  ],\n" +
                 "  \"metadata\": {\n" +

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BasicRollupsOutputSerializer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BasicRollupsOutputSerializer.java
@@ -204,7 +204,7 @@ public interface BasicRollupsOutputSerializer<T> {
             @Override
             Object convertRollupToObject(Rollup rollup) throws Exception {
                 if (rollup instanceof BluefloodEnumRollup)
-                    return rollup.getRollupType().toString();
+                    return MetricData.Type.ENUM;
                 else
                     // every other type.
                     throw new Exception(String.format("Enum values supported for this type: %s", rollup.getClass().getSimpleName()));

--- a/blueflood-http/src/test/resources/sample_enums_payload.json
+++ b/blueflood-http/src/test/resources/sample_enums_payload.json
@@ -1,6 +1,6 @@
 {
     "tenantId":"333333",
-    "timestamp":1439231324000,
+    "timestamp":1389211230,
     "enums": [
         {
             "name": "enum_metric_test",


### PR DESCRIPTION
WHAT: validate single and multiplot queries for enum values, include tests for enum metrics

HOW: 
- Refactor HttpEnumIntegrationTest and move tests setup to a new HttpIntegrationTestBase class to extend from.
- Add integration tests at the http level to ingest and query for single plot and multiplot metrics which also extend from the HttpIntegrationTestBase class.