### PR TITLE
Fixing a bug with the collectionTime of the enum payload

### DIFF
--- a/contrib/grinder/scripts/ingestenum.py
+++ b/contrib/grinder/scripts/ingestenum.py
@@ -58,7 +58,7 @@ class EnumIngestThread(AbstractThread):
 
   def generate_enum_metric(self, time, tenant_id, metric_id):
     return {'tenantId': str(tenant_id),
-            'timestamp': int(round(time * 1000)),
+            'timestamp': time,
             'enums': [{'name': 'enum_grinder_'+str(metric_id), 'value': 'e_g_'+str(metric_id)}]
             }
 

--- a/contrib/grinder/scripts/tests.py
+++ b/contrib/grinder/scripts/tests.py
@@ -276,11 +276,11 @@ class BluefloodTests(unittest.TestCase):
   def test_generate_enum_payload(self):
     self.tm.create_all_metrics(1)
     thread = ingestenum.EnumIngestThread(0)
-    payload = json.loads(thread.generate_payload(0, [[2, 1], [2, 2]]))
-    valid_payload = [{u'timestamp': 0,
+    payload = json.loads(thread.generate_payload(1, [[2, 1], [2, 2]]))
+    valid_payload = [{u'timestamp': 1,
                       u'tenantId': u'2',
                       u'enums': [{u'value': u'e_g_1', u'name': u'enum_grinder_1'}]},
-                     {u'timestamp': 0,
+                     {u'timestamp': 1,
                       u'tenantId': u'2',
                       u'enums': [{u'value': u'e_g_2', u'name': u'enum_grinder_2'}]}
                     ]
@@ -351,7 +351,7 @@ class BluefloodTests(unittest.TestCase):
       thread.slice = [[[2, 0], [2, 1]]]
       thread.position = 0
       thread.finish_time = 10000
-      valid_payload = [{'tenantId': '2', 'timestamp': 1000000, 'enums': [{'value': 'e_g_0', 'name': 'enum_grinder_0'}]}, {'tenantId': '2', 'timestamp': 1000000, 'enums': [{'value': 'e_g_1', 'name': 'enum_grinder_1'}]}]
+      valid_payload = [{'tenantId': '2', 'timestamp': 1000, 'enums': [{'value': 'e_g_0', 'name': 'enum_grinder_0'}]}, {'tenantId': '2', 'timestamp': 1000, 'enums': [{'value': 'e_g_1', 'name': 'enum_grinder_1'}]}]
 
       url, payload = thread.make_request(pp)
       #confirm request generates proper URL and payload


### PR DESCRIPTION
*What:*
It's not required to multiply the collectionTime with 1000, because it's already converted into milliseconds before passing it onto the individual threads. Corrected tests to reflect this bug. 
