### PR TITLE
Adding meters for enums per granularity

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -108,7 +108,7 @@ public class RollupRunnable implements Runnable {
             ColumnFamily<Locator, Long> dstCF = CassandraModel.getColumnFamily(rollupClass, dstGran);
 
             if (rollupType == RollupType.ENUM) {
-                singleRollupReadContext.getEnumMetricsMeter().mark();
+                singleRollupReadContext.getEnumMetricsMeterForGranularity(dstGran).mark();
                 //Run the validation for enums every 5 minutes, when data is being rolled up from full to 5m
                 if (dstGran.equals(Granularity.MIN_5) && Configuration.getInstance().getBooleanProperty(CoreConfig.ENUM_VALIDATOR_ENABLED) == true) {
                     enumValidatorExecutor.execute(new EnumValidator(Sets.newHashSet(rollupLocator)));

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupReadContext.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupReadContext.java
@@ -27,6 +27,7 @@ import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Range;
 
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -37,7 +38,12 @@ public class SingleRollupReadContext {
     private final Range range;
     private static final Timer executeTimer = Metrics.timer(RollupService.class, "Rollup Execution Timer");
     private static final Histogram waitHist = Metrics.histogram(RollupService.class, "Rollup Wait Histogram");
-    private static final Meter enumMetricsMeter = Metrics.meter(RollupService.class, "Enum Metrics Rollup Meter");
+    private static HashMap<Granularity, Meter> granToEnumMeters = new HashMap<Granularity, Meter>();
+    static {
+        for (Granularity rollupGranularity : Granularity.rollupGranularities()) {
+            granToEnumMeters.put(rollupGranularity, Metrics.meter(RollupService.class, String.format("%s Enum Metrics Rolled up", rollupGranularity.shortName())));
+        }
+    }
 
     // documenting that this represents the DESTINATION granularity, not the SOURCE granularity.
     private final Granularity rollupGranularity;
@@ -56,7 +62,7 @@ public class SingleRollupReadContext {
         return waitHist;
     }
 
-    Meter getEnumMetricsMeter() { return enumMetricsMeter; }
+    Meter getEnumMetricsMeterForGranularity(Granularity g) { return granToEnumMeters.get(g); }
 
     Granularity getRollupGranularity() {
         return this.rollupGranularity;


### PR DESCRIPTION
*What:*
Changed rollup meter of enums to be per destination granularity to provide better insight into enum locators getting rolled up at each granularity. 