### PR TITLE
upgrade maven-coverall-plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
       <plugin>
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>4.1.0</version>
         <configuration>
           <jacocoReports>
             <jacocoReport>blueflood-core/target/site/jacoco/jacoco.xml</jacocoReport>


### PR DESCRIPTION
Upgrade to the latest maven-coverall-plugins. In version 4.0.0, they have added a way to combine multiple coverage reports
https://github.com/trautonen/coveralls-maven-plugin/blob/master/CHANGELOG.md#400