### PR TITLE
fix tests with metrics_mapping.json

### DIFF
--- a/blueflood-elasticsearch/src/main/resources/metrics_mapping.json
+++ b/blueflood-elasticsearch/src/main/resources/metrics_mapping.json
@@ -13,8 +13,9 @@
                 "index": "not_analyzed"
             },
             "metric_name": {
-                "type": "string",
-                "index": "not_analyzed"
+                "index_analyzer": "prefix-test-analyzer",
+                "search_analyzer": "keyword",
+                "type": "string"
             }
         }
     }

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticIOTest.java
@@ -104,7 +104,7 @@ public class ElasticIOTest {
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping_v1.json")));
+                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
         elasticIO = new ElasticIO(esSetup.client());
 
         elasticIO.insertDiscovery(createTestMetrics(TENANT_A));
@@ -277,7 +277,8 @@ public class ElasticIOTest {
         Assert.assertEquals(results.get(0).getMetricName(), testLocator.getMetricName());
         // Actually create the new index
         esSetup.execute(EsSetup.createIndex(ES_DUP)
-                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping_v1.json")));
+                .withSettings(EsSetup.fromClassPath("index_settings.json"))
+                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
         // Insert metric into the new index
         elasticIO.setINDEX_NAME_WRITE(ES_DUP);
         ArrayList metricList = new ArrayList();

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -68,7 +68,7 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping_v1.json")));
+                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
         elasticIO = new ElasticIO(esSetup.client());
     }
 


### PR DESCRIPTION
WHAT:  fix failing tests from master changes of metrics_mapping.json (removal of metrics_mapping_v1.json).

HOW:  modify tests to use metris_mapping.json and change json content to use latest mappings on the elasticsearch search nodes (with analyzer and tokenizer).

NOTE: the failing tests are from *other* tests looking for metrics_mapping.json that was removed in master.  but since I renamed metrics_mapping_v1.json back to metrics_mapping.json, I don't have to modify those broken tests and just have to fix any tests still referencing metrics_mapping_v1.json.
