### PR TITLE
remove unneeded assert in test that breaks when run under jdk 1.8

### DIFF
--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/IMetricSerializerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/IMetricSerializerTest.java
@@ -74,8 +74,6 @@ public class IMetricSerializerTest {
         BluefloodSetRollup setDeserialized = mapper.readValue(setValue, BluefloodSetRollup.class);
         String setSerialized = mapper.writeValueAsString(setDeserialized);
 
-        //Assert.assertEquals(setValue, setSerialized);
-
         BluefloodSetRollup setReserialized = mapper.readValue(setSerialized, BluefloodSetRollup.class);
         Assert.assertEquals(setDeserialized, setReserialized);
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/IMetricSerializerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/IMetricSerializerTest.java
@@ -73,7 +73,8 @@ public class IMetricSerializerTest {
 
         BluefloodSetRollup setDeserialized = mapper.readValue(setValue, BluefloodSetRollup.class);
         String setSerialized = mapper.writeValueAsString(setDeserialized);
-        Assert.assertEquals(setValue, setSerialized);
+
+        //Assert.assertEquals(setValue, setSerialized);
 
         BluefloodSetRollup setReserialized = mapper.readValue(setSerialized, BluefloodSetRollup.class);
         Assert.assertEquals(setDeserialized, setReserialized);


### PR DESCRIPTION
JDK 1.8 hashes differently than JDK 1.7. We are doing a string compare on a JSON payload (containing hashed keys) before and after deserialization/serialization. This is unneeded Assert -- we are not testing any of our code, since we are just calling methods on Jackson's ObjectMapper.

I propose we remove this Assert since it's breaking with JDK 1.8