### PR TITLE
test and refactor configuration class - part 2

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -96,14 +96,14 @@ public class Configuration {
         return props.getProperty(name);
     }
 
-    public static String getRawStringProperty(Enum<? extends ConfigDefaults> name) {
+    public String getRawStringProperty(Enum<? extends ConfigDefaults> name) {
         return getRawStringProperty(name.toString());
     }
-    public static String getRawStringProperty(String name) {
+    public String getRawStringProperty(String name) {
         return props.getProperty(name);
     }
 
-    public static boolean containsKey(String key) {
+    public boolean containsKey(String key) {
         return props.containsKey(key);
     }
 
@@ -166,10 +166,10 @@ public class Configuration {
         setProperty(name.toString(), value);
     }
 
-    public static void clearProperty(String name) {
+    public void clearProperty(String name) {
         props.remove(name);
     }
-    public static void clearProperty(Enum<? extends ConfigDefaults> name) {
+    public void clearProperty(Enum<? extends ConfigDefaults> name) {
         clearProperty(name.toString());
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -148,13 +148,17 @@ public class Configuration {
         return list;
     }
 
-    @VisibleForTesting
     public void setProperty(String name, String val) {
       props.setProperty(name, val);
     }
+    public void setProperty(Enum<? extends ConfigDefaults> name, String value) {
+        setProperty(name.toString(), value);
+    }
 
-    @VisibleForTesting
     public void clearProperty(String name) {
         props.remove(name);
+    }
+    public void clearProperty(Enum<? extends ConfigDefaults> name) {
+        clearProperty(name.toString());
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -96,6 +96,17 @@ public class Configuration {
         return props.getProperty(name);
     }
 
+    public static String getRawStringProperty(Enum<? extends ConfigDefaults> name) {
+        return getRawStringProperty(name.toString());
+    }
+    public static String getRawStringProperty(String name) {
+        return props.getProperty(name);
+    }
+
+    public static boolean containsKey(String key) {
+        return props.containsKey(key);
+    }
+
     public int getIntegerProperty(Enum<? extends ConfigDefaults> name) {
         return getIntegerProperty(name.toString());
     }
@@ -155,10 +166,10 @@ public class Configuration {
         setProperty(name.toString(), value);
     }
 
-    public void clearProperty(String name) {
+    public static void clearProperty(String name) {
         props.remove(name);
     }
-    public void clearProperty(Enum<? extends ConfigDefaults> name) {
+    public static void clearProperty(Enum<? extends ConfigDefaults> name) {
         clearProperty(name.toString());
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -88,9 +88,7 @@ public class Configuration {
         return getStringProperty(name.toString());
     }
     public String getStringProperty(String name) {
-        if (System.getProperty(name) != null && !props.containsKey("original." + name)) {
-            if (props.containsKey(name))
-                props.put("original." + name, props.get(name));
+        if (System.getProperty(name) != null) {
             props.put(name, System.getProperty(name));
         }
         return props.getProperty(name);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -25,8 +25,8 @@ import java.net.URL;
 import java.util.*;
 
 public class Configuration {
-    private static final Properties defaultProps = new Properties();
-    private static Properties props;
+    public static final Properties defaultProps = new Properties();
+    public static Properties props;
     private static final Configuration INSTANCE = new Configuration();
 
     public static Configuration getInstance() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -88,7 +88,9 @@ public class Configuration {
         return getStringProperty(name.toString());
     }
     public String getStringProperty(String name) {
-        if (System.getProperty(name) != null) {
+        if (System.getProperty(name) != null && !props.containsKey("original." + name)) {
+            if (props.containsKey(name))
+                props.put("original." + name, props.get(name));
             props.put(name, System.getProperty(name));
         }
         return props.getProperty(name);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/Configuration.java
@@ -25,8 +25,8 @@ import java.net.URL;
 import java.util.*;
 
 public class Configuration {
-    public static final Properties defaultProps = new Properties();
-    public static Properties props;
+    private static final Properties defaultProps = new Properties();
+    private static Properties props;
     private static final Configuration INSTANCE = new Configuration();
 
     public static Configuration getInstance() {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -216,60 +216,6 @@ public class ConfigurationTest {
         }
     }
 
-    // originals
-
-    @Test
-    public void testGettingValuesCreatesOriginals() {
-
-        final String keyName = CoreConfig.ROLLUP_KEYSPACE.toString();
-
-        // The behavior of getStringProperty() when it creates new 'original.*'
-        // entries is very convoluted. It requires:
-        //  1. A system property named $NAME exists
-        //  2. A property named "original.$NAME" does NOT exist in the props object
-        //  3. A property named $NAME does exist in the props object
-        // Hence the calls to System.setProperty and config.setProperty below
-        // with different values. That way, we create the 'original.*' entry
-        // from the intended source and can test it.
-
-        try {
-            // arrange
-            Configuration config = Configuration.getInstance();
-
-            Map<Object, Object> props = config.getAllProperties();
-
-            // preconditions
-            Assert.assertTrue(
-                    "props should already have 'ROLLUP_KEYSPACE', because that's a default",
-                    props.containsKey(keyName));
-            Assert.assertFalse(
-                    "props should not contain 'original.ROLLUP_KEYSPACE' yet",
-                    props.containsKey("original." + keyName));
-
-            // act
-            System.setProperty(keyName, "some value");
-            config.setProperty(keyName, "some other value");
-            String value = config.getStringProperty(CoreConfig.ROLLUP_KEYSPACE);
-            Assert.assertEquals("some value", value);
-
-            // assert
-            Map<Object, Object> props2 = config.getAllProperties();
-
-            Assert.assertTrue(
-                    "props2 should already have 'ROLLUP_KEYSPACE', because that's a default",
-                    props2.containsKey(keyName));
-            Assert.assertTrue(
-                    "props2 should now contain 'original.ROLLUP_KEYSPACE'",
-                    props2.containsKey("original." + keyName));
-
-            Assert.assertEquals("some value", config.getStringProperty(CoreConfig.ROLLUP_KEYSPACE));
-            Assert.assertEquals("some other value", config.getStringProperty("original." + keyName));
-
-        } finally {
-            System.clearProperty(keyName);
-        }
-    }
-
     // getProperties
 
     @Test

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -270,6 +270,249 @@ public class ConfigurationTest {
         }
     }
 
+    @Test
+    public void testOriginals1() {
+
+        // arrange
+        final String keyName = "some-key-name";
+        final String keyName2 = "original." + keyName;
+        Configuration config = Configuration.getInstance();
+
+        try {
+            // precondition
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+
+            // act
+            String value = config.getStringProperty(keyName);
+
+            // assert
+            Assert.assertNull(value);
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+        } finally {
+            Configuration.props.remove(keyName);
+            Configuration.props.remove(keyName2);
+            System.clearProperty(keyName);
+        }
+    }
+
+    @Test
+    public void testOriginals2() {
+
+        // arrange
+        final String keyName = "some-key-name";
+        final String keyName2 = "original." + keyName;
+        Configuration config = Configuration.getInstance();
+
+        try {
+            // precondition
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+
+            // act
+            config.setProperty(keyName, "some value");
+            String value = config.getStringProperty(keyName);
+
+            // assert
+            Assert.assertEquals("some value", value);
+            Assert.assertTrue(Configuration.props.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+        } finally {
+            Configuration.props.remove(keyName);
+            Configuration.props.remove(keyName2);
+            System.clearProperty(keyName);
+        }
+    }
+
+    @Test
+    public void testOriginals3() {
+
+        // arrange
+        final String keyName = "some-key-name";
+        final String keyName2 = "original." + keyName;
+        Configuration config = Configuration.getInstance();
+
+        try {
+            // precondition
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+
+            // act
+            System.setProperty(keyName, "some value");
+            String value = config.getStringProperty(keyName);
+
+            // assert
+
+            Assert.assertEquals("some value", value);
+            Assert.assertTrue(Configuration.props.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+        } finally {
+            Configuration.props.remove(keyName);
+            Configuration.props.remove(keyName2);
+            System.clearProperty(keyName);
+        }
+    }
+
+    @Test
+    public void testOriginals4() {
+
+        // arrange
+        final String keyName = "some-key-name";
+        final String keyName2 = "original." + keyName;
+        Configuration config = Configuration.getInstance();
+
+        try {
+            // precondition
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+
+            // act
+            System.setProperty(keyName, "some value");
+            config.setProperty(keyName, "some other value");
+            String value = config.getStringProperty(keyName);
+
+            // assert
+
+            Assert.assertEquals("some value", value);
+            Assert.assertTrue(Configuration.props.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
+            Assert.assertTrue(Configuration.props.containsKey(keyName2));
+            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName2));
+        } finally {
+            Configuration.props.remove(keyName);
+            Configuration.props.remove(keyName2);
+            System.clearProperty(keyName);
+        }
+    }
+
+
+    @Test
+    public void testOriginals5() {
+
+        // arrange
+        final String keyName = "some-key-name";
+        final String keyName2 = "original." + keyName;
+        Configuration config = Configuration.getInstance();
+
+        try {
+            // precondition
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+
+            // act
+            config.setProperty(keyName2, "more value");
+            String value = config.getStringProperty(keyName);
+
+            // assert
+            Assert.assertNull(value);
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertTrue(Configuration.props.containsKey(keyName2));
+            Assert.assertEquals("more value", Configuration.props.getProperty(keyName2));
+        } finally {
+            Configuration.props.remove(keyName);
+            Configuration.props.remove(keyName2);
+            System.clearProperty(keyName);
+        }
+    }
+
+    @Test
+    public void testOriginals6() {
+
+        // arrange
+        final String keyName = "some-key-name";
+        final String keyName2 = "original." + keyName;
+        Configuration config = Configuration.getInstance();
+
+        try {
+            // precondition
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+
+            // act
+            config.setProperty(keyName, "some value");
+            config.setProperty(keyName2, "more value");
+            String value = config.getStringProperty(keyName);
+
+            // assert
+            Assert.assertEquals("some value", value);
+            Assert.assertTrue(Configuration.props.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
+            Assert.assertTrue(Configuration.props.containsKey(keyName2));
+            Assert.assertEquals("more value", Configuration.props.getProperty(keyName2));
+        } finally {
+            Configuration.props.remove(keyName);
+            Configuration.props.remove(keyName2);
+            System.clearProperty(keyName);
+        }
+    }
+
+    @Test
+    public void testOriginals7() {
+
+        // arrange
+        final String keyName = "some-key-name";
+        final String keyName2 = "original." + keyName;
+        Configuration config = Configuration.getInstance();
+
+        try {
+            // precondition
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+
+            // act
+            System.setProperty(keyName, "some value");
+            config.setProperty(keyName2, "more value");
+            String value = config.getStringProperty(keyName);
+
+            // assert
+
+            Assert.assertNull(value);
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertTrue(Configuration.props.containsKey(keyName2));
+            Assert.assertEquals("more value", Configuration.props.getProperty(keyName2));
+        } finally {
+            Configuration.props.remove(keyName);
+            Configuration.props.remove(keyName2);
+            System.clearProperty(keyName);
+        }
+    }
+
+    @Test
+    public void testOriginals8() {
+
+        // arrange
+        final String keyName = "some-key-name";
+        final String keyName2 = "original." + keyName;
+        Configuration config = Configuration.getInstance();
+
+        try {
+            // precondition
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+
+            // act
+            System.setProperty(keyName, "some value");
+            config.setProperty(keyName, "some other value");
+            config.setProperty(keyName2, "more value");
+            String value = config.getStringProperty(keyName);
+
+            // assert
+
+            Assert.assertEquals("some other value", value);
+            Assert.assertTrue(Configuration.props.containsKey(keyName));
+            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName));
+            Assert.assertTrue(Configuration.props.containsKey(keyName2));
+            Assert.assertEquals("more value", Configuration.props.getProperty(keyName2));
+        } finally {
+            Configuration.props.remove(keyName);
+            Configuration.props.remove(keyName2);
+            System.clearProperty(keyName);
+        }
+    }
+
     // getProperties
 
     @Test

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -216,6 +216,60 @@ public class ConfigurationTest {
         }
     }
 
+    // originals
+
+    @Test
+    public void testGettingValuesCreatesOriginals() {
+
+        final String keyName = CoreConfig.ROLLUP_KEYSPACE.toString();
+
+        // The behavior of getStringProperty() when it creates new 'original.*'
+        // entries is very convoluted. It requires:
+        //  1. A system property named $NAME exists
+        //  2. A property named "original.$NAME" does NOT exist in the props object
+        //  3. A property named $NAME does exist in the props object
+        // Hence the calls to System.setProperty and config.setProperty below
+        // with different values. That way, we create the 'original.*' entry
+        // from the intended source and can test it.
+
+        try {
+            // arrange
+            Configuration config = Configuration.getInstance();
+
+            Map<Object, Object> props = config.getAllProperties();
+
+            // preconditions
+            Assert.assertTrue(
+                    "props should already have 'ROLLUP_KEYSPACE', because that's a default",
+                    props.containsKey(keyName));
+            Assert.assertFalse(
+                    "props should not contain 'original.ROLLUP_KEYSPACE' yet",
+                    props.containsKey("original." + keyName));
+
+            // act
+            System.setProperty(keyName, "some value");
+            config.setProperty(keyName, "some other value");
+            String value = config.getStringProperty(CoreConfig.ROLLUP_KEYSPACE);
+            Assert.assertEquals("some value", value);
+
+            // assert
+            Map<Object, Object> props2 = config.getAllProperties();
+
+            Assert.assertTrue(
+                    "props2 should already have 'ROLLUP_KEYSPACE', because that's a default",
+                    props2.containsKey(keyName));
+            Assert.assertTrue(
+                    "props2 should now contain 'original.ROLLUP_KEYSPACE'",
+                    props2.containsKey("original." + keyName));
+
+            Assert.assertEquals("some value", config.getStringProperty(CoreConfig.ROLLUP_KEYSPACE));
+            Assert.assertEquals("some other value", config.getStringProperty("original." + keyName));
+
+        } finally {
+            System.clearProperty(keyName);
+        }
+    }
+
     // getProperties
 
     @Test

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -224,7 +224,7 @@ public class ConfigurationTest {
         }
     }
 
-    // originals
+    // originals, a.k.a. backup keys
 
     @Test
     public void testGettingValuesCreatesOriginals() {
@@ -279,7 +279,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testOriginals1() {
+    public void testWhenNoSyspropExistsAndTheKeyIsntPresentInConfigAndTheBackupKeyIsntPresentThenReturnValueShouldBeNullAndNoBackupCreated() {
 
         // arrange
         final String keyName = "some-key-name";
@@ -295,9 +295,16 @@ public class ConfigurationTest {
             String value = config.getStringProperty(keyName);
 
             // assert
+
+            // return value is null
             Assert.assertNull(value);
+
+            // the key is not present
             Assert.assertFalse(Configuration.containsKey(keyName));
+
+            // the backup key is not present
             Assert.assertFalse(Configuration.containsKey(keyName2));
+
         } finally {
             Configuration.clearProperty(keyName);
             Configuration.clearProperty(keyName2);
@@ -306,7 +313,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testOriginals2() {
+    public void testWhenNoSyspropExistsAndTheKeyIsPresentInConfigAndTheBackupKeyIsntPresentThenReturnValueShouldBeThePreviouslySetValueAndNoBackupCreated() {
 
         // arrange
         final String keyName = "some-key-name";
@@ -323,10 +330,17 @@ public class ConfigurationTest {
             String value = config.getStringProperty(keyName);
 
             // assert
+
+            // return value is previously-set value
             Assert.assertEquals("some value", value);
+
+            // key is present and its value is equal to what we set it to
             Assert.assertTrue(Configuration.containsKey(keyName));
             Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+
+            //backup key is not present
             Assert.assertFalse(Configuration.containsKey(keyName2));
+
         } finally {
             Configuration.clearProperty(keyName);
             Configuration.clearProperty(keyName2);
@@ -335,7 +349,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testOriginals3() {
+    public void testWhenSyspropExistsAndTheKeyIsntPresentInConfigAndTheBackupKeyIsntPresentThenReturnValueShouldBeSyspropValueAndNoBackupCreated() {
 
         // arrange
         final String keyName = "some-key-name";
@@ -353,10 +367,16 @@ public class ConfigurationTest {
 
             // assert
 
+            // return value is system property value
             Assert.assertEquals("some value", value);
+
+            // the key has been added and its value is that of the sysprop
             Assert.assertTrue(Configuration.containsKey(keyName));
             Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+
+            // the backup key has not been added
             Assert.assertFalse(Configuration.containsKey(keyName2));
+
         } finally {
             Configuration.clearProperty(keyName);
             Configuration.clearProperty(keyName2);
@@ -365,7 +385,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testOriginals4() {
+    public void testWhenSyspropExistsAndTheKeyIsPresentInConfigAndTheBackupKeyIsntPresentThenReturnValueShouldBeSyspropValueAndNoBackupCreated() {
 
         // arrange
         final String keyName = "some-key-name";
@@ -384,11 +404,17 @@ public class ConfigurationTest {
 
             // assert
 
+            // return value is the sysprop
             Assert.assertEquals("some value", value);
+
+            // the key is present and its value has been changed to that of the sysprop
             Assert.assertTrue(Configuration.containsKey(keyName));
             Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+
+            // the backup key has been added and its value is the previously-set value of the (non-backup) key
             Assert.assertTrue(Configuration.containsKey(keyName2));
             Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2));
+
         } finally {
             Configuration.clearProperty(keyName);
             Configuration.clearProperty(keyName2);
@@ -484,9 +510,8 @@ public class ConfigurationTest {
         }
     }
 
-
     @Test
-    public void testOriginals5() {
+    public void testWhenSyspropDoesntExistAndTheKeyIsntPresentInConfigAndTheBackupKeyIsPresentThenReturnValueShouldBeNullAndBackupRemainsAsIs() {
 
         // arrange
         final String keyName = "some-key-name";
@@ -503,10 +528,17 @@ public class ConfigurationTest {
             String value = config.getStringProperty(keyName);
 
             // assert
+
+            // return value is null
             Assert.assertNull(value);
+
+            // the key is not added
             Assert.assertFalse(Configuration.containsKey(keyName));
+
+            // the backup key is still present and has the same value
             Assert.assertTrue(Configuration.containsKey(keyName2));
             Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
+
         } finally {
             Configuration.clearProperty(keyName);
             Configuration.clearProperty(keyName2);
@@ -515,7 +547,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testOriginals6() {
+    public void testWhenSyspropDoesntExistAndTheKeyIsPresentInConfigAndTheBackupKeyIsPresentThenReturnValueShouldBeKeysValueAndBackupRemainsAsIs() {
 
         // arrange
         final String keyName = "some-key-name";
@@ -533,11 +565,18 @@ public class ConfigurationTest {
             String value = config.getStringProperty(keyName);
 
             // assert
+
+            // return value is previously-set value
             Assert.assertEquals("some value", value);
+
+            // key is present and its value is equal to what we set it to
             Assert.assertTrue(Configuration.containsKey(keyName));
             Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+
+            // the backup key is still present and has the same value
             Assert.assertTrue(Configuration.containsKey(keyName2));
             Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
+
         } finally {
             Configuration.clearProperty(keyName);
             Configuration.clearProperty(keyName2);
@@ -546,7 +585,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testOriginals7() {
+    public void testWhenSyspropExistsAndTheKeyIsntPresentInConfigAndTheBackupKeyIsPresentThenReturnValueShouldBeNullAndBackupRemainsAsIs() {
 
         // arrange
         final String keyName = "some-key-name";
@@ -565,10 +604,16 @@ public class ConfigurationTest {
 
             // assert
 
+            // return value is null (not sysprop as we might expect)
             Assert.assertNull(value);
+
+            // key is not present
             Assert.assertFalse(Configuration.containsKey(keyName));
+
+            // the backup key is still present and has the same value
             Assert.assertTrue(Configuration.containsKey(keyName2));
             Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
+
         } finally {
             Configuration.clearProperty(keyName);
             Configuration.clearProperty(keyName2);
@@ -577,7 +622,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testOriginals8() {
+    public void testWhenSyspropExistsAndTheKeyIsPresentInConfigAndTheBackupKeyIsPresentThenReturnValueShouldBeKeysValueAndBackupRemainsAsIs() {
 
         // arrange
         final String keyName = "some-key-name";
@@ -597,11 +642,17 @@ public class ConfigurationTest {
 
             // assert
 
+            // return value is null (not sysprop as we might expect)
             Assert.assertEquals("some other value", value);
+
+            // key is present and its value is equal to what we set it to
             Assert.assertTrue(Configuration.containsKey(keyName));
             Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName));
+
+            // the backup key is still present and has the same value
             Assert.assertTrue(Configuration.containsKey(keyName2));
             Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
+
         } finally {
             Configuration.clearProperty(keyName);
             Configuration.clearProperty(keyName2);

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -220,7 +220,7 @@ public class ConfigurationTest {
                     config.getStringProperty(CoreConfig.MAX_CASSANDRA_CONNECTIONS));
         } finally {
             System.clearProperty(keyName);
-            config.clearProperty(keyName);
+            Configuration.clearProperty(keyName);
         }
     }
 
@@ -288,19 +288,19 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
 
             // act
             String value = config.getStringProperty(keyName);
 
             // assert
             Assert.assertNull(value);
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
         } finally {
-            Configuration.props.remove(keyName);
-            Configuration.props.remove(keyName2);
+            Configuration.clearProperty(keyName);
+            Configuration.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -315,8 +315,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
 
             // act
             config.setProperty(keyName, "some value");
@@ -324,12 +324,12 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertEquals("some value", value);
-            Assert.assertTrue(Configuration.props.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertTrue(Configuration.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
         } finally {
-            Configuration.props.remove(keyName);
-            Configuration.props.remove(keyName2);
+            Configuration.clearProperty(keyName);
+            Configuration.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -344,8 +344,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");
@@ -354,12 +354,12 @@ public class ConfigurationTest {
             // assert
 
             Assert.assertEquals("some value", value);
-            Assert.assertTrue(Configuration.props.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertTrue(Configuration.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
         } finally {
-            Configuration.props.remove(keyName);
-            Configuration.props.remove(keyName2);
+            Configuration.clearProperty(keyName);
+            Configuration.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -374,8 +374,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");
@@ -385,13 +385,13 @@ public class ConfigurationTest {
             // assert
 
             Assert.assertEquals("some value", value);
-            Assert.assertTrue(Configuration.props.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
-            Assert.assertTrue(Configuration.props.containsKey(keyName2));
-            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName2));
+            Assert.assertTrue(Configuration.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(Configuration.containsKey(keyName2));
+            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2));
         } finally {
-            Configuration.props.remove(keyName);
-            Configuration.props.remove(keyName2);
+            Configuration.clearProperty(keyName);
+            Configuration.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -406,8 +406,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");              // A
@@ -416,10 +416,10 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertEquals("some value", value); // equal to the sysprop A
-            Assert.assertTrue(Configuration.props.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
-            Assert.assertTrue(Configuration.props.containsKey(keyName2));
-            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName2));
+            Assert.assertTrue(Configuration.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(Configuration.containsKey(keyName2));
+            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2));
 
             // act
             System.setProperty(keyName, "another value");           // C
@@ -428,14 +428,14 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertEquals("another another value", value2); // _not_ equal to the sysprop C
-            Assert.assertTrue(Configuration.props.containsKey(keyName));
-            Assert.assertEquals("another another value", Configuration.props.getProperty(keyName));
-            Assert.assertTrue(Configuration.props.containsKey(keyName2));
-            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName2));
+            Assert.assertTrue(Configuration.containsKey(keyName));
+            Assert.assertEquals("another another value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(Configuration.containsKey(keyName2));
+            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2));
 
         } finally {
-            Configuration.props.remove(keyName);
-            Configuration.props.remove(keyName2);
+            Configuration.clearProperty(keyName);
+            Configuration.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -450,8 +450,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");              // A
@@ -460,10 +460,10 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertEquals("some value", value);
-            Assert.assertTrue(Configuration.props.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
-            Assert.assertTrue(Configuration.props.containsKey(keyName2));
-            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName2)); // equal to config value B
+            Assert.assertTrue(Configuration.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(Configuration.containsKey(keyName2));
+            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2)); // equal to config value B
 
             // act
             System.setProperty(keyName, "another value");           // C
@@ -472,14 +472,14 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertEquals("another another value", value2);
-            Assert.assertTrue(Configuration.props.containsKey(keyName));
-            Assert.assertEquals("another another value", Configuration.props.getProperty(keyName));
-            Assert.assertTrue(Configuration.props.containsKey(keyName2));
-            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName2)); // _still_ equal to config value B
+            Assert.assertTrue(Configuration.containsKey(keyName));
+            Assert.assertEquals("another another value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(Configuration.containsKey(keyName2));
+            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2)); // _still_ equal to config value B
 
         } finally {
-            Configuration.props.remove(keyName);
-            Configuration.props.remove(keyName2);
+            Configuration.clearProperty(keyName);
+            Configuration.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -495,8 +495,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
 
             // act
             config.setProperty(keyName2, "more value");
@@ -504,12 +504,12 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertNull(value);
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertTrue(Configuration.props.containsKey(keyName2));
-            Assert.assertEquals("more value", Configuration.props.getProperty(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertTrue(Configuration.containsKey(keyName2));
+            Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
         } finally {
-            Configuration.props.remove(keyName);
-            Configuration.props.remove(keyName2);
+            Configuration.clearProperty(keyName);
+            Configuration.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -524,8 +524,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
 
             // act
             config.setProperty(keyName, "some value");
@@ -534,13 +534,13 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertEquals("some value", value);
-            Assert.assertTrue(Configuration.props.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
-            Assert.assertTrue(Configuration.props.containsKey(keyName2));
-            Assert.assertEquals("more value", Configuration.props.getProperty(keyName2));
+            Assert.assertTrue(Configuration.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(Configuration.containsKey(keyName2));
+            Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
         } finally {
-            Configuration.props.remove(keyName);
-            Configuration.props.remove(keyName2);
+            Configuration.clearProperty(keyName);
+            Configuration.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -555,8 +555,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");
@@ -566,12 +566,12 @@ public class ConfigurationTest {
             // assert
 
             Assert.assertNull(value);
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertTrue(Configuration.props.containsKey(keyName2));
-            Assert.assertEquals("more value", Configuration.props.getProperty(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertTrue(Configuration.containsKey(keyName2));
+            Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
         } finally {
-            Configuration.props.remove(keyName);
-            Configuration.props.remove(keyName2);
+            Configuration.clearProperty(keyName);
+            Configuration.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -586,8 +586,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.props.containsKey(keyName));
-            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(Configuration.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");
@@ -598,13 +598,13 @@ public class ConfigurationTest {
             // assert
 
             Assert.assertEquals("some other value", value);
-            Assert.assertTrue(Configuration.props.containsKey(keyName));
-            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName));
-            Assert.assertTrue(Configuration.props.containsKey(keyName2));
-            Assert.assertEquals("more value", Configuration.props.getProperty(keyName2));
+            Assert.assertTrue(Configuration.containsKey(keyName));
+            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(Configuration.containsKey(keyName2));
+            Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
         } finally {
-            Configuration.props.remove(keyName);
-            Configuration.props.remove(keyName2);
+            Configuration.clearProperty(keyName);
+            Configuration.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -388,6 +388,94 @@ public class ConfigurationTest {
         }
     }
 
+    @Test
+    public void testAfterAnOriginalIsCreatedSystemPropertyNoLongerOverrides() {
+
+        // arrange
+        final String keyName = "some-key-name";
+        final String keyName2 = "original." + keyName;
+        Configuration config = Configuration.getInstance();
+
+        try {
+            // precondition
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+
+            // act
+            System.setProperty(keyName, "some value");              // A
+            config.setProperty(keyName, "some other value");        // B
+            String value = config.getStringProperty(keyName);
+
+            // assert
+            Assert.assertEquals("some value", value); // equal to the sysprop A
+            Assert.assertTrue(Configuration.props.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
+            Assert.assertTrue(Configuration.props.containsKey(keyName2));
+            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName2));
+
+            // act
+            System.setProperty(keyName, "another value");           // C
+            config.setProperty(keyName, "another another value");   // D
+            String value2 = config.getStringProperty(keyName);
+
+            // assert
+            Assert.assertEquals("another another value", value2); // _not_ equal to the sysprop C
+            Assert.assertTrue(Configuration.props.containsKey(keyName));
+            Assert.assertEquals("another another value", Configuration.props.getProperty(keyName));
+            Assert.assertTrue(Configuration.props.containsKey(keyName2));
+            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName2));
+
+        } finally {
+            Configuration.props.remove(keyName);
+            Configuration.props.remove(keyName2);
+            System.clearProperty(keyName);
+        }
+    }
+
+    @Test
+    public void testAfterAnOriginalIsCreatedItIsNeverUpdated() {
+
+        // arrange
+        final String keyName = "some-key-name";
+        final String keyName2 = "original." + keyName;
+        Configuration config = Configuration.getInstance();
+
+        try {
+            // precondition
+            Assert.assertFalse(Configuration.props.containsKey(keyName));
+            Assert.assertFalse(Configuration.props.containsKey(keyName2));
+
+            // act
+            System.setProperty(keyName, "some value");              // A
+            config.setProperty(keyName, "some other value");        // B
+            String value = config.getStringProperty(keyName);
+
+            // assert
+            Assert.assertEquals("some value", value);
+            Assert.assertTrue(Configuration.props.containsKey(keyName));
+            Assert.assertEquals("some value", Configuration.props.getProperty(keyName));
+            Assert.assertTrue(Configuration.props.containsKey(keyName2));
+            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName2)); // equal to config value B
+
+            // act
+            System.setProperty(keyName, "another value");           // C
+            config.setProperty(keyName, "another another value");   // D
+            String value2 = config.getStringProperty(keyName);
+
+            // assert
+            Assert.assertEquals("another another value", value2);
+            Assert.assertTrue(Configuration.props.containsKey(keyName));
+            Assert.assertEquals("another another value", Configuration.props.getProperty(keyName));
+            Assert.assertTrue(Configuration.props.containsKey(keyName2));
+            Assert.assertEquals("some other value", Configuration.props.getProperty(keyName2)); // _still_ equal to config value B
+
+        } finally {
+            Configuration.props.remove(keyName);
+            Configuration.props.remove(keyName2);
+            System.clearProperty(keyName);
+        }
+    }
+
 
     @Test
     public void testOriginals5() {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -220,7 +220,7 @@ public class ConfigurationTest {
                     config.getStringProperty(CoreConfig.MAX_CASSANDRA_CONNECTIONS));
         } finally {
             System.clearProperty(keyName);
-            Configuration.clearProperty(keyName);
+            config.clearProperty(keyName);
         }
     }
 
@@ -288,8 +288,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.containsKey(keyName));
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName2));
 
             // act
             String value = config.getStringProperty(keyName);
@@ -300,14 +300,14 @@ public class ConfigurationTest {
             Assert.assertNull(value);
 
             // the key is not present
-            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName));
 
             // the backup key is not present
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName2));
 
         } finally {
-            Configuration.clearProperty(keyName);
-            Configuration.clearProperty(keyName2);
+            config.clearProperty(keyName);
+            config.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -322,8 +322,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.containsKey(keyName));
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName2));
 
             // act
             config.setProperty(keyName, "some value");
@@ -335,15 +335,15 @@ public class ConfigurationTest {
             Assert.assertEquals("some value", value);
 
             // key is present and its value is equal to what we set it to
-            Assert.assertTrue(Configuration.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(config.containsKey(keyName));
+            Assert.assertEquals("some value", config.getRawStringProperty(keyName));
 
             //backup key is not present
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName2));
 
         } finally {
-            Configuration.clearProperty(keyName);
-            Configuration.clearProperty(keyName2);
+            config.clearProperty(keyName);
+            config.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -358,8 +358,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.containsKey(keyName));
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");
@@ -371,15 +371,15 @@ public class ConfigurationTest {
             Assert.assertEquals("some value", value);
 
             // the key has been added and its value is that of the sysprop
-            Assert.assertTrue(Configuration.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(config.containsKey(keyName));
+            Assert.assertEquals("some value", config.getRawStringProperty(keyName));
 
             // the backup key has not been added
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName2));
 
         } finally {
-            Configuration.clearProperty(keyName);
-            Configuration.clearProperty(keyName2);
+            config.clearProperty(keyName);
+            config.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -394,8 +394,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.containsKey(keyName));
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");
@@ -408,16 +408,16 @@ public class ConfigurationTest {
             Assert.assertEquals("some value", value);
 
             // the key is present and its value has been changed to that of the sysprop
-            Assert.assertTrue(Configuration.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(config.containsKey(keyName));
+            Assert.assertEquals("some value", config.getRawStringProperty(keyName));
 
             // the backup key has been added and its value is the previously-set value of the (non-backup) key
-            Assert.assertTrue(Configuration.containsKey(keyName2));
-            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2));
+            Assert.assertTrue(config.containsKey(keyName2));
+            Assert.assertEquals("some other value", config.getRawStringProperty(keyName2));
 
         } finally {
-            Configuration.clearProperty(keyName);
-            Configuration.clearProperty(keyName2);
+            config.clearProperty(keyName);
+            config.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -432,8 +432,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.containsKey(keyName));
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");              // A
@@ -442,10 +442,10 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertEquals("some value", value); // equal to the sysprop A
-            Assert.assertTrue(Configuration.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
-            Assert.assertTrue(Configuration.containsKey(keyName2));
-            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2));
+            Assert.assertTrue(config.containsKey(keyName));
+            Assert.assertEquals("some value", config.getRawStringProperty(keyName));
+            Assert.assertTrue(config.containsKey(keyName2));
+            Assert.assertEquals("some other value", config.getRawStringProperty(keyName2));
 
             // act
             System.setProperty(keyName, "another value");           // C
@@ -454,14 +454,14 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertEquals("another another value", value2); // _not_ equal to the sysprop C
-            Assert.assertTrue(Configuration.containsKey(keyName));
-            Assert.assertEquals("another another value", Configuration.getRawStringProperty(keyName));
-            Assert.assertTrue(Configuration.containsKey(keyName2));
-            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2));
+            Assert.assertTrue(config.containsKey(keyName));
+            Assert.assertEquals("another another value", config.getRawStringProperty(keyName));
+            Assert.assertTrue(config.containsKey(keyName2));
+            Assert.assertEquals("some other value", config.getRawStringProperty(keyName2));
 
         } finally {
-            Configuration.clearProperty(keyName);
-            Configuration.clearProperty(keyName2);
+            config.clearProperty(keyName);
+            config.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -476,8 +476,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.containsKey(keyName));
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");              // A
@@ -486,10 +486,10 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertEquals("some value", value);
-            Assert.assertTrue(Configuration.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
-            Assert.assertTrue(Configuration.containsKey(keyName2));
-            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2)); // equal to config value B
+            Assert.assertTrue(config.containsKey(keyName));
+            Assert.assertEquals("some value", config.getRawStringProperty(keyName));
+            Assert.assertTrue(config.containsKey(keyName2));
+            Assert.assertEquals("some other value", config.getRawStringProperty(keyName2)); // equal to config value B
 
             // act
             System.setProperty(keyName, "another value");           // C
@@ -498,14 +498,14 @@ public class ConfigurationTest {
 
             // assert
             Assert.assertEquals("another another value", value2);
-            Assert.assertTrue(Configuration.containsKey(keyName));
-            Assert.assertEquals("another another value", Configuration.getRawStringProperty(keyName));
-            Assert.assertTrue(Configuration.containsKey(keyName2));
-            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName2)); // _still_ equal to config value B
+            Assert.assertTrue(config.containsKey(keyName));
+            Assert.assertEquals("another another value", config.getRawStringProperty(keyName));
+            Assert.assertTrue(config.containsKey(keyName2));
+            Assert.assertEquals("some other value", config.getRawStringProperty(keyName2)); // _still_ equal to config value B
 
         } finally {
-            Configuration.clearProperty(keyName);
-            Configuration.clearProperty(keyName2);
+            config.clearProperty(keyName);
+            config.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -520,8 +520,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.containsKey(keyName));
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName2));
 
             // act
             config.setProperty(keyName2, "more value");
@@ -533,15 +533,15 @@ public class ConfigurationTest {
             Assert.assertNull(value);
 
             // the key is not added
-            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName));
 
             // the backup key is still present and has the same value
-            Assert.assertTrue(Configuration.containsKey(keyName2));
-            Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
+            Assert.assertTrue(config.containsKey(keyName2));
+            Assert.assertEquals("more value", config.getRawStringProperty(keyName2));
 
         } finally {
-            Configuration.clearProperty(keyName);
-            Configuration.clearProperty(keyName2);
+            config.clearProperty(keyName);
+            config.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -556,8 +556,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.containsKey(keyName));
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName2));
 
             // act
             config.setProperty(keyName, "some value");
@@ -570,16 +570,16 @@ public class ConfigurationTest {
             Assert.assertEquals("some value", value);
 
             // key is present and its value is equal to what we set it to
-            Assert.assertTrue(Configuration.containsKey(keyName));
-            Assert.assertEquals("some value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(config.containsKey(keyName));
+            Assert.assertEquals("some value", config.getRawStringProperty(keyName));
 
             // the backup key is still present and has the same value
-            Assert.assertTrue(Configuration.containsKey(keyName2));
-            Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
+            Assert.assertTrue(config.containsKey(keyName2));
+            Assert.assertEquals("more value", config.getRawStringProperty(keyName2));
 
         } finally {
-            Configuration.clearProperty(keyName);
-            Configuration.clearProperty(keyName2);
+            config.clearProperty(keyName);
+            config.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -594,8 +594,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.containsKey(keyName));
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");
@@ -608,15 +608,15 @@ public class ConfigurationTest {
             Assert.assertNull(value);
 
             // key is not present
-            Assert.assertFalse(Configuration.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName));
 
             // the backup key is still present and has the same value
-            Assert.assertTrue(Configuration.containsKey(keyName2));
-            Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
+            Assert.assertTrue(config.containsKey(keyName2));
+            Assert.assertEquals("more value", config.getRawStringProperty(keyName2));
 
         } finally {
-            Configuration.clearProperty(keyName);
-            Configuration.clearProperty(keyName2);
+            config.clearProperty(keyName);
+            config.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }
@@ -631,8 +631,8 @@ public class ConfigurationTest {
 
         try {
             // precondition
-            Assert.assertFalse(Configuration.containsKey(keyName));
-            Assert.assertFalse(Configuration.containsKey(keyName2));
+            Assert.assertFalse(config.containsKey(keyName));
+            Assert.assertFalse(config.containsKey(keyName2));
 
             // act
             System.setProperty(keyName, "some value");
@@ -646,16 +646,16 @@ public class ConfigurationTest {
             Assert.assertEquals("some other value", value);
 
             // key is present and its value is equal to what we set it to
-            Assert.assertTrue(Configuration.containsKey(keyName));
-            Assert.assertEquals("some other value", Configuration.getRawStringProperty(keyName));
+            Assert.assertTrue(config.containsKey(keyName));
+            Assert.assertEquals("some other value", config.getRawStringProperty(keyName));
 
             // the backup key is still present and has the same value
-            Assert.assertTrue(Configuration.containsKey(keyName2));
-            Assert.assertEquals("more value", Configuration.getRawStringProperty(keyName2));
+            Assert.assertTrue(config.containsKey(keyName2));
+            Assert.assertEquals("more value", config.getRawStringProperty(keyName2));
 
         } finally {
-            Configuration.clearProperty(keyName);
-            Configuration.clearProperty(keyName2);
+            config.clearProperty(keyName);
+            config.clearProperty(keyName2);
             System.clearProperty(keyName);
         }
     }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ConfigurationTest.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.service;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,6 +27,13 @@ import java.util.List;
 import java.util.Map;
 
 public class ConfigurationTest {
+
+    @After
+    public void tearDown() throws IOException {
+
+        // this resets the configuration after each test method invocation
+        Configuration.getInstance().init();
+    }
 
     @Test
     public void testConfiguration() {


### PR DESCRIPTION
In my previous PR, #597 , I had said that I next wanted to remove the side effects of `getStringProperty`. However, it's still a little too early to do that. Lots of the code relies on that method and doesn't yet have sufficient tests. Before I make that change I want to create more tests across the codebase.

This PR adds several tests that completely describe the overriding behavior of `getStringProperty`. These will be useful when we start changing the method's behavior.

This PR also adds some methods for manually reading, setting, and clearing values within the `Configuration` object, without manually dealing with system properties in the code. These will be useful in the next part, when I modify the codebase to use them instead of the sysprops.

Here's my checklist, roughly in order, of things I intend to do next:

- [x] clarify the overriding behavior
- [ ] change existing code and tests to use `setProperty` and similar methods, instead of setting system properties
- [ ] write a ton of tests for large portions of the codebase
- [ ] don't back up values under `original.*` keys
- [ ] don't store the values of system properties, just return them
- [ ] use independent instances of the class, instead of just a singleton