### PR TITLE
test and refactor configuration class

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -24,10 +24,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.*;
 
-/**
- * java/conf/bf-dev.con has an exhaustive description of each configuration option.
- *
- */
 public class Configuration {
     private static final Properties defaultProps = new Properties();
     private static Properties props;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -57,13 +57,21 @@ public class Configuration {
         }
     }
 
+    /**
+     * Convert the existing configuration values into a Map. Does not include defaults from the defaultProps object.
+     *
+     * @return an unmodifiable Map
+     */
     public Map<Object,Object> getProperties() {
         return Collections.unmodifiableMap(props);
     }
 
+    /**
+     * Convert the existing configuration values into a Map, including those specified in defaultProps.
+     *
+     * @return an unmodifiable Map
+     */
     public Map<Object, Object> getAllProperties() {
-
-        // includes defaults values, which are not captured by the above getProperties method
 
         Map<Object, Object> map = new HashMap<Object, Object>();
         for (Object key : defaultProps.keySet()) {
@@ -72,6 +80,7 @@ public class Configuration {
         for (Object key : props.keySet()) {
             map.put(key, props.getProperty(key.toString()));
         }
+
         return Collections.unmodifiableMap(map);
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -65,6 +65,20 @@ public class Configuration {
         return Collections.unmodifiableMap(props);
     }
 
+    public Map<Object, Object> getAllProperties() {
+
+        // includes defaults values, which are not captured by the above getProperties method
+
+        Map<Object, Object> map = new HashMap<Object, Object>();
+        for (Object key : defaultProps.keySet()) {
+            map.put(key, defaultProps.getProperty(key.toString()));
+        }
+        for (Object key : props.keySet()) {
+            map.put(key, props.getProperty(key.toString()));
+        }
+        return Collections.unmodifiableMap(map);
+    }
+
     public String getStringProperty(Enum<? extends ConfigDefaults> name) {
         return getStringProperty(name.toString());
     }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -133,4 +133,9 @@ public class Configuration {
     public void setProperty(String name, String val) {
       props.setProperty(name, val);
     }
+
+    @VisibleForTesting
+    public void clearProperty(String name) {
+        props.remove(name);
+    }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -95,36 +95,50 @@ public class Configuration {
         return getIntegerProperty(name.toString());
     }
     public int getIntegerProperty(String name) {
-        return Integer.parseInt(getStringProperty(name));
+        return intFromString(getStringProperty(name));
+    }
+    public static int intFromString(String value) {
+        return Integer.parseInt(value);
     }
 
     public float getFloatProperty(Enum<? extends ConfigDefaults> name) {
         return getFloatProperty(name.toString());
     }
     public float getFloatProperty(String name) {
-        return Float.parseFloat(getStringProperty(name));
+        return floatFromString(getStringProperty(name));
+    }
+    public static float floatFromString(String value) {
+        return Float.parseFloat(value);
     }
 
     public long getLongProperty(Enum<? extends ConfigDefaults> name) {
         return getLongProperty(name.toString());
     }
     public long getLongProperty(String name) {
-        return Long.parseLong(getStringProperty(name));
+        return longFromString(getStringProperty(name));
+    }
+    public static long longFromString(String value) {
+        return Long.parseLong(value);
     }
 
     public boolean getBooleanProperty(Enum<? extends ConfigDefaults> name) {
         return getBooleanProperty(name.toString());
     }
-
     public boolean getBooleanProperty(String name) {
-        return "true".equalsIgnoreCase(getStringProperty(name));
+        return booleanFromString(getStringProperty(name));
+    }
+    public static boolean booleanFromString(String value) {
+        return "true".equalsIgnoreCase(value);
     }
 
     public List<String> getListProperty(Enum<? extends ConfigDefaults> name) {
         return getListProperty(name.toString());
     }
     public List<String> getListProperty(String name) {
-        List<String> list = Lists.newArrayList(getStringProperty(name).split("\\s*,\\s*"));
+        return stringListFromString(getStringProperty(name));
+    }
+    public static List<String> stringListFromString(String value) {
+        List<String> list = Lists.newArrayList(value.split("\\s*,\\s*"));
         list.removeAll(Arrays.asList("", null));
         return list;
     }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -92,18 +92,22 @@ public class ConfigurationTest {
 
     @Test
     public void testSystemPropertiesOverrideConfigurationValues() {
+
+        final String keyName = CoreConfig.MAX_CASSANDRA_CONNECTIONS.toString();
+
         Configuration config = Configuration.getInstance();
 
         try {
             Assert.assertEquals("75",
                     config.getStringProperty(CoreConfig.MAX_CASSANDRA_CONNECTIONS));
 
-            System.setProperty(CoreConfig.MAX_CASSANDRA_CONNECTIONS.toString(), "something else");
+            System.setProperty(keyName, "something else");
 
             Assert.assertEquals("something else",
                     config.getStringProperty(CoreConfig.MAX_CASSANDRA_CONNECTIONS));
         } finally {
-            System.clearProperty(CoreConfig.MAX_CASSANDRA_CONNECTIONS.toString());
+            System.clearProperty(keyName);
+            config.clearProperty(keyName);
         }
     }
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -67,11 +67,26 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testBooleanProperty() {
+    public void testNullShouldBeInterpretedAsBooleanFalse() {
+
+        // arrange
         Configuration config = Configuration.getInstance();
+
+        // precondition
         Assert.assertEquals(config.getStringProperty("foo"), null);
+
+        // assert
         Assert.assertFalse(config.getBooleanProperty("foo"));
+    }
+
+    @Test
+    public void test_TRUE_ShouldBeInterpretedAsBooleanTrue() {
+
+        // arrange
+        Configuration config = Configuration.getInstance();
         System.setProperty("foo", "TRUE");
+
+        // assert
         Assert.assertTrue(config.getBooleanProperty("foo"));
     }
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -223,6 +223,15 @@ public class ConfigurationTest {
 
         final String keyName = CoreConfig.ROLLUP_KEYSPACE.toString();
 
+        // The behavior of getStringProperty() when it creates new 'original.*'
+        // entries is very convoluted. It requires:
+        //  1. A system property named $NAME exists
+        //  2. A property named "original.$NAME" does NOT exist in the props object
+        //  3. A property named $NAME does exist in the props object
+        // Hence the calls to System.setProperty and config.setProperty below
+        // with different values. That way, we create the 'original.*' entry
+        // from the intended source and can test it.
+
         try {
             // arrange
             Configuration config = Configuration.getInstance();

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 public class ConfigurationTest {
@@ -56,38 +57,60 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testGetListProperty() {
-        Configuration config = Configuration.getInstance();
-        Assert.assertEquals(config.getStringProperty(CoreConfig.QUERY_MODULES), "");
-        Assert.assertTrue(config.getListProperty(CoreConfig.QUERY_MODULES).isEmpty());
-        System.setProperty("QUERY_MODULES", "a");
-        Assert.assertEquals(config.getListProperty(CoreConfig.QUERY_MODULES).size(), 1);
-        System.setProperty("QUERY_MODULES", "a,b , c");
-        Assert.assertEquals(Arrays.asList("a","b","c"), config.getListProperty(CoreConfig.QUERY_MODULES));
+    public void testMultipleCommaSeparatedItemsShouldYieldTheSameNumberOfElements() {
+
+        String[] expected = { "a", "b", "c" };
+        List<String> actual = Configuration.stringListFromString("a,b,c");
+
+        Assert.assertArrayEquals(expected, actual.toArray());
+    }
+
+    @Test
+    public void testWhitespaceBetweenElementsIsNotSignificant() {
+
+        String[] expected = { "a", "b", "c" };
+        List<String> actual = Configuration.stringListFromString("a,  b,c");
+
+        Assert.assertArrayEquals(expected, actual.toArray());
+    }
+
+    @Test
+    public void testLeadingWhitespaceIsKept() {
+
+        String[] expected = { "   a", "b", "c" };
+        List<String> actual = Configuration.stringListFromString("   a,b,c");
+
+        Assert.assertArrayEquals(expected, actual.toArray());
+    }
+
+    @Test
+    public void testTrailingWhitespaceIsKept() {
+
+        String[] expected = { "a", "b", "c   " };
+        List<String> actual = Configuration.stringListFromString("a,b,c   ");
+
+        Assert.assertArrayEquals(expected, actual.toArray());
+    }
+
+    @Test
+    public void testConsecutiveCommasDontProduceEmptyElements() {
+
+        String[] expected = { "a", "b", "c" };
+        List<String> actual = Configuration.stringListFromString("a,,,b,c");
+
+        Assert.assertArrayEquals(expected, actual.toArray());
     }
 
     @Test
     public void testNullShouldBeInterpretedAsBooleanFalse() {
 
-        // arrange
-        Configuration config = Configuration.getInstance();
-
-        // precondition
-        Assert.assertEquals(config.getStringProperty("foo"), null);
-
-        // assert
-        Assert.assertFalse(config.getBooleanProperty("foo"));
+        Assert.assertFalse(Configuration.booleanFromString(null));
     }
 
     @Test
     public void test_TRUE_ShouldBeInterpretedAsBooleanTrue() {
 
-        // arrange
-        Configuration config = Configuration.getInstance();
-        System.setProperty("foo", "TRUE");
-
-        // assert
-        Assert.assertTrue(config.getBooleanProperty("foo"));
+        Assert.assertTrue(Configuration.booleanFromString("TRUE"));
     }
 
     @Test

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -56,6 +56,8 @@ public class ConfigurationTest {
         Assert.assertEquals("NONE", config.getStringProperty(CoreConfig.SHARDS));
     }
 
+    // list of strings
+
     @Test
     public void testMultipleCommaSeparatedItemsShouldYieldTheSameNumberOfElements() {
 
@@ -101,6 +103,8 @@ public class ConfigurationTest {
         Assert.assertArrayEquals(expected, actual.toArray());
     }
 
+    // boolean values
+
     @Test
     public void testNullShouldBeInterpretedAsBooleanFalse() {
 
@@ -112,6 +116,8 @@ public class ConfigurationTest {
 
         Assert.assertTrue(Configuration.booleanFromString("TRUE"));
     }
+
+    // override behavior
 
     @Test
     public void testSystemPropertiesOverrideConfigurationValues() {
@@ -133,6 +139,8 @@ public class ConfigurationTest {
             config.clearProperty(keyName);
         }
     }
+
+    // originals
 
     @Test
     public void testGettingValuesCreatesOriginals() {
@@ -176,6 +184,8 @@ public class ConfigurationTest {
             System.clearProperty(keyName);
         }
     }
+
+    // getProperties
 
     @Test
     public void testGetPropertiesDoesntWorkForDefaults() {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -117,6 +117,82 @@ public class ConfigurationTest {
         Assert.assertTrue(Configuration.booleanFromString("TRUE"));
     }
 
+    // integer values
+
+    @Test
+    public void testIntegerOneShouldBeInterpretedAsOne() {
+        Assert.assertEquals(1, Configuration.intFromString("1"));
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testIntegerLeadingWhitespaceShouldBeIgnored() {
+        int value = Configuration.intFromString("   1");
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testIntegerTrailingWhitespaceShouldBeIgnored() {
+        int value = Configuration.intFromString("1   ");
+    }
+
+    // long values
+
+    @Test
+    public void testLongOneShouldBeInterpretedAsOne() {
+        Assert.assertEquals(1L, Configuration.longFromString("1"));
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testLongLeadingWhitespaceShouldBeRejected() {
+        long value = Configuration.longFromString("   1");
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testLongTrailingWhitespaceShouldBeRejected() {
+        long value = Configuration.longFromString("1   ");
+    }
+
+    // float values
+
+    @Test
+    public void testFloatOneShouldBeInterpretedAsOne() {
+        Assert.assertEquals(1.0f, Configuration.floatFromString("1"), 0.00001f);
+    }
+
+    @Test
+    public void testFloatExtendedFormat() {
+        Assert.assertEquals(-1100.0f, Configuration.floatFromString("-1.1e3"), 0.00001f);
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testFloatExtendedFormatSpaceBeforeDotIsInvalid() {
+        Assert.assertEquals(-1100.0f, Configuration.floatFromString("-1 .1e3"), 0.00001f);
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testFloatExtendedFormatSpaceAfterDotIsInvalid() {
+        Assert.assertEquals(-1100.0f, Configuration.floatFromString("-1. 1e3"), 0.00001f);
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testFloatExtendedFormatSpaceBeforeExponentMarkerIsInvalid() {
+        Assert.assertEquals(-1100.0f, Configuration.floatFromString("-1.1 e3"), 0.00001f);
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testFloatExtendedFormatSpaceAfterExponentMarkerIsInvalid() {
+        Assert.assertEquals(-1100.0f, Configuration.floatFromString("-1.1e 3"), 0.00001f);
+    }
+
+    @Test
+    public void testFloatLeadingWhitespaceShouldBeIgnored() {
+        Assert.assertEquals(1.0f, Configuration.floatFromString("   1"), 0.00001f);
+    }
+
+    @Test
+    public void testFloatTrailingWhitespaceShouldBeIgnored() {
+        Assert.assertEquals(1.0f, Configuration.floatFromString("1   "), 0.00001f);
+    }
+
     // override behavior
 
     @Test


### PR DESCRIPTION
As a `tester`,

In order to `test the top-level service classes`,

I want to `override configuration values programmatically`.

Explanation
-----------

The `Configuration` class stores all of the configuration for the system. It includes facilities for loading config values from the config file, overriding with system properties, and falling back to hard-coded default values (from e.g. the `CoreConfig` enum).
Many parts of the system, many classes and objects, rely on this class in order to get set up. In order to test those classes and objects, I would need to override configuration values.

The problem with this is the way the `Configuration` class works.
It is not possible to properly test code that relies on it, because its effects can't be isolated.
All fields in the class are static.
Any change to a config value in one part of the system affects all other parts of the system that interact with that config value.
Also, changes persist from one test invocation to another.
This makes testing the top-level services impossible, because tests cannot be independent.

In order to manually set or override the configuration for a single test (e.g. an as-yet-unwritten `BluefloodServiceStartTest`), I need a way to modify a single `Configuration` instance (or load values into it) that doesn't affect any other instance.

Complicating all of this are a few other problems:
 1. The `getStringProperty` method has side effects. Sometimes. In certain circumstances. Which aren't documented anywhere.
 2. The overriding behavior (system property vs. from config file) is unclear, and the code is hard to read.
 3. **Storing values as strings** is a separate concern from **converting strings to other data types**, but they are conflated within the class. In order to provide proper tests of the type conversion methods, one must modify the global config values.
 4. Existing tests are cramped, and try to test multiple pieces of functionality at the same time.
 5. Once a value is overridden, either by loading from a file or from a system property, there is no way to un-set that value. Subsequent test invocations in the same JVM will always see a value for the given key.
 6. `getProperties` returns a map and ignores the `defaultProps` field completely

Proposed Changes
----------------

Before we can even get to the static/instance problem, the code has to be cleaned up.
This PR makes the following changes:
 - Add more unit tests for the `Configuration class`
 - Separate tests so that they only test one piece of functionality at a time (see #4 above)
 - Split out static conversion methods, so they can be tested apart from modifying global config values (see #3 above)
 - Add a `clearProperty` method that removes key/value pairs from the `props` field (see #5 above)
 - Add a `getAllProperties` method that returns a map with all key/value pairs, including from `defaultProps` (see #6 above)

The goal with this PR is to be able to properly test the `Configuration` class, _as it works now_, so that it can safely be refactored it in the future.
Subsequent PR's will (a) remove the side effects from `getStringProperty`, (b) clean up and clarify the overriding behavior, and (c) finally tackle the creation of independent instances of the class.
