### PR TITLE
Fix metadata cache bottleneck

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/RollupRunnableIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/RollupRunnableIntegrationTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class RollupRunnableIntegrationTest extends IntegrationTestBase {
@@ -128,7 +129,7 @@ public class RollupRunnableIntegrationTest extends IntegrationTestBase {
         RollupExecutionContext rec = new RollupExecutionContext(Thread.currentThread());
         SingleRollupReadContext rc = new SingleRollupReadContext(normalLocator, range, Granularity.MIN_5);
         RollupBatchWriter batchWriter = new RollupBatchWriter(new ThreadPoolBuilder().build(), rec);
-        RollupRunnable rr = new RollupRunnable(rec, rc, batchWriter);
+        RollupRunnable rr = new RollupRunnable(rec, rc, batchWriter, null);
         rr.run();
 
         while (!rec.doneReading() && !rec.doneWriting()) {
@@ -187,7 +188,13 @@ public class RollupRunnableIntegrationTest extends IntegrationTestBase {
         RollupExecutionContext rec = new RollupExecutionContext(Thread.currentThread());
         SingleRollupReadContext rc = new SingleRollupReadContext(locator, range, Granularity.MIN_5);
         RollupBatchWriter batchWriter = new RollupBatchWriter(new ThreadPoolBuilder().build(), rec);
-        RollupRunnable rr = new RollupRunnable(rec, rc, batchWriter);
+        ThreadPoolExecutor enumValidatorExec = new ThreadPoolBuilder()
+                .withName("Validating Enum Metrics")
+                .withCorePoolSize(10)
+                .withMaxPoolSize(10)
+                .withUnboundedQueue()
+                .build();
+        RollupRunnable rr = new RollupRunnable(rec, rc, batchWriter, enumValidatorExec);
         rr.run();
         
         // assert something in 5m for this locator.

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/RollupRunnableIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/RollupRunnableIntegrationTest.java
@@ -151,32 +151,32 @@ public class RollupRunnableIntegrationTest extends IntegrationTestBase {
     }
     
     @Test
-    public void testCounterRollup() throws Exception {
+    public void testCounterRollup() throws IOException {
         testRolledupMetric(counterLocator, BluefloodCounterRollup.class, BluefloodCounterRollup.class);
     }
     
     @Test
-    public void testGaugeRollup() throws Exception {
+    public void testGaugeRollup() throws IOException {
         testRolledupMetric(gaugeLocator, BluefloodGaugeRollup.class, BluefloodGaugeRollup.class);
     }
     
     @Test
-    public void testTimerRollup() throws Exception {
+    public void testTimerRollup() throws IOException {
         testRolledupMetric(timerLocator, BluefloodTimerRollup.class, BluefloodTimerRollup.class);
     }
     
     @Test
-    public void testSetRollup() throws Exception {
+    public void testSetRollup() throws IOException {
         testRolledupMetric(setLocator, BluefloodSetRollup.class, BluefloodSetRollup.class);
     }
 
     @Test
-    public void testEnumRollup() throws Exception {
+    public void testEnumRollup() throws IOException {
         testRolledupMetric(enumLocator, BluefloodEnumRollup.class, BluefloodEnumRollup.class);
-        testEnumValidatorRunsFor5M(enumLocator,BluefloodEnumRollup.class);
+        testEnumValidatorRunsFor5M(enumLocator, BluefloodEnumRollup.class);
     }
     
-    private void testRolledupMetric(Locator locator, Class fullResClass, Class rollupClass) throws Exception {
+    private void testRolledupMetric(Locator locator, Class fullResClass, Class rollupClass) throws IOException {
         // full res has 5 samples.
         Assert.assertEquals(5, reader.getDataToRoll(fullResClass,
                                                     locator,

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/RollupRunnableIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/RollupRunnableIntegrationTest.java
@@ -173,7 +173,6 @@ public class RollupRunnableIntegrationTest extends IntegrationTestBase {
     @Test
     public void testEnumRollup() throws IOException {
         testRolledupMetric(enumLocator, BluefloodEnumRollup.class, BluefloodEnumRollup.class);
-        testEnumValidatorRunsFor5M(enumLocator, BluefloodEnumRollup.class);
     }
     
     private void testRolledupMetric(Locator locator, Class fullResClass, Class rollupClass) throws IOException {
@@ -197,7 +196,7 @@ public class RollupRunnableIntegrationTest extends IntegrationTestBase {
         rr.run();
 
         if (rollupClass == BluefloodEnumRollup.class) {
-            verify(enumValidatorExec, never()).execute(any(EnumValidator.class));
+            verify(enumValidatorExec, times(1)).execute(any(EnumValidator.class));
         }
 
         // assert something in 5m for this locator.
@@ -213,18 +212,5 @@ public class RollupRunnableIntegrationTest extends IntegrationTestBase {
                                                     locator,
                                                     range,
                                                     CassandraModel.CF_METRICS_PREAGGREGATED_5M).getPoints().size());
-    }
-
-    private void testEnumValidatorRunsFor5M (Locator locator, Class rollupClass) {
-        RollupExecutionContext rec = new RollupExecutionContext(Thread.currentThread());
-        SingleRollupReadContext rc = new SingleRollupReadContext(locator, range, Granularity.MIN_20);
-        RollupBatchWriter batchWriter = new RollupBatchWriter(new ThreadPoolBuilder().build(), rec);
-        ThreadPoolExecutor enumValidatorExec = mock(ThreadPoolExecutor.class);
-        RollupRunnable rr = new RollupRunnable(rec, rc, batchWriter, enumValidatorExec);
-        rr.run();
-
-        if (rollupClass == BluefloodEnumRollup.class) {
-            verify(enumValidatorExec, times(1)).execute(any(EnumValidator.class));
-        }
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -707,17 +707,4 @@ public class AstyanaxReader extends AstyanaxIO {
         }
         return map;
     }
-
-    public HashSet<Locator> getEnumLocatorsFromLocatorSet(Set<Locator> locators) throws Exception{
-        HashSet<Locator> locatorHashSet = new HashSet<Locator>();
-
-        for (Locator loc : locators) {
-            RollupType rollupType = RollupType.fromString(metaCache.get(loc, rollupTypeCacheKey));
-            if (rollupType == RollupType.ENUM) {
-                locatorHashSet.add(loc);
-            }
-        }
-
-        return locatorHashSet;
-    }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxReader.java
@@ -708,7 +708,7 @@ public class AstyanaxReader extends AstyanaxIO {
         return map;
     }
 
-    public Set<Locator> getEnumLocatorsFromLocatorSet(Set<Locator> locators) throws Exception{
+    public HashSet<Locator> getEnumLocatorsFromLocatorSet(Set<Locator> locators) throws Exception{
         HashSet<Locator> locatorHashSet = new HashSet<Locator>();
 
         for (Locator loc : locators) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/HistogramRollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/HistogramRollupRunnable.java
@@ -36,7 +36,7 @@ public class HistogramRollupRunnable extends RollupRunnable {
     public HistogramRollupRunnable(RollupExecutionContext executionContext,
                                    SingleRollupReadContext singleRollupReadContext,
                                    RollupBatchWriter rollupBatchWriter) {
-        super(executionContext, singleRollupReadContext, rollupBatchWriter);
+        super(executionContext, singleRollupReadContext, rollupBatchWriter, null);
     }
 
     public void run() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -97,6 +97,7 @@ class LocatorFetchRunnable implements Runnable {
             log.error("Failed reading locators for slot: " + parentSlot, e);
         }
 
+        /*
         try {
             enumLocators = AstyanaxReader.getInstance().getEnumLocatorsFromLocatorSet(locators);
         } catch (Exception e) {
@@ -114,6 +115,7 @@ class LocatorFetchRunnable implements Runnable {
                 log.error(String.format("Exception in EnumValidator for locators %s: %s", Arrays.toString(locators.toArray()), e.getMessage()), e);
             }
         }
+        */
 
         for (Locator locator : locators) {
             if (log.isTraceEnabled())
@@ -124,7 +126,7 @@ class LocatorFetchRunnable implements Runnable {
                 rollupReadExecutor.execute(new RollupRunnable(executionContext, singleRollupReadContext, rollupBatchWriter));
                 rollCount += 1;
 
-                if(enumLocators.contains(locator)) {
+                if(enumLocators != null && enumLocators.contains(locator)) {
                     singleRollupReadContext.getEnumMetricsMeter().mark();
                 }
             } catch (Throwable any) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -47,8 +47,6 @@ class LocatorFetchRunnable implements Runnable {
     private final ScheduleContext scheduleCtx;
     private final long serverTime;
     private static final Timer rollupLocatorExecuteTimer = Metrics.timer(RollupService.class, "Locate and Schedule Rollups for Slot");
-    private static final Timer enumMetaTypeGetTimer = Metrics.timer(RollupService.class, "Enum Get RollupType Metacache");
-    private static final Timer enumValidatorTimer = Metrics.timer(RollupService.class, "Enum validation scheduling");
 
     private static final boolean enableHistograms = Configuration.getInstance().
             getBooleanProperty(CoreConfig.ENABLE_HISTOGRAMS);
@@ -90,7 +88,6 @@ class LocatorFetchRunnable implements Runnable {
         final RollupExecutionContext executionContext = new RollupExecutionContext(Thread.currentThread());
         final RollupBatchWriter rollupBatchWriter = new RollupBatchWriter(rollupWriteExecutor, executionContext);
         Set<Locator> locators = new HashSet<Locator>();
-        HashSet<Locator> enumLocators = null ;
 
         try {
             // get a list of all locators to rollup for a shard

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -104,9 +104,11 @@ public class RollupRunnable implements Runnable {
                     rollupLocator, MetricMetadata.ROLLUP_TYPE.name().toLowerCase()));
             Class<? extends Rollup> rollupClass = RollupType.classOf(rollupType, srcGran.coarser());
             ColumnFamily<Locator, Long> srcCF = CassandraModel.getColumnFamily(rollupClass, srcGran);
-            ColumnFamily<Locator, Long> dstCF = CassandraModel.getColumnFamily(rollupClass, srcGran.coarser());
+            Granularity dstGran = srcGran.coarser();
+            ColumnFamily<Locator, Long> dstCF = CassandraModel.getColumnFamily(rollupClass, dstGran);
 
-            if (rollupType == RollupType.ENUM && srcGran.equals(Granularity.MIN_5)) {
+            //Run the validation for enums every 5 minutes, when data is being rolledup from full to 5m
+            if (rollupType == RollupType.ENUM && dstGran.equals(Granularity.MIN_5)) {
                 singleRollupReadContext.getEnumMetricsMeter().mark();
                 enumValidatorExecutor.execute(new EnumValidator(Sets.newHashSet(rollupLocator)));
             }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupReadContext.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupReadContext.java
@@ -17,6 +17,7 @@
 package com.rackspacecloud.blueflood.service;
 
 import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.netflix.astyanax.model.ColumnFamily;
 import com.rackspacecloud.blueflood.types.Locator;
@@ -36,7 +37,8 @@ public class SingleRollupReadContext {
     private final Range range;
     private static final Timer executeTimer = Metrics.timer(RollupService.class, "Rollup Execution Timer");
     private static final Histogram waitHist = Metrics.histogram(RollupService.class, "Rollup Wait Histogram");
-    
+    private static final Meter enumMetricsMeter = Metrics.meter(RollupService.class, "Enum Metrics Rollup Meter");
+
     // documenting that this represents the DESTINATION granularity, not the SOURCE granularity.
     private final Granularity rollupGranularity;
 
@@ -53,6 +55,8 @@ public class SingleRollupReadContext {
     Histogram getWaitHist() {
         return waitHist;
     }
+
+    Meter getEnumMetricsMeter() { return enumMetricsMeter; }
 
     Granularity getRollupGranularity() {
         return this.rollupGranularity;


### PR DESCRIPTION
*What*:
Moving enums validation logic from LocatorFetchRunnable to RollupRunnable 

*Why*:
After deploying the change eac288add478dc2ae03430db2befd325d8169005 in the enums-feature branch we discovered that the time required for LocatorFetchRunnable to finish had increased from 200k miliseconds to 1.3 million miliseconds and the rollup throughput was poor as a result. 
Turns out, since we were narrowing down the locators to be validated using the Metadata cache. We were querying the metadata cache for rollup type of all locators to be rolled up causing the cache to thrash and retrieve data from Cassandra. 

*How*:
The fix in this PR puts the logic of enumvalidation in RollupRunnable because the metadata about rollup types is already retrieved and an extra operation to do the same is not required. 





