### PR TITLE
Spinning up Enum validator threads only for Enum metrics

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -707,4 +707,17 @@ public class AstyanaxReader extends AstyanaxIO {
         }
         return map;
     }
+
+    public Set<Locator> getEnumLocatorsFromLocatorSet(Set<Locator> locators) throws Exception{
+        HashSet<Locator> locatorHashSet = new HashSet<Locator>();
+
+        for (Locator loc : locators) {
+            RollupType rollupType = RollupType.fromString(metaCache.get(loc, rollupTypeCacheKey));
+            if (rollupType == RollupType.ENUM) {
+                locatorHashSet.add(loc);
+            }
+        }
+
+        return locatorHashSet;
+    }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -99,8 +99,11 @@ class LocatorFetchRunnable implements Runnable {
         // if gran 5 minutes rollup, start a thread with EnumValidator runnable to validate enum values for this set of locators
         if (gran.equals(Granularity.MIN_5)) {
             try {
-                log.debug(String.format("Starting an EnumValidator thread at granularity %s for locators: %s", gran, Arrays.toString(locators.toArray())));
-                enumValidatorExecutor.execute(new EnumValidator(locators));
+                Set<Locator> enumLocators = AstyanaxReader.getInstance().getEnumLocatorsFromLocatorSet(locators);
+                if (enumLocators.size() > 0) {
+                    log.debug(String.format("Starting an EnumValidator thread at granularity %s for locators: %s", gran, Arrays.toString(enumLocators.toArray())));
+                    enumValidatorExecutor.execute(new EnumValidator(enumLocators));
+                }
             } catch (Exception e) {
                 log.error(String.format("Exception in EnumValidator for locators %s: %s", Arrays.toString(locators.toArray()), e.getMessage()), e);
             }


### PR DESCRIPTION
*What*:
The enum validation code is performed only for enum metrics and not for all others. 

*Why*:
After deploying enums-feature to staging, we found that the heap consumption of rollups is through the roof, as is the rollup wait time. We discovered that a new runnable is created for every metric, which may be the cause of it. 
 
*How*:
We check metadata cache to see if the metric that is being rolled up has the rollupType Enum. Only then we create an EnumValidator runnable and go through the whole process of getting enum values from ElasticSearch. 