### PR TITLE
Introduced a config value to enable/disable EnumValidation

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -153,6 +153,7 @@ public enum CoreConfig implements ConfigDefaults {
     DELAYED_METRICS_MILLIS("300000"),
     ENUM_VALIDATOR_THREADS("20"),
     ENUM_UNIQUE_VALUES_THRESHOLD("100"),
+    ENUM_VALIDATOR_ENABLED("true"),
     EXCESS_ENUM_READER_SLEEP("600000");
 
     static {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -107,10 +107,12 @@ public class RollupRunnable implements Runnable {
             Granularity dstGran = srcGran.coarser();
             ColumnFamily<Locator, Long> dstCF = CassandraModel.getColumnFamily(rollupClass, dstGran);
 
-            //Run the validation for enums every 5 minutes, when data is being rolledup from full to 5m
-            if (rollupType == RollupType.ENUM && dstGran.equals(Granularity.MIN_5)) {
+            if (rollupType == RollupType.ENUM) {
                 singleRollupReadContext.getEnumMetricsMeter().mark();
-                enumValidatorExecutor.execute(new EnumValidator(Sets.newHashSet(rollupLocator)));
+                //Run the validation for enums every 5 minutes, when data is being rolled up from full to 5m
+                if (dstGran.equals(Granularity.MIN_5) && Configuration.getInstance().getBooleanProperty(CoreConfig.ENUM_VALIDATOR_ENABLED) == true) {
+                    enumValidatorExecutor.execute(new EnumValidator(Sets.newHashSet(rollupLocator)));
+                }
             }
 
             try {


### PR DESCRIPTION
*What:*
* Introduced a config value to enable/disable EnumValidation
* Fixed a bug where the enum rollups meter was counting only the locators getting validated, We need for it to track all enum locators getting rolled up.