### PR TITLE
add profile, add ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 ############################
 /target
 */target
+**/target
 /build
 */build
 

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,12 @@
       </modules>
     </profile>
     <profile>
+      <id>logstash-support</id>
+      <modules>
+        <module>contrib/logstash-support</module>
+      </modules>
+    </profile>
+    <profile>
       <id>release</id>
       <build>
         <plugins>


### PR DESCRIPTION
I forgot a few things from the previous PR #593  to enable building logstash-support:
* add an entry to git ignore contrib/logstash-support/target
* add a profile to the main pom.xml so I can do a build from Jenkins
