### PR TITLE
Modify blueflood Tracker to get tenantId via URI

### DIFF
--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
@@ -1,9 +1,13 @@
 package com.rackspacecloud.blueflood.tracker;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
 import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class TrackerTest {
     Tracker tracker;
@@ -20,9 +24,9 @@ public class TrackerTest {
         tracker.addTenant(testTenant1);
 
         Set tenants = tracker.getTenants();
-        Assert.assertTrue("tenant " + testTenant1 + " not added", tracker.isTracking(testTenant1));
-        Assert.assertTrue("tenants.size not 1", tenants.size() == 1);
-        Assert.assertTrue("tenants does not contain " + testTenant1, tenants.contains(testTenant1));
+        assertTrue( "tenant " + testTenant1 + " not added", tracker.isTracking( testTenant1 ) );
+        assertTrue( "tenants.size not 1", tenants.size() == 1 );
+        assertTrue( "tenants does not contain " + testTenant1, tenants.contains( testTenant1 ) );
     }
 
     @Test
@@ -31,35 +35,59 @@ public class TrackerTest {
         tracker.addTenant(testTenant1);
 
         Set tenants = tracker.getTenants();
-        Assert.assertTrue("tenant " + testTenant1 + " not added", tracker.isTracking(testTenant1));
-        Assert.assertTrue("tenants.size not 1", tenants.size() == 1);
+        assertTrue( "tenant " + testTenant1 + " not added", tracker.isTracking( testTenant1 ) );
+        assertTrue( "tenants.size not 1", tenants.size() == 1 );
     }
 
     @Test
     public void testRemoveTenant() {
         tracker.addTenant(testTenant1);
-        Assert.assertTrue("tenant " + testTenant1 + " not added", tracker.isTracking(testTenant1));
+        assertTrue( "tenant " + testTenant1 + " not added", tracker.isTracking( testTenant1 ) );
 
         tracker.removeTenant(testTenant1);
 
         Set tenants = tracker.getTenants();
-        Assert.assertFalse("tenant " + testTenant1 + " not removed", tracker.isTracking(testTenant1));
-        Assert.assertEquals("tenants.size not 0", tenants.size(), 0);
-        Assert.assertFalse("tenants contains " + testTenant1, tenants.contains(testTenant1));
+        assertFalse( "tenant " + testTenant1 + " not removed", tracker.isTracking( testTenant1 ) );
+        assertEquals( "tenants.size not 0", tenants.size(), 0 );
+        assertFalse( "tenants contains " + testTenant1, tenants.contains( testTenant1 ) );
     }
 
     @Test
     public void testRemoveAllTenant() {
         tracker.addTenant(testTenant1);
         tracker.addTenant(testTenant2);
-        Assert.assertTrue("tenant " + testTenant1 + " not added", tracker.isTracking(testTenant1));
-        Assert.assertTrue("tenant " + testTenant2 + " not added", tracker.isTracking(testTenant2));
+        assertTrue( "tenant " + testTenant1 + " not added", tracker.isTracking( testTenant1 ) );
+        assertTrue( "tenant " + testTenant2 + " not added", tracker.isTracking( testTenant2 ) );
 
         tracker.removeAllTenants();
-        Assert.assertFalse("tenant " + testTenant1 + " not removed", tracker.isTracking(testTenant1));
-        Assert.assertFalse("tenant " + testTenant2 + " not removed", tracker.isTracking(testTenant2));
+        assertFalse( "tenant " + testTenant1 + " not removed", tracker.isTracking( testTenant1 ) );
+        assertFalse( "tenant " + testTenant2 + " not removed", tracker.isTracking( testTenant2 ) );
 
         Set tenants = tracker.getTenants();
-        Assert.assertEquals("tenants.size not 0", tenants.size(), 0);
+        assertEquals( "tenants.size not 0", tenants.size(), 0 );
+    }
+
+    @Test
+    public void testFindTidFound() {
+
+        assertEquals( Tracker.findTid( "/v2.0/6000/views" ), "6000" );
+    }
+
+    @Test
+         public void testTrackTenantNoVersion() {
+
+        assertEquals( Tracker.findTid( "/6000/views" ), null );
+    }
+
+    @Test
+    public void testTrackTenantBadVersion() {
+
+        assertEquals( Tracker.findTid( "blah/6000/views" ), null );
+    }
+
+    @Test
+    public void testTrackTenantTrailingSlash() {
+
+        assertEquals( Tracker.findTid( "/v2.0/6000/views/" ), "6000" );
     }
 }


### PR DESCRIPTION
For the Tracker, pull tenant id from UIR rather than a HTTP header.
