### PR TITLE
add tracking ingest requests for specific metric names

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
@@ -42,6 +42,7 @@ public class Tracker implements TrackerMBean {
 
     static Set tenantIds = new HashSet();
     static boolean isTrackingDelayedMetrics = false;
+    static Set<String> metricNames = new HashSet<String>();
 
     public Tracker() {
         registerMBean();
@@ -50,6 +51,11 @@ public class Tracker implements TrackerMBean {
     public void addTenant(String tenantId) {
         tenantIds.add(tenantId);
         log.info("[TRACKER] tenantId " + tenantId + " added.");
+    }
+
+    public void addMetricName(String metricName) {
+        metricNames.add(metricName);
+        log.info("[TRACKER] Metric name "+ metricName + " added.");
     }
 
     public void setIsTrackingDelayedMetrics() {
@@ -72,8 +78,35 @@ public class Tracker implements TrackerMBean {
         log.info("[TRACKER] all tenants removed.");
     }
 
+    public void removeMetricName(String metricName) {
+        metricNames.remove(metricName);
+        log.info("[TRACKER] Metric name "+ metricName + " removed.");
+    }
+
+    public void removeAllMetricNames() {
+        metricNames.clear();
+        log.info("[TRACKER] All metric names removed.");
+    }
+
     public static boolean isTracking(String tenantId) {
         return tenantIds.contains(tenantId);
+    }
+
+    public static boolean doesMessageContainMetricNames(String logmessage) {
+        boolean toLog = false;
+
+        if (metricNames.size() == 0) {
+            toLog = true;
+        }
+        else {
+            for (String name : metricNames) {
+                if (logmessage.contains(name)) {
+                    toLog = true;
+                    break;
+                }
+            }
+        }
+        return toLog;
     }
 
     public Set getTenants() {
@@ -123,7 +156,9 @@ public class Tracker implements TrackerMBean {
                     "HEADERS: " + headers +
                     requestContent;
 
-            log.info(logMessage);
+            if (doesMessageContainMetricNames(logMessage)) {
+                log.info(logMessage);
+            }
         }
     }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/TrackerMBean.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/TrackerMBean.java
@@ -21,8 +21,11 @@ import java.util.Set;
 public interface TrackerMBean {
 
     public void addTenant(String tenantId);
+    public void addMetricName(String metricName);
     public void removeTenant(String tenantId);
     public void removeAllTenants();
+    public void removeMetricName(String metricName);
+    public void removeAllMetricNames();
     public Set getTenants();
     public void setIsTrackingDelayedMetrics();
     public void resetIsTrackingDelayedMetrics();

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
@@ -55,19 +55,19 @@ public class TrackerTest {
     @Test
     public void testAddAndRemoveMetricName() {
         tracker.addMetricName("metricName");
-        Assert.assertTrue("metricName not added",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+        assertTrue("metricName not added",tracker.doesMessageContainMetricNames("Track.this.metricName"));
 
         tracker.addMetricName("anotherMetricNom");
-        Assert.assertTrue("metricName not being logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
-        Assert.assertTrue("anotherMetricNom not being logged",tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
-        Assert.assertFalse("randomMetricNameNom should not be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
+        assertTrue("metricName not being logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+        assertTrue("anotherMetricNom not being logged",tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
+        assertFalse("randomMetricNameNom should not be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
 
         tracker.removeMetricName("metricName");
-        Assert.assertFalse("metricName should not be logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+        assertFalse("metricName should not be logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
 
         tracker.removeMetricName("anotherMetricNom");
-        Assert.assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
-        Assert.assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
+        assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
+        assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
     }
 
     @Test
@@ -75,15 +75,15 @@ public class TrackerTest {
         tracker.addMetricName("metricName");
         tracker.addMetricName("anotherMetricNom");
 
-        Assert.assertTrue("metricName not being logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
-        Assert.assertTrue("anotherMetricNom not being logged",tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
-        Assert.assertFalse("randomMetricNameNom should not be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
+        assertTrue("metricName not being logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+        assertTrue("anotherMetricNom not being logged",tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
+        assertFalse("randomMetricNameNom should not be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
 
         tracker.removeAllMetricNames();
 
-        Assert.assertTrue("Everything should be logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
-        Assert.assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
-        Assert.assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
+        assertTrue("Everything should be logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+        assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
+        assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
     }
 
     @Test

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
@@ -53,6 +53,40 @@ public class TrackerTest {
     }
 
     @Test
+    public void testAddAndRemoveMetricName() {
+        tracker.addMetricName("metricName");
+        Assert.assertTrue("metricName not added",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+
+        tracker.addMetricName("anotherMetricNom");
+        Assert.assertTrue("metricName not being logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+        Assert.assertTrue("anotherMetricNom not being logged",tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
+        Assert.assertFalse("randomMetricNameNom should not be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
+
+        tracker.removeMetricName("metricName");
+        Assert.assertFalse("metricName should not be logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+
+        tracker.removeMetricName("anotherMetricNom");
+        Assert.assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
+        Assert.assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
+    }
+
+    @Test
+    public void testRemoveAllMetricNames() {
+        tracker.addMetricName("metricName");
+        tracker.addMetricName("anotherMetricNom");
+
+        Assert.assertTrue("metricName not being logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+        Assert.assertTrue("anotherMetricNom not being logged",tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
+        Assert.assertFalse("randomMetricNameNom should not be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
+
+        tracker.removeAllMetricNames();
+
+        Assert.assertTrue("Everything should be logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+        Assert.assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
+        Assert.assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
+    }
+
+    @Test
     public void testRemoveAllTenant() {
         tracker.addTenant(testTenant1);
         tracker.addTenant(testTenant2);


### PR DESCRIPTION
This PR supersedes PR #552. The goal of the PR is to add a way to track only specific metric names that are sent to already tracked tenant. 