### PR TITLE
get rid of using files to serialize objects

### DIFF
--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/CounterRollupSerializationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/CounterRollupSerializationTest.java
@@ -13,21 +13,14 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package com.rackspacecloud.blueflood.io.serializers;
 
-import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.types.BluefloodCounterRollup;
 import junit.framework.Assert;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.nio.ByteBuffer;
 
 public class CounterRollupSerializationTest {
@@ -36,37 +29,25 @@ public class CounterRollupSerializationTest {
     public void testCounterV1RoundTrip() throws IOException {
         BluefloodCounterRollup c0 = new BluefloodCounterRollup().withCount(7442245).withSampleCount(1);
         BluefloodCounterRollup c1 = new BluefloodCounterRollup().withCount(34454722343L).withSampleCount(10);
-        
-        if (System.getProperty("GENERATE_COUNTER_SERIALIZATION") != null) {
-            OutputStream os = new FileOutputStream("src/test/resources/serializations/counter_version_" + Constants.VERSION_1_COUNTER_ROLLUP + ".bin", false);
-            os.write(Base64.encodeBase64(new NumericSerializer.CounterRollupSerializer().toByteBuffer(c0).array()));
-            os.write("\n".getBytes());
-            os.write(Base64.encodeBase64(new NumericSerializer.CounterRollupSerializer().toByteBuffer(c1).array()));
-            os.write("\n".getBytes());
-            os.close();
-        }
-        
-        Assert.assertTrue(new File("src/test/resources/serializations").exists());
-                
-        int count = 0;
-        int version = 0;
-        final int maxVersion = Constants.VERSION_1_COUNTER_ROLLUP;
-        while (version <= maxVersion) {
-            BufferedReader reader = new BufferedReader(new FileReader("src/test/resources/serializations/counter_version_" + version + ".bin"));
-            
-            ByteBuffer bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
-            BluefloodCounterRollup cc0 = NumericSerializer.serializerFor(BluefloodCounterRollup.class).fromByteBuffer(bb);
-            Assert.assertEquals(c0, cc0);
-            
-            bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
-            BluefloodCounterRollup cc1 = NumericSerializer.serializerFor(BluefloodCounterRollup.class).fromByteBuffer(bb);
-            Assert.assertEquals(c1, cc1);
-            
-            Assert.assertFalse(cc0.equals(cc1));
-            version++;
-            count++;
-        }
-        
-        Assert.assertTrue(count > 0);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        baos.write(Base64.encodeBase64(new NumericSerializer.CounterRollupSerializer().toByteBuffer(c0).array()));
+        baos.write("\n".getBytes());
+        baos.write(Base64.encodeBase64(new NumericSerializer.CounterRollupSerializer().toByteBuffer(c1).array()));
+        baos.write("\n".getBytes());
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        BufferedReader reader = new BufferedReader(new InputStreamReader(bais));
+
+        ByteBuffer bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
+        BluefloodCounterRollup cc0 = NumericSerializer.serializerFor(BluefloodCounterRollup.class).fromByteBuffer(bb);
+        Assert.assertEquals(c0, cc0);
+
+        bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
+        BluefloodCounterRollup cc1 = NumericSerializer.serializerFor(BluefloodCounterRollup.class).fromByteBuffer(bb);
+
+        Assert.assertEquals(c1, cc1);
+        Assert.assertFalse(cc0.equals(cc1));
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/EnumRollupSerializationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/EnumRollupSerializationTest.java
@@ -13,15 +13,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-
-
 package com.rackspacecloud.blueflood.io.serializers;
 
-import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.types.BluefloodEnumRollup;
 import com.rackspacecloud.blueflood.types.BluefloodEnumRollupTest;
-import com.rackspacecloud.blueflood.types.Points;
 import junit.framework.Assert;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
@@ -45,48 +40,35 @@ public class EnumRollupSerializationTest {
         Assert.assertTrue(map.get((long)"enumValue1".hashCode()) == 3L);
         Assert.assertTrue(map.get((long)"enumValue2".hashCode()) == 15L);
 
-        if (System.getProperty("GENERATE_ENUM_SERIALIZATION") != null) {
-            OutputStream os = new FileOutputStream("src/test/resources/serializations/enum_version_" + Constants.VERSION_1_ENUM_ROLLUP + ".bin", false);
-            os.write(Base64.encodeBase64(new NumericSerializer.EnumRollupSerializer().toByteBuffer(e0).array()));
-            os.write("\n".getBytes());
-            os.write(Base64.encodeBase64(new NumericSerializer.EnumRollupSerializer().toByteBuffer(e1).array()));
-            os.write("\n".getBytes());
-            os.write(Base64.encodeBase64(new NumericSerializer.EnumRollupSerializer().toByteBuffer(e2).array()));
-            os.write("\n".getBytes());
-            os.write(Base64.encodeBase64(new NumericSerializer.EnumRollupSerializer().toByteBuffer(er).array()));
-            os.write("\n".getBytes());
-            os.close();
-        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(Base64.encodeBase64(new NumericSerializer.EnumRollupSerializer().toByteBuffer(e0).array()));
+        baos.write("\n".getBytes());
+        baos.write(Base64.encodeBase64(new NumericSerializer.EnumRollupSerializer().toByteBuffer(e1).array()));
+        baos.write("\n".getBytes());
+        baos.write(Base64.encodeBase64(new NumericSerializer.EnumRollupSerializer().toByteBuffer(e2).array()));
+        baos.write("\n".getBytes());
+        baos.write(Base64.encodeBase64(new NumericSerializer.EnumRollupSerializer().toByteBuffer(er).array()));
+        baos.write("\n".getBytes());
+        baos.close();
 
-        Assert.assertTrue(new File("src/test/resources/serializations").exists());
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())));
 
-        int count = 0;
-        int version = 0;
-        final int maxVersion = Constants.VERSION_1_ENUM_ROLLUP;
-        while (version <= maxVersion) {
-            BufferedReader reader = new BufferedReader(new FileReader("src/test/resources/serializations/enum_version_" + version + ".bin"));
+        ByteBuffer bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
+        BluefloodEnumRollup ee0 = NumericSerializer.serializerFor(BluefloodEnumRollup.class).fromByteBuffer(bb);
+        Assert.assertEquals(e0, ee0);
 
-            ByteBuffer bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
-            BluefloodEnumRollup ee0 = NumericSerializer.serializerFor(BluefloodEnumRollup.class).fromByteBuffer(bb);
-            Assert.assertEquals(e0, ee0);
+        bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
+        BluefloodEnumRollup ee1 = NumericSerializer.serializerFor(BluefloodEnumRollup.class).fromByteBuffer(bb);
+        Assert.assertEquals(e1, ee1);
 
-            bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
-            BluefloodEnumRollup ee1 = NumericSerializer.serializerFor(BluefloodEnumRollup.class).fromByteBuffer(bb);
-            Assert.assertEquals(e1, ee1);
+        bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
+        BluefloodEnumRollup ee2 = NumericSerializer.serializerFor(BluefloodEnumRollup.class).fromByteBuffer(bb);
+        Assert.assertEquals(e2, ee2);
 
-            bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
-            BluefloodEnumRollup ee2 = NumericSerializer.serializerFor(BluefloodEnumRollup.class).fromByteBuffer(bb);
-            Assert.assertEquals(e2, ee2);
+        bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
+        BluefloodEnumRollup ee3 = NumericSerializer.serializerFor(BluefloodEnumRollup.class).fromByteBuffer(bb);
+        Assert.assertEquals(er, ee3);
 
-            bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
-            BluefloodEnumRollup ee3 = NumericSerializer.serializerFor(BluefloodEnumRollup.class).fromByteBuffer(bb);
-            Assert.assertEquals(er, ee3);
-
-            Assert.assertFalse(ee0.equals(ee1));
-            version++;
-            count++;
-        }
-
-        Assert.assertTrue(count > 0);
+        Assert.assertFalse(ee0.equals(ee1));
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/HistogramSerializationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/HistogramSerializationTest.java
@@ -13,12 +13,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package com.rackspacecloud.blueflood.io.serializers;
 
 import com.bigml.histogram.Bin;
 import com.bigml.histogram.SimpleTarget;
-import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.types.*;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Assert;
@@ -49,27 +47,17 @@ public class HistogramSerializationTest {
 
     @Test
     public void testSerializationDeserializationVersion1() throws Exception {
-        if (System.getProperty("GENERATE_HIST_SERIALIZATION") != null) {
-            OutputStream os = new FileOutputStream("src/test/resources/serializations/histogram_version_" +
-                    Constants.VERSION_1_HISTOGRAM + ".bin", false);
 
-            os.write(Base64.encodeBase64(HistogramSerializer.get().toByteBuffer(histogramRollup).array()));
-            os.write("\n".getBytes());
-            os.close();
-        }
-
-        Assert.assertTrue(new File("src/test/resources/serializations").exists());
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(Base64.encodeBase64(HistogramSerializer.get().toByteBuffer(histogramRollup).array()));
+        baos.write("\n".getBytes());
+        baos.close();
 
         // ensure we can read historical serializations.
-        int version = 0;
-        int maxVersion = Constants.VERSION_1_HISTOGRAM;
-        while (version <= maxVersion) {
-            BufferedReader reader = new BufferedReader(new FileReader("src/test/resources/serializations/histogram_version_" + version + ".bin"));
-            ByteBuffer bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
-            HistogramRollup histogramRollupDes = HistogramSerializer.get().fromByteBuffer(bb);
-            Assert.assertTrue(areHistogramsEqual(histogramRollup, histogramRollupDes));
-            version++;
-        }
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())));
+        ByteBuffer bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
+        HistogramRollup histogramRollupDes = HistogramSerializer.get().fromByteBuffer(bb);
+        Assert.assertTrue(areHistogramsEqual(histogramRollup, histogramRollupDes));
     }
 
     @Test

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/TimerSerializationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/serializers/TimerSerializationTest.java
@@ -16,18 +16,12 @@
 
 package com.rackspacecloud.blueflood.io.serializers;
 
-import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.types.BluefloodTimerRollup;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.nio.ByteBuffer;
 
 public class TimerSerializationTest {
@@ -46,19 +40,13 @@ public class TimerSerializationTest {
         r0.setPercentile("foo", 741.32d);
         r0.setPercentile("bar", 0.0323d);
 
-        if (System.getProperty("GENERATE_TIMER_SERIALIZATION") != null) {
-            OutputStream os = new FileOutputStream("src/test/resources/serializations/timer_version_" + Constants.VERSION_1_TIMER + ".bin", false);
-            //The V1 serialization is artificially constructed for the purposes of this test and should no longer be used.
-            os.write(Base64.encodeBase64(new NumericSerializer.TimerRollupSerializer().toByteBufferWithV1Serialization(r0).array()));
-            os.write("\n".getBytes());
-            os.close();
-        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        //The V1 serialization is artificially constructed for the purposes of this test and should no longer be used.
+        baos.write(Base64.encodeBase64(new NumericSerializer.TimerRollupSerializer().toByteBufferWithV1Serialization(r0).array()));
+        baos.write("\n".getBytes());
+        baos.close();
 
-        Assert.assertTrue(new File("src/test/resources/serializations").exists());
-
-        int version = 0;
-
-        BufferedReader reader = new BufferedReader(new FileReader("src/test/resources/serializations/timer_version_" + version + ".bin"));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())));
         ByteBuffer bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
         BluefloodTimerRollup r1 = new NumericSerializer.TimerRollupSerializer().fromByteBuffer(bb);
         Assert.assertEquals(r0, r1);
@@ -78,29 +66,14 @@ public class TimerSerializationTest {
         r0.setPercentile("foo", 741.32d);
         r0.setPercentile("bar", 0.0323d);
 
-        if (System.getProperty("GENERATE_TIMER_SERIALIZATION") != null) {
-            OutputStream os = new FileOutputStream("src/test/resources/serializations/timer_version_" + Constants.VERSION_2_TIMER + ".bin", false);
-            os.write(Base64.encodeBase64(new NumericSerializer.TimerRollupSerializer().toByteBuffer(r0).array()));
-            os.write("\n".getBytes());
-            os.close();
-        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(Base64.encodeBase64(new NumericSerializer.TimerRollupSerializer().toByteBuffer(r0).array()));
+        baos.write("\n".getBytes());
+        baos.close();
 
-        Assert.assertTrue(new File("src/test/resources/serializations").exists());
-
-        // ensure historical reads work.
-        int version = 0;
-        int maxVersion = Constants.VERSION_2_TIMER;
-
-        int count = 0;
-        while (version <= maxVersion) {
-            BufferedReader reader = new BufferedReader(new FileReader("src/test/resources/serializations/timer_version_" + version + ".bin"));
-            ByteBuffer bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
-            BluefloodTimerRollup r1 = new NumericSerializer.TimerRollupSerializer().fromByteBuffer(bb);
-            Assert.assertEquals(r0, r1);
-            count++;
-            version++;
-        }
-
-        Assert.assertTrue("Nothing was tested", count > 0);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())));
+        ByteBuffer bb = ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes()));
+        BluefloodTimerRollup r1 = new NumericSerializer.TimerRollupSerializer().fromByteBuffer(bb);
+        Assert.assertEquals(r0, r1);
     }
 }


### PR DESCRIPTION
**Why:**
In order to improve test coverage, we need to be testing the serializer code. Our tests currently gated the serializing code with a system property: GENERATE_*_SERIALIZATION. We never run tests with these system properties set. We used a set of files that were generated a long time ago and these files were checked into Git.

**How:**
I am doing this incrementally. This is the first of many PRs to clean up the tests. With this PR, I am removing our use of the files checked in under ```src/test/resources/serializations``` directory. Everytime we run the tests, we serialize the objects into memory, and de-serialize them back into objects.

I am also getting rid of the loop that supposedly test back serialization/deserialization of older versions. We don't have older versions for most objects. We just have version 1 (whose value is 0). When we do have the next version in the future, we should write them as new methods, instead of testing them all in one method (which btw already has the name V1).
