### PR TITLE
Removing logging from bf-rollups-delay.py

### DIFF
--- a/ops/rackspace-agent-plugins/bf-rollups-delay.py
+++ b/ops/rackspace-agent-plugins/bf-rollups-delay.py
@@ -17,7 +17,7 @@
 import pycassa
 import sys
 import time
-import logging
+
 from collections import defaultdict
 
 SLOTS = 4032
@@ -120,18 +120,13 @@ def print_stats_for_metrics_state(metrics_state_for_shards):
 
 def main(servers):
     try:
-        logging.basicConfig(format='%(asctime)s %(message)s',
-                            filename='/tmp/bf-rollup.log', level=logging.DEBUG)
         shards = range(128)
-        logging.debug('getting metrics state for shards')
         metrics_state_for_shards = get_metrics_state_for_shards(shards,
                                                                 servers)
         print 'status ok bf_health_check'
-        logging.debug('printing stats for metrics state')
         print_stats_for_metrics_state(metrics_state_for_shards)
         # find_duplicates(shards, metrics_for_shards)
     except Exception, ex:
-        logging.exception(ex)
         print "status error", ex
         raise ex
 


### PR DESCRIPTION
Hi all, I attempted to run bf-rollups-delay.py on the db node and couldn't because @GeorgeJahad already wrote the file and I was locked out of writing to it.

Looked like the logging was pretty basic and thought it might be best just to get rid of it.  Let me know what you all think.
