### PR TITLE
script for creating column family in db to support enum metrics

### DIFF
--- a/src/cassandra/cli/load.cdl
+++ b/src/cassandra/cli/load.cdl
@@ -1,0 +1,180 @@
+-- this cdl schema create the main tables for blueflood in cassandra using the cqlsh client
+-- usage:
+--   $ cqlsh hostname -f load.cdl -u username -p password
+-- example:
+--   $ cqlsh 127.0.0.1 -f ./blueflood/src/cassandra/cli/load.cdl
+
+CREATE KEYSPACE IF NOT EXISTS "DATA"
+    WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_locator (
+    key bigint,
+    column1 text,
+    value text,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_discovery (
+    key text,
+    column1 text,
+    value text,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_state (
+    key bigint,
+    column1 text,
+    value bigint,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_metadata (
+    key text,
+    column1 text,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_string (
+    key text,
+    column1 bigint,
+    value text,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_enum (
+    key text,
+    column1 bigint,
+    value text,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_excess_enums (
+    key text,
+    column1 bigint,
+    value bigint,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_full (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_5m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_20m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_60m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_240m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_1440m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_preaggregated_full (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_preaggregated_5m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_preaggregated_20m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_preaggregated_60m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_preaggregated_240m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_preaggregated_1440m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_histogram_5m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_histogram_20m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_histogram_60m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_histogram_240m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';
+
+CREATE TABLE IF NOT EXISTS "DATA".metrics_histogram_1440m (
+    key text,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND speculative_retry = 'NONE';

--- a/src/cassandra/cli/load.script
+++ b/src/cassandra/cli/load.script
@@ -1,15 +1,21 @@
+-- this script create the main column families for blueflood in cassandra using the deprecated cassandra-cli client
+-- usage:
+--   $ cassandra-cli -f load.script -h <cassandra_hostname> -p <cassandra_port>
+-- example:
+--   $ cassandra-cli -f ./blueflood/src/cassandra/cli/load.script -h 127.0.0.1 -p 9160
+
 CREATE KEYSPACE DATA
     WITH placement_strategy = 'org.apache.cassandra.locator.SimpleStrategy'
     AND strategy_options = {replication_factor:1};
 USE DATA;
 
-CREATE COLUMN FAMILY metrics_locator WITH column_type='Standard' AND comparator='UTF8Type' AND key_validation_class='LongType' AND default_validation_class='UTF8Type';
-CREATE COLUMN FAMILY metrics_excess_enums WITH column_type='Standard' AND comparator='LongType' AND key_validation_class='UTF8Type' AND default_validation_class='LongType';
 CREATE COLUMN FAMILY metrics_discovery WITH column_type='Standard' AND comparator='UTF8Type' AND key_validation_class='UTF8Type' AND default_validation_class='UTF8Type';
-CREATE COLUMN FAMILY metrics_state WITH column_type='Standard' AND comparator='UTF8Type' AND key_validation_class='LongType' AND default_validation_class='LongType';
-CREATE COLUMN FAMILY metrics_metadata WITH column_type='Standard' AND comparator='UTF8Type' AND key_validation_class='UTF8Type' AND default_validation_class='BytesType';
-CREATE COLUMN FAMILY metrics_string WITH column_type='Standard' AND comparator='LongType' AND key_validation_class='UTF8Type' AND default_validation_class='UTF8Type';
 CREATE COLUMN FAMILY metrics_enum WITH column_type='Standard' AND comparator='LongType' AND key_validation_class='UTF8Type' AND default_validation_class='UTF8Type';
+CREATE COLUMN FAMILY metrics_excess_enums WITH column_type='Standard' AND comparator='LongType' AND key_validation_class='UTF8Type' AND default_validation_class='LongType';
+CREATE COLUMN FAMILY metrics_locator WITH column_type='Standard' AND comparator='UTF8Type' AND key_validation_class='LongType' AND default_validation_class='UTF8Type';
+CREATE COLUMN FAMILY metrics_metadata WITH column_type='Standard' AND comparator='UTF8Type' AND key_validation_class='UTF8Type' AND default_validation_class='BytesType';
+CREATE COLUMN FAMILY metrics_state WITH column_type='Standard' AND comparator='UTF8Type' AND key_validation_class='LongType' AND default_validation_class='LongType';
+CREATE COLUMN FAMILY metrics_string WITH column_type='Standard' AND comparator='LongType' AND key_validation_class='UTF8Type' AND default_validation_class='UTF8Type';
 
 CREATE COLUMN FAMILY metrics_full WITH column_type='Standard' AND comparator='LongType' AND key_validation_class='UTF8Type' AND default_validation_class='BytesType';
 CREATE COLUMN FAMILY metrics_5m WITH column_type='Standard' AND comparator='LongType' AND key_validation_class='UTF8Type' AND default_validation_class='BytesType';


### PR DESCRIPTION
WHAT:  need to create two new tables to support enum metrics:  "metrics_enum" and "metrics_excess_enums"

HOW:  manually execute the script in this pr (01_add_enums_cf.cql) to create the tables in the respective (stage/prod) environment like so:

```
$ cqlsh 127.0.0.1 -f load.cdl

-- syntax if username/password require
$ cqlsh 127.0.0.1 -f load.cdl -u username -p password
```

Note:  see https://github.com/rackerlabs/blueflood-chef/pull/702 for the cql in blueflood-chef to use for our own environment