### PR TITLE
George/fix mplot queries

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -157,6 +157,7 @@ class LocatorFetchRunnable implements Runnable {
 
         if (executionContext.wasSuccessful()) {
             this.scheduleCtx.clearFromRunning(parentSlotKey);
+            log.info("Successful completion of rollups for (gran,slot,shard) {} in {}", new Object[] {parentSlotKey, System.currentTimeMillis() - waitStart});
         } else {
             log.error("Performing BasicRollups for {} failed", parentSlotKey);
             this.scheduleCtx.pushBackToScheduled(parentSlotKey, false);

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -51,7 +51,7 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
                 "        {\n" +
                 "          \"numPoints\": 1,\n" +
                 "          \"timestamp\": 1382400000,\n" +
-                "          \"average\": 397\n" +
+                "          \"latest\": 397\n" +
                 "        }\n" +
                 "      ],\n" +
                 "      \"type\": \"number\"\n" +
@@ -63,7 +63,7 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
                 "        {\n" +
                 "          \"numPoints\": 1,\n" +
                 "          \"timestamp\": 1382400000,\n" +
-                "          \"average\": 56\n" +
+                "          \"latest\": 56\n" +
                 "        }\n" +
                 "      ],\n" +
                 "      \"type\": \"number\"\n" +

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BatchedMetricsJSONOutputSerializer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BatchedMetricsJSONOutputSerializer.java
@@ -43,7 +43,7 @@ public class BatchedMetricsJSONOutputSerializer extends JSONBasicRollupsOutputSe
             singleMetricJSON.put("unit", one.getValue().getUnit() == null ? Util.UNKNOWN : one.getValue().getUnit());
             singleMetricJSON.put("type", one.getValue().getType());
             Set<MetricStat> oneFilterStats = fixFilterStats(one.getValue(), filterStats);
-            JSONArray values = transformDataToJSONArray(one.getValue(), filterStats);
+            JSONArray values = transformDataToJSONArray(one.getValue(), oneFilterStats);
             singleMetricJSON.put("data", values);
             metricsArray.add(singleMetricJSON);
         }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BatchedMetricsJSONOutputSerializer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BatchedMetricsJSONOutputSerializer.java
@@ -36,11 +36,13 @@ public class BatchedMetricsJSONOutputSerializer extends JSONBasicRollupsOutputSe
         final JSONObject globalJSON = new JSONObject();
         final JSONArray metricsArray = new JSONArray();
 
+
         for (Map.Entry<Locator, MetricData> one : metricData.entrySet()) {
             final JSONObject singleMetricJSON = new JSONObject();
             singleMetricJSON.put("metric", one.getKey().getMetricName());
             singleMetricJSON.put("unit", one.getValue().getUnit() == null ? Util.UNKNOWN : one.getValue().getUnit());
             singleMetricJSON.put("type", one.getValue().getType());
+            Set<MetricStat> oneFilterStats = fixFilterStats(one.getValue(), filterStats);
             JSONArray values = transformDataToJSONArray(one.getValue(), filterStats);
             singleMetricJSON.put("data", values);
             metricsArray.add(singleMetricJSON);

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/FakeMetricDataGenerator.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/FakeMetricDataGenerator.java
@@ -96,6 +96,17 @@ public class FakeMetricDataGenerator {
         return points;
     }
     
+    public static Points<BluefloodEnumRollup> generateFakeEnumRollupPoints() {
+        Points<BluefloodEnumRollup> points = new Points<BluefloodEnumRollup>();
+        long startTime = 1234567L;
+        for (int i = 0; i < 5; i++) {
+            long timeNow = startTime + i*1000;
+            Points.Point<BluefloodEnumRollup> point = new Points.Point<BluefloodEnumRollup>(timeNow, new BluefloodEnumRollup().withEnumValue("enum_value_" + i));
+            points.add(point);
+        }
+        return points;
+    }
+
     public static Points<BluefloodSetRollup> generateFakeSetRollupPoints() {
         Points<BluefloodSetRollup> points = new Points<BluefloodSetRollup>();
         long startTime = 1234567L;

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupsOutputSerializer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupsOutputSerializer.java
@@ -31,13 +31,8 @@ import java.util.Set;
 
 public class JSONBasicRollupsOutputSerializer implements BasicRollupsOutputSerializer<JSONObject> {
     private static final Logger log = LoggerFactory.getLogger(JSONBasicRollupsOutputSerializer.class);
-    
-    @Override
-    public JSONObject transformRollupData(MetricData metricData, Set<MetricStat> filterStats)
-            throws SerializationException {
-        final JSONObject globalJSON = new JSONObject();
-        final JSONObject metaObject = new JSONObject();
-        
+
+    protected Set<MetricStat> fixFilterStats(MetricData metricData, Set<MetricStat> filterStats) {
         // if no stats were entered, figure out what type we are dealing with and select out default stats. 
         if (metricData.getData().getPoints().size() > 0 && filterStats == PlotRequestParser.DEFAULT_STATS) {
             Class dataClass = metricData.getData().getDataClass();
@@ -55,6 +50,16 @@ public class JSONBasicRollupsOutputSerializer implements BasicRollupsOutputSeria
                 filterStats = PlotRequestParser.DEFAULT_ENUM;
             // else, I got nothing.
         }
+
+        return filterStats;
+    }
+
+    @Override
+    public JSONObject transformRollupData(MetricData metricData, Set<MetricStat> filterStats)
+            throws SerializationException {
+        final JSONObject globalJSON = new JSONObject();
+        final JSONObject metaObject = new JSONObject();
+        filterStats = fixFilterStats(metricData, filterStats);
 
         final JSONArray valuesArray = transformDataToJSONArray(metricData, filterStats);
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/BatchedMetricsJSONOutputSerializerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/BatchedMetricsJSONOutputSerializerTest.java
@@ -17,6 +17,7 @@
 package com.rackspacecloud.blueflood.outputs.serializers;
 
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
+import com.rackspacecloud.blueflood.outputs.utils.PlotRequestParser;
 import com.rackspacecloud.blueflood.types.Locator;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -61,6 +62,34 @@ public class BatchedMetricsJSONOutputSerializerTest {
             JSONObject singleMetricObject = metricsObjects.next();
             Assert.assertTrue(singleMetricObject.get("unit").equals("unknown"));
             Assert.assertTrue(singleMetricObject.get("type").equals("number"));
+            JSONArray data = (JSONArray) singleMetricObject.get("data");
+            Assert.assertTrue(data != null);
+        }
+    }
+
+    @Test
+    public void testBatchedEnumMetricsSerialization() throws Exception {
+        final BatchedMetricsJSONOutputSerializer serializer = new BatchedMetricsJSONOutputSerializer();
+
+        final Map<Locator, MetricData> metrics = new HashMap<Locator, MetricData>();
+        for (int i = 0; i < 2; i++) {
+            final MetricData metricData = new MetricData(FakeMetricDataGenerator.generateFakeEnumRollupPoints(), "unknown",
+                    MetricData.Type.ENUM);
+
+            metrics.put(Locator.createLocatorFromPathComponents(tenantId, String.valueOf(i)), metricData);
+        }
+
+        JSONObject jsonMetrics = serializer.transformRollupData(metrics, PlotRequestParser.DEFAULT_STATS);
+        Assert.assertTrue(jsonMetrics.get("metrics") != null);
+        JSONArray jsonMetricsArray = (JSONArray) jsonMetrics.get("metrics");
+
+        Iterator<JSONObject> metricsObjects = jsonMetricsArray.iterator();
+        Assert.assertTrue(metricsObjects.hasNext());
+
+        while (metricsObjects.hasNext()) {
+            JSONObject singleMetricObject = metricsObjects.next();
+            Assert.assertTrue(singleMetricObject.get("unit").equals("unknown"));
+            Assert.assertTrue(singleMetricObject.get("type").equals("enum"));
             JSONArray data = (JSONArray) singleMetricObject.get("data");
             Assert.assertTrue(data != null);
         }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.Map;
 
 public class JSONBasicRollupOutputSerializerTest {
     private final Set<MetricStat> filterStats;
@@ -161,6 +162,33 @@ public class JSONBasicRollupOutputSerializerTest {
         }
     }
     
+    @Test
+    public void testEnums() throws Exception {
+        final JSONBasicRollupsOutputSerializer serializer = new JSONBasicRollupsOutputSerializer();
+        final MetricData metricData = new MetricData(
+                FakeMetricDataGenerator.generateFakeEnumRollupPoints(), 
+                "unknown", 
+                MetricData.Type.ENUM);
+        JSONObject metricDataJSON = serializer.transformRollupData(metricData, PlotRequestParser.DEFAULT_STATS);
+        final JSONArray data = (JSONArray)metricDataJSON.get("values");
+        
+        Assert.assertEquals(5, data.size());
+        for (int i = 0; i < data.size(); i++) {
+            final JSONObject dataJSON = (JSONObject)data.get(i);
+            final Map<String,Long> evJSON = (Map<String, Long>)dataJSON.get("enum_values");
+            Set<String> keys = evJSON.keySet();
+
+            Assert.assertEquals(1, keys.size());
+            for (String key : keys) {
+              Assert.assertEquals(key, "enum_value_" + i);
+              Assert.assertEquals((long)evJSON.get(key), 1);
+            }
+            Assert.assertNotNull(dataJSON.get("numPoints"));
+            Assert.assertEquals(1, dataJSON.get("numPoints"));
+            Assert.assertEquals(MetricData.Type.ENUM, dataJSON.get("type"));
+        }
+    }
+
     @Test
     public void testGauges() throws Exception {
         final JSONBasicRollupsOutputSerializer serializer = new JSONBasicRollupsOutputSerializer();


### PR DESCRIPTION
This PR fixes the exception generated by enum mplot queries:
java.lang.Exception: average not supported for this type: BluefloodEnumRollup


Multiplot enum and gauge queries were not treating default filterStats the same as singlePlot queries.  This PR refactors the code so singlePlot and multiPlot work the same.

Also added another logmessage for rollups.

