### PR TITLE
Izrik/maven versioning

### DIFF
--- a/blueflood-all/pom.xml
+++ b/blueflood-all/pom.xml
@@ -6,7 +6,8 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+    <version>${BLUEFLOOD_VERSION}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/blueflood-cloudfiles/pom.xml
+++ b/blueflood-cloudfiles/pom.xml
@@ -20,7 +20,8 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+    <version>${BLUEFLOOD_VERSION}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -19,7 +19,8 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+    <version>${BLUEFLOOD_VERSION}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -22,7 +22,8 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+    <version>${BLUEFLOOD_VERSION}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -22,7 +22,8 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+    <version>${BLUEFLOOD_VERSION}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/blueflood-kafka/pom.xml
+++ b/blueflood-kafka/pom.xml
@@ -20,7 +20,8 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+    <version>${BLUEFLOOD_VERSION}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/blueflood-rollupTools/pom.xml
+++ b/blueflood-rollupTools/pom.xml
@@ -20,7 +20,8 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+    <version>${BLUEFLOOD_VERSION}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/blueflood-udp/pom.xml
+++ b/blueflood-udp/pom.xml
@@ -6,7 +6,8 @@
   <parent>
     <artifactId>blueflood</artifactId>
     <groupId>com.rackspacecloud</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+    <version>${BLUEFLOOD_VERSION}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/build_and_release.rb
+++ b/build_and_release.rb
@@ -9,6 +9,15 @@
 #
 # Running maven from the command line (e.g. `mvn package`), instead of the
 # script, will still produce artifacts with the SNAPSHOT version string.
+#
+# To produce a snapshot build of the software, run the following at the command
+# line:
+#   mvn package
+#
+# To produce a release build of the software, run the following:
+#   ruby build_and_release VERSION_SUFFIX
+# where VERSION_SUFFIX is a number.
+
 
 require 'rexml/document'
 

--- a/build_and_release.rb
+++ b/build_and_release.rb
@@ -78,6 +78,14 @@ end
 build_number = ARGV.shift
 new_version = get_version_number(build_number)
 
+# Check the branch that we're on. if not master, add the branch name and treat as snapshot
+branches = run_command_return_lines("git branch --no-color --contains")
+branch = branches.find {|line| line.start_with?("*")}.sub(/^\*\s*/, '').strip()
+if branch != "master"
+  branch.sub!(/_/, '__')
+  branch.sub!(/[\\\/]/,'_')
+  build_number += "-" + branch + "-SNAPSHOT"
+end
 
 
 # build the project

--- a/build_and_release.rb
+++ b/build_and_release.rb
@@ -1,0 +1,50 @@
+
+require 'rexml/document'
+
+
+def get_version_number(build_number)
+  pom = REXML::Document.new(File.new("pom.xml"))
+  version = pom.elements["project/properties/BLUEFLOOD_VERSION"].text
+
+  if version.end_with? '${VERSION_SUFFIX}'
+    return version.gsub('${VERSION_SUFFIX}', build_number)
+  end
+
+  return version
+end
+
+def run_command(command)
+  puts "Running command: #{command}"
+  ret = IO.popen(command, :err=>[:child, :out]) {|io|
+    io.each {|line|
+      puts ">> #{line}"
+    }
+  }
+  if $?.exitstatus != 0
+    puts "Failed with code #{$?.exitstatus}"
+    exit 1
+  end
+end
+
+
+if ARGV.length < 1
+  $stderr.puts "Usage: #{$0} BUILD_NUMBER"
+  exit 1
+end
+
+
+# Get the new version, as MAJOR.MINOR.BUILD
+build_number = ARGV.shift
+new_version = get_version_number(build_number)
+
+
+
+# build the project
+run_command("mvn clean")
+run_command("mvn verify -DBUILD_SUFFIX=#{build_number} -P cassandra-2.0 findbugs:findbugs")
+
+
+
+# # tag the commit so we can associate it with the release
+# run_command("git tag release-#{new_version}")
+# run_command("git push --tags")

--- a/build_and_release.rb
+++ b/build_and_release.rb
@@ -76,7 +76,7 @@ end
 
 options = parser.parse!
 
-if options < 1
+if options.length < 1
   $stderr.puts parser.help
   exit 1
 end

--- a/build_and_release.rb
+++ b/build_and_release.rb
@@ -1,3 +1,14 @@
+#!/usr/bin/ruby
+
+# This script builds the code, overriding the version number of the pom with
+# one of the form MAJOR.MINOR.BUILD. The major and minor version numbers are
+# taken from the pom file (see the BLUEFLOOD_VERSION maven parameter). The
+# build number should be passed in as the first and only command line argument
+# to the script. The script will then turn a snapshot version string, such as
+# "2.0-SNAPSHOT", into something suitable for a release build, like "2.0.36".
+#
+# Running maven from the command line (e.g. `mvn package`), instead of the
+# script, will still produce artifacts with the SNAPSHOT version string.
 
 require 'rexml/document'
 

--- a/build_and_release.rb
+++ b/build_and_release.rb
@@ -56,6 +56,6 @@ run_command("mvn verify -DBUILD_SUFFIX=#{build_number} -P cassandra-2.0 findbugs
 
 
 
-# # tag the commit so we can associate it with the release
-# run_command("git tag release-#{new_version}")
-# run_command("git push --tags")
+# tag the commit so we can associate it with the release
+run_command("git tag release-#{new_version}")
+run_command("git push --tags")

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <artifactId>blueflood</artifactId>
   <name>Blueflood</name>
   <packaging>pom</packaging>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>${BLUEFLOOD_VERSION}</version>
   <modules>
     <module>blueflood-core</module>
     <module>blueflood-udp</module>
@@ -41,6 +41,8 @@
   <url>http://blueflood.io</url>
 
   <properties>
+    <BUILD_SUFFIX>0-SNAPSHOT</BUILD_SUFFIX>
+    <BLUEFLOOD_VERSION>2.0.${BUILD_SUFFIX}</BLUEFLOOD_VERSION>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <!-- Used to locate the profile specific configuration file. -->
     <build.profile.id>dev</build.profile.id>

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
   <url>http://blueflood.io</url>
 
   <properties>
-    <BUILD_SUFFIX>0-SNAPSHOT</BUILD_SUFFIX>
-    <BLUEFLOOD_VERSION>2.0.${BUILD_SUFFIX}</BLUEFLOOD_VERSION>
+    <VERSION_SUFFIX>0-SNAPSHOT</VERSION_SUFFIX>
+    <BLUEFLOOD_VERSION>2.0.${VERSION_SUFFIX}</BLUEFLOOD_VERSION>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <!-- Used to locate the profile specific configuration file. -->
     <build.profile.id>dev</build.profile.id>


### PR DESCRIPTION
This PR modifies pom files and adds a script to build the code with a release-style (not a snapshot) version string. 

The build script could be run from either jenkins or travis-ci. It should work with both. Here's an example of it in action: https://jenkins.bf.k1k.me/jenkins/job/izrik-clone-blueflood-verify-master/15/console

I haven't made any configurations changes to our jenkins jobs. They will still run maven in the usual way and will ignore the new build script. Changing them to use the build script will be a part of a future story. Same goes for `.travis.yml`.

The script has a place to tag the commit and push said tag to the repo. Before the script is run by a CI/CD system, proper credentials for pushing tags to the repo will have to be configured. I didn't have much trouble settings that up in Jenkins in my prototype jobs, but it is a "gotcha" to be aware of. Setting up said credentials will be a part of the future story to turn on the script.

As far as I know, everything in  the build process should stay exactly the same if this PR is merged. Travis-CI, jenkins, and local dev machines will still produce `2.0.0-SNAPSHOT` artifacts.

Because the `<version>` in the pom is now an expression instead of a hard-coded value, we won't be able to use the maven release plugin to produce releases. But that's ok, since we weren't using it anyways.
