### PR TITLE
adjust integration tests to not do string compare, to make tests work better in JDK 1.8

### DIFF
--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -16,6 +16,10 @@
 
 package com.rackspacecloud.blueflood.outputs.handlers;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
@@ -42,6 +46,10 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
 
         // assert response content
         String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
+
+        JsonParser jsonParser = new JsonParser();
+        JsonObject responseObject = jsonParser.parse(responseContent).getAsJsonObject();
+
         String expectedResponse = "{\n" +
                 "  \"metrics\": [\n" +
                 "    {\n" +
@@ -70,8 +78,9 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
                 "    }\n" +
                 "  ]\n" +
                 "}";
+        JsonObject expectedObject = jsonParser.parse(expectedResponse).getAsJsonObject();
 
-        Assert.assertEquals(expectedResponse, responseContent);
+        Assert.assertEquals(expectedObject, responseObject);
         EntityUtils.consume(query_response.getEntity());
     }
 
@@ -92,6 +101,10 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
 
         // assert response content
         String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
+
+        JsonParser jsonParser = new JsonParser();
+        JsonObject responseObject = jsonParser.parse(responseContent).getAsJsonObject();
+
         String expectedResponse = String.format("{\n" +
                 "  \"metrics\": [\n" +
                 "    {\n" +
@@ -116,7 +129,9 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
                 "  ]\n" +
                 "}", metric_name);
 
-        Assert.assertEquals(expectedResponse, responseContent);
+        JsonObject expectedObject = jsonParser.parse(expectedResponse).getAsJsonObject();
+
+        Assert.assertEquals(expectedObject, responseObject);
         EntityUtils.consume(query_response.getEntity());
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
@@ -16,6 +16,8 @@
 
 package com.rackspacecloud.blueflood.outputs.handlers;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
@@ -43,6 +45,10 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
 
         // assert response content
         String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
+
+        JsonParser jsonParser = new JsonParser();
+        JsonObject responseObject = jsonParser.parse(responseContent).getAsJsonObject();
+
         String expectedResponse = "{\n" +
                 "  \"unit\": \"unknown\",\n" +
                 "  \"values\": [\n" +
@@ -59,8 +65,9 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
                 "    \"marker\": null\n" +
                 "  }\n" +
                 "}";
+        JsonObject expectedObject = jsonParser.parse(expectedResponse).getAsJsonObject();
 
-        Assert.assertEquals(expectedResponse, responseContent);
+        Assert.assertEquals(expectedObject, responseObject);
         EntityUtils.consume(query_response.getEntity());
     }
 
@@ -81,6 +88,10 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
 
         // assert response content
         String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
+
+        JsonParser jsonParser = new JsonParser();
+        JsonObject responseObject = jsonParser.parse(responseContent).getAsJsonObject();
+
         String expectedResponse = "{\n" +
                 "  \"unit\": \"unknown\",\n" +
                 "  \"values\": [\n" +
@@ -100,8 +111,9 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
                 "    \"marker\": null\n" +
                 "  }\n" +
                 "}";
+        JsonObject expectedObject = jsonParser.parse(expectedResponse).getAsJsonObject();
 
-        Assert.assertEquals(expectedResponse, responseContent);
+        Assert.assertEquals(expectedObject, responseObject);
         EntityUtils.consume(query_response.getEntity());
     }
 }


### PR DESCRIPTION
Hashing mechanism is different in JDK 1.8. String compare of json output is generally not a good idea. The tests that are failing under JDK 1.8 has been updated to parse the JSON object and compare it with the expected JSON object.