### PR TITLE
Changing Sun to Fri

### DIFF
--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/utils/DateTimeParserTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/utils/DateTimeParserTest.java
@@ -116,9 +116,9 @@ public class DateTimeParserTest {
     @Test
     public void testDayOfWeekFormat() {
         DateTime todayDate = referenceDateTime();
-        for (String dateTimeString: Arrays.asList("Sun", "14:42 Sun", "noon Sun")) {
+        for (String dateTimeString: Arrays.asList("Fri", "14:42 Fri", "noon Fri")) {
             DateTime date = DateTimeParser.parse(dateTimeString);
-            Assert.assertEquals(date.getDayOfWeek(), 7);
+            Assert.assertEquals(date.getDayOfWeek(), 5);
             Assert.assertTrue(todayDate.getYear() == date.getYear());
             Assert.assertTrue(todayDate.getDayOfYear() - date.getDayOfYear() <= 7);
         }


### PR DESCRIPTION
*Why:*
DatetimeParser is giving the year as 2015 when Sun is passed as argument.

**Merge this PR or wait until Sunday to get the build stabilized.**