### PR TITLE
for counters, return sampleCount in numPoints attribute

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BasicRollupsOutputSerializer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/BasicRollupsOutputSerializer.java
@@ -106,7 +106,7 @@ public interface BasicRollupsOutputSerializer<T> {
                 else if (rollup instanceof BluefloodTimerRollup)
                     return ((BluefloodTimerRollup) rollup).getCount();
                 else if (rollup instanceof BluefloodCounterRollup)
-                    return ((BluefloodCounterRollup) rollup).getCount();
+                    return ((BluefloodCounterRollup) rollup).getSampleCount();
                 else if (rollup instanceof BluefloodSetRollup)
                     return ((BluefloodSetRollup) rollup).getCount();
                 else if (rollup instanceof BluefloodEnumRollup)

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/FakeMetricDataGenerator.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/FakeMetricDataGenerator.java
@@ -90,7 +90,7 @@ public class FakeMetricDataGenerator {
             Points.Point<BluefloodCounterRollup> point = new Points.Point<BluefloodCounterRollup>(timeNow, new BluefloodCounterRollup()
                     .withCount(i + 1000)
                     .withRate((double) i)
-                    .withSampleCount(1));
+                    .withSampleCount(i+1));
             points.add(point);
         }
         return points;

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupsOutputSerializer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupsOutputSerializer.java
@@ -94,8 +94,6 @@ public class JSONBasicRollupsOutputSerializer implements BasicRollupsOutputSeria
         JSONObject filterStatsObject = null;
         long numPoints = 1;
         
-        
-        
         // todo: adding getCount() to Rollup interface will simplify this block.
         // because of inheritance, GaugeRollup needs to come before BasicRollup. sorry.
         if (point.getData() instanceof BluefloodGaugeRollup) {

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/serializers/JSONBasicRollupOutputSerializerTest.java
@@ -153,7 +153,7 @@ public class JSONBasicRollupOutputSerializerTest {
             final JSONObject dataJSON = (JSONObject)data.get(i);
             
             Assert.assertNotNull(dataJSON.get("numPoints"));
-            Assert.assertEquals((long) (i + 1000), dataJSON.get("numPoints"));
+            Assert.assertEquals(i+1, dataJSON.get("numPoints"));
 
             Assert.assertNotNull(dataJSON.get("sum"));
             Assert.assertEquals((long) (i + 1000), dataJSON.get("sum"));


### PR DESCRIPTION
Currently, numPoints for Counters holds the value of the stats for the counter, which is incorrect. 
```
curl -i -X GET "http://localhost:20000/v2.0/123456/views/my_counter?from=1452614038000&to=1499614038000&points=20"
HTTP/1.1 200 OK
Content-Length: 224

{
  "unit": "unknown",
  "values": [
    {
      "numPoints": 72,
      "timestamp": 1452556800000,
      "sum": 72
    }
  ],
  "metadata": {
    "limit": null,
    "next_href": null,
    "count": 1,
    "marker": null
  }
}
```

This PR changes it so that numPoints holds the value of sampleCount for the Counters. The same curl call would result:
```
curl -i -X GET "http://localhost:20000/v2.0/123456/views/my_counter?from=1452614038000&to=1499614038000&points=20"
HTTP/1.1 200 OK
Content-Length: 224

{
  "unit": "unknown",
  "values": [
    {
      "numPoints": 3,
      "timestamp": 1452556800000,
      "sum": 72
    }
  ],
  "metadata": {
    "limit": null,
    "next_href": null,
    "count": 1,
    "marker": null
  }
}
```