### PR TITLE
fix path in start up script

### DIFF
--- a/bin/blueflood-start.sh
+++ b/bin/blueflood-start.sh
@@ -12,6 +12,12 @@ SCRIPTDIR=`pwd`/`dirname $0`
 # top level source directory
 TOPDIR=$SCRIPTDIR/..
 
+if [ ! -d $TOPDIR/blueflood-all/target ]; then
+    echo "Error: blueflood-all/target directory does not exist. Please run build:"
+    echo "    mvn clean package -P all-modules"
+    exit 1
+fi
+
 JAVA=/usr/bin/java
 
 $JAVA \

--- a/bin/blueflood-start.sh
+++ b/bin/blueflood-start.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
-/usr/bin/java \
-        -Dblueflood.config=file:./demo/local/config/blueflood.conf \
-        -Dlog4j.configuration=file:./demo/local/config/blueflood-log4j.properties \
+
+#
+# This is a simple script that can be used to start blueflood service.
+# To run this, you must have built the blueflood package by running:
+#     mvn clean package -P all-modules
+#
+
+# directory where the script is located
+SCRIPTDIR=`pwd`/`dirname $0`  
+
+# top level source directory
+TOPDIR=$SCRIPTDIR/..
+
+JAVA=/usr/bin/java
+
+$JAVA \
+        -Dblueflood.config=file:///$TOPDIR/demo/local/config/blueflood.conf \
+        -Dlog4j.configuration=file:///$TOPDIR/demo/local/config/blueflood-log4j.properties \
         -Xms1G \
         -Xmx1G \
         -Dcom.sun.management.jmxremote.authenticate=false \
         -Dcom.sun.management.jmxremote.ssl=false \
         -Djava.rmi.server.hostname=localhost \
         -Dcom.sun.management.jmxremote.port=9180 \
-        -classpath ./blueflood-all/target/blueflood-all-*-jar-with-dependencies.jar com.rackspacecloud.blueflood.service.BluefloodServiceStarter 2>&1
+        -classpath $TOPDIR/blueflood-all/target/blueflood-all-*-jar-with-dependencies.jar com.rackspacecloud.blueflood.service.BluefloodServiceStarter 2>&1

--- a/demo/local/config/blueflood-log4j.properties
+++ b/demo/local/config/blueflood-log4j.properties
@@ -7,4 +7,5 @@ log4j.logger.org.apache.http.client.protocol=INFO
 log4j.logger.org.apache.http.wire=INFO
 log4j.logger.org.apache.http.impl=INFO
 log4j.logger.org.apache.http.headers=INFO
+log4j.logger.com.rackspacecloud.blueflood=INFO # Change to DEBUG for more output from Blueflood
 log4j.rootLogger=INFO, console


### PR DESCRIPTION
**Why:**
Yesterday while helping someone in #blueflood IRC, I noticed that the script assumes that it was run from top level directory and all references file paths (the log4j.properties, the *.conf file) is relative to the top level directory. This person was running the script from the bin/ directory and things didn't work.

**How:**
Change the script so that we use absolute paths for the files we referenced. This way, the script can be run from anywhere on the filesystem.