### PR TITLE
Default blueflood.conf and blueflood-log4j.properties files for sample run

### DIFF
--- a/demo/local/config/blueflood-log4j.properties
+++ b/demo/local/config/blueflood-log4j.properties
@@ -1,0 +1,10 @@
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %-20.20c{1}:%-3L - %m%n
+log4j.logger.httpclient.wire.header=WARN
+log4j.logger.httpclient.wire.content=WARN
+log4j.logger.org.apache.http.client.protocol=INFO
+log4j.logger.org.apache.http.wire=INFO
+log4j.logger.org.apache.http.impl=INFO
+log4j.logger.org.apache.http.headers=INFO
+log4j.rootLogger=INFO, console

--- a/demo/local/config/blueflood.conf
+++ b/demo/local/config/blueflood.conf
@@ -1,0 +1,53 @@
+CASSANDRA_HOSTS=127.0.0.1:9160
+DEFAULT_CASSANDRA_PORT=9160
+# This number is only accurate if MAX_CASSANDRA_CONNECTIONS is evenly divisible by number of hosts
+MAX_CASSANDRA_CONNECTIONS=70
+
+ROLLUP_KEYSPACE=DATA
+CLUSTER_NAME=Test Cluster
+
+INGESTION_MODULES=com.rackspacecloud.blueflood.service.HttpIngestionService
+QUERY_MODULES=com.rackspacecloud.blueflood.service.HttpQueryService
+DISCOVERY_MODULES=com.rackspacecloud.blueflood.io.ElasticIO
+
+MAX_ROLLUP_THREADS=20
+# Maximum timeout waiting on exhausted connection pools in milliseconds.
+# Maps directly to Astyanax's ConnectionPoolConfiguration.setMaxTimeoutWhenExhausted
+MAX_TIMEOUT_WHEN_EXHAUSTED=2000
+SCHEDULE_POLL_PERIOD=60000
+
+# Config refresh interval (If a new config is pushed out, we need to pick up the changes)
+# time is in milliseconds
+CONFIG_REFRESH_PERIOD=10000
+
+# this is a special string, or a comma list of integers. e.g.: "1,2,3,4"
+# valid shards are 0..127
+SHARDS=ALL
+
+# thread sleep times between shard push/pulls.
+SHARD_PUSH_PERIOD=2000
+SHARD_PULL_PERIOD=20000
+
+# blueflood uses zookeeper to acquire locks before working on shards
+ZOOKEEPER_CLUSTER=NONE
+
+# 20 min
+SHARD_LOCK_HOLD_PERIOD_MS=1200000
+# 1 min
+SHARD_LOCK_DISINTERESTED_PERIOD_MS=60000
+# 2 min
+SHARD_LOCK_SCAVENGE_INTERVAL_MS=120000
+MAX_ZK_LOCKS_TO_ACQUIRE_PER_CYCLE=1
+
+INTERNAL_API_CLUSTER=127.0.0.1:50020,127.0.0.1:50020
+
+GRAPHITE_HOST=
+  GRAPHITE_PORT=2003
+GRAPHITE_PREFIX=unconfiguredNode.metrics.
+
+INGEST_MODE=true
+ROLLUP_MODE=true
+QUERY_MODE=true
+
+# set <= 0 to not retry
+CASSANDRA_MAX_RETRIES=5


### PR DESCRIPTION
Contains necessary files to run blueflood locally at ```demo/local/config```.  Assumes the following
- Cassandra is accessible at ```127.0.0.1:9160```
- Elastic search is accessible at ```localhost:9300``` (not required to have blueflood accept requests)

Once this is accepted, I'll update the wiki with these files.