### PR TITLE
WIP: Instrumenting enum rollups

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -708,7 +708,7 @@ public class AstyanaxReader extends AstyanaxIO {
         return map;
     }
 
-    public Set<Locator> getEnumLocatorsFromLocatorSet(Set<Locator> locators) throws Exception{
+    public HashSet<Locator> getEnumLocatorsFromLocatorSet(Set<Locator> locators) throws Exception{
         HashSet<Locator> locatorHashSet = new HashSet<Locator>();
 
         for (Locator loc : locators) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupReadContext.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupReadContext.java
@@ -17,6 +17,7 @@
 package com.rackspacecloud.blueflood.service;
 
 import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.netflix.astyanax.model.ColumnFamily;
 import com.rackspacecloud.blueflood.types.Locator;
@@ -36,7 +37,8 @@ public class SingleRollupReadContext {
     private final Range range;
     private static final Timer executeTimer = Metrics.timer(RollupService.class, "Rollup Execution Timer");
     private static final Histogram waitHist = Metrics.histogram(RollupService.class, "Rollup Wait Histogram");
-    
+    private static final Meter enumMetricsMeter = Metrics.meter(RollupService.class, "Enum Metrics Rollup Meter");
+
     // documenting that this represents the DESTINATION granularity, not the SOURCE granularity.
     private final Granularity rollupGranularity;
 
@@ -53,6 +55,8 @@ public class SingleRollupReadContext {
     Histogram getWaitHist() {
         return waitHist;
     }
+
+    Meter getEnumMetricsMeter() { return enumMetricsMeter; }
 
     Granularity getRollupGranularity() {
         return this.rollupGranularity;


### PR DESCRIPTION
*What:*
Adding a meter to mark the number of enum rollups being scheduled per minute

*How:*
We already know which locators from a given batch of to-be-rolled-up locators are enums, because we only validate Enums. Utilizing that hashset of enum locators to determine how many locators in the current to-be-rolled batch are enums by incrementing a meter. I used SingleRollupReadContext because it is already being used to track the ```*.iad.blueflood.*.com.rackspacecloud.blueflood.service.RollupService.Rollup-Execution-Timer.count``` (Rollups_per_minute count in the Grafana dashboard)

TODO:
Moar testing!