### PR TITLE
Make the enums rollup integration test more realistic.

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxReaderIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/AstyanaxReaderIntegrationTest.java
@@ -301,7 +301,7 @@ public class AstyanaxReaderIntegrationTest extends IntegrationTestBase {
     private void verifyPointsData(Map<Long, Points.Point<BluefloodEnumRollup>> actualData) {
         for (Long timestamp : actualData.keySet()) {
             BluefloodEnumRollup er = actualData.get(timestamp).getData();
-            Assert.assertEquals(2, er.getStringEnumValuesWithCounts().size());
+            Assert.assertEquals(1, er.getStringEnumValuesWithCounts().size());
             verifyRollupValues(er);
         }
     }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
@@ -157,7 +157,7 @@ public class IntegrationTestBase {
 
     protected PreaggregatedMetric getEnumMetric(String name, String tenantid, long timestamp) {
         final Locator locator = Locator.createLocatorFromPathComponents(tenantid, name);
-        BluefloodEnumRollup rollup = new BluefloodEnumRollup().withEnumValue(pickAnEnumValue()).withEnumValue(pickAnEnumValue(),1L);
+        BluefloodEnumRollup rollup = new BluefloodEnumRollup().withEnumValue("enumValue"+pickAnEnumValue());
         return new PreaggregatedMetric(timestamp, locator, new TimeValue(1, TimeUnit.DAYS), rollup);
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
@@ -86,7 +86,7 @@ public class IntegrationTestBase {
     private static final char[] STRING_SEEDS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_".toCharArray();
     private static final Random rand = new Random(System.currentTimeMillis());
     protected static final ConcurrentHashMap<Locator, String> locatorToUnitMap = new ConcurrentHashMap<Locator, String>();
-    private static final List<String> enumValueList = new ArrayList<String>() {{ add("A");  add("B");  add("C"); add("D"); add("E"); }};
+    private static final List<String> enumValueList = Arrays.asList("A", "B", "C", "D", "E");
 
     protected final void assertNumberOfRows(String cf, int rows) throws Exception {
         new AstyanaxTester().assertNumberOfRows(cf, rows);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
@@ -86,6 +86,7 @@ public class IntegrationTestBase {
     private static final char[] STRING_SEEDS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_".toCharArray();
     private static final Random rand = new Random(System.currentTimeMillis());
     protected static final ConcurrentHashMap<Locator, String> locatorToUnitMap = new ConcurrentHashMap<Locator, String>();
+    private static final List<String> enumValueList = new ArrayList<String>() {{ add("A");  add("B");  add("C"); add("D"); add("E"); }};
 
     protected final void assertNumberOfRows(String cf, int rows) throws Exception {
         new AstyanaxTester().assertNumberOfRows(cf, rows);
@@ -156,7 +157,7 @@ public class IntegrationTestBase {
 
     protected PreaggregatedMetric getEnumMetric(String name, String tenantid, long timestamp) {
         final Locator locator = Locator.createLocatorFromPathComponents(tenantid, name);
-        BluefloodEnumRollup rollup = new BluefloodEnumRollup().withEnumValue("enumValue"+randString(5),1L).withEnumValue("enumValue"+randString(5),1L);
+        BluefloodEnumRollup rollup = new BluefloodEnumRollup().withEnumValue(pickAnEnumValue()).withEnumValue(pickAnEnumValue(),1L);
         return new PreaggregatedMetric(timestamp, locator, new TimeValue(1, TimeUnit.DAYS), rollup);
     }
 
@@ -201,6 +202,11 @@ public class IntegrationTestBase {
 
     protected static <T> Metric makeMetric(final Locator locator, long timestamp, T value) {
         return new Metric(locator, value, timestamp, new TimeValue(1, TimeUnit.DAYS), "unknown");
+    }
+
+    protected String pickAnEnumValue() {
+        int index = rand.nextInt(enumValueList.size() - 1);
+        return enumValueList.get(index);
     }
 
     private enum UNIT_ENUM {


### PR DESCRIPTION
*What:*
Added a fix for the enums test so that only one of 5 values will be picked for an enum value instead of a new one every single time

*Why:*
Previously, the test was picking a new enum value every single time for each of it's posts. It causes the enum value list to have 1400 unique values (which is not representative of a real enum) causing the enums rollup to go on for a long time. 

*How:*
Create a static list of enum values. ```pickAnEnumValue``` will pick one of the 5 values in that list. 