### PR TITLE
fix condition for writing enum values to elasticsearch enums index

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/EnumValidator.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/EnumValidator.java
@@ -96,9 +96,8 @@ public class EnumValidator implements Runnable {
             if (currentEnumValues != null) Collections.sort(currentEnumValues);
             if (elasticsearchEnumValues != null) Collections.sort(elasticsearchEnumValues);
 
-            // compare two list of enum values
-            if (((currentEnumValues != null) && (!currentEnumValues.equals(elasticsearchEnumValues))) ||
-                    ((currentEnumValues == null) && (elasticsearchEnumValues != null) && (elasticsearchEnumValues.size() > 0)))
+            // compare two list of enum values and right if CF has enum values for the metric and it doesn't equal to the values in elasticsearch
+            if ((currentEnumValues != null) && (currentEnumValues.size() > 0) && (!currentEnumValues.equals(elasticsearchEnumValues)))
             {
                 // if not equal, create or update enums index in elastic search
                 BluefloodEnumRollup rollupWithEnumValues = createRollupWithEnumValues(currentEnumValues);


### PR DESCRIPTION
WHAT:  fix bug with EnumValidator attempting to write to elasticsearch with non-enum metrics if ElasticSearch cluster is down/unreachable.

WHY:  the result from cassandra retrieving enum values return in a non-null object with size 0, and current code only tested for NULL result.

HOW:  modify the condition to check for both non-null and size > 0 for enum values query of a metric from cassandra, if neither is true then it's a no-op for write to ElasticSearch.