### PR TITLE
fix(blueflood-elasticsearch): Make init-es script take cli args

### DIFF
--- a/blueflood-elasticsearch/src/main/resources/init-es.sh
+++ b/blueflood-elasticsearch/src/main/resources/init-es.sh
@@ -2,9 +2,10 @@
 # init-es.sh is the script to be run to properly setup the es cluster.  The main things
 #  it does is set up the aliases and mappings as required by BF.  The mappings
 #  are required to properly tokenize the incoming data.
-
+# You can pass it a url if your elastic search doesn't reside on localhost:9092
 #WARNING: this script will destroy existing ES data and reset it to the proper init state
 
+ELASTICSEARCH_URL=${1:-"http://localhost:9200"}
 
 function checkFile
 {
@@ -21,32 +22,32 @@ checkFile metrics_mapping_enums.json
 checkFile events_mapping.json
 
 #delete the old indices
-curl -XDELETE 'http://localhost:9200/enums/' >& /dev/null
-curl -XDELETE 'http://localhost:9200/events/' >& /dev/null
-curl -XDELETE 'http://localhost:9200/metric_metadata/' >& /dev/null
-curl -XDELETE 'http://localhost:9200/metric_metadata_v2/' >& /dev/null
-curl -XDELETE 'http://localhost:9200/metric_metadata_write/' >& /dev/null
+curl -XDELETE $ELASTICSEARCH_URL'/enums/' >& /dev/null
+curl -XDELETE $ELASTICSEARCH_URL'/events/' >& /dev/null
+curl -XDELETE $ELASTICSEARCH_URL'/metric_metadata/' >& /dev/null
+curl -XDELETE $ELASTICSEARCH_URL'/metric_metadata_v2/' >& /dev/null
+curl -XDELETE $ELASTICSEARCH_URL'/metric_metadata_write/' >& /dev/null
 
 
 #create the new indices
-curl -XPUT 'http://localhost:9200/metric_metadata'
-curl -XPUT 'http://localhost:9200/enums'
-curl -XPUT 'http://localhost:9200/events'
+curl -XPUT $ELASTICSEARCH_URL'/metric_metadata'
+curl -XPUT $ELASTICSEARCH_URL'/enums'
+curl -XPUT $ELASTICSEARCH_URL'/events'
 
 #create the aliases
-curl -XPOST 'http://localhost:9200/_aliases' -d '
+curl -XPOST $ELASTICSEARCH_URL'/_aliases' -d '
 {
     "actions" : [
         { "add" : { "alias" : "metric_metadata_write", "index" : "metric_metadata" } }
     ]
 }'
-curl -XPOST 'http://localhost:9200/_aliases' -d '
+curl -XPOST $ELASTICSEARCH_URL'/_aliases' -d '
 {
     "actions" : [
         { "add" : { "alias" : "metric_metadata_read", "index" : "metric_metadata" } }
     ]
 }'
-curl -XPOST 'http://localhost:9200/_aliases' -d '
+curl -XPOST $ELASTICSEARCH_URL'/_aliases' -d '
 {
     "actions" : [
         { "add" : { "alias" : "metric_metadata_read", "index" : "enums" } }
@@ -54,25 +55,25 @@ curl -XPOST 'http://localhost:9200/_aliases' -d '
 }'
 
 #add index settings to metric_metadata index
-curl -XPOST 'localhost:9200/metric_metadata/_close'
-curl -XPUT 'localhost:9200/metric_metadata/_settings' -d @index_settings.json
-curl -XPOST 'localhost:9200/metric_metadata/_open'
+curl -XPOST $ELASTICSEARCH_URL'/metric_metadata/_close'
+curl -XPUT $ELASTICSEARCH_URL'/metric_metadata/_settings' -d @index_settings.json
+curl -XPOST $ELASTICSEARCH_URL'/metric_metadata/_open'
 
 
 #add mappings to metric_metadata index
-curl -XDELETE 'http://localhost:9200/metric_metadata/_mapping/metrics' >& /dev/null
-curl -XPUT 'http://localhost:9200/metric_metadata/_mapping/metrics' -d @metrics_mapping.json
+curl -XDELETE $ELASTICSEARCH_URL'/metric_metadata/_mapping/metrics' >& /dev/null
+curl -XPUT $ELASTICSEARCH_URL'/metric_metadata/_mapping/metrics' -d @metrics_mapping.json
 
 #add index settings to enums index
-curl -XPOST 'localhost:9200/enums/_close'
-curl -XPUT 'localhost:9200/enums/_settings' -d  @index_settings.json
-curl -XPOST 'localhost:9200/enums/_open'
+curl -XPOST $ELASTICSEARCH_URL'/enums/_close'
+curl -XPUT $ELASTICSEARCH_URL'/enums/_settings' -d  @index_settings.json
+curl -XPOST $ELASTICSEARCH_URL'/enums/_open'
 
 #add mappings to enums index
-curl -XDELETE 'http://localhost:9200/enums/_mapping/metrics'  >& /dev/null
-curl -XPUT 'http://localhost:9200/enums/_mapping/metrics' -d @metrics_mapping_enums.json
+curl -XDELETE $ELASTICSEARCH_URL'/enums/_mapping/metrics'  >& /dev/null
+curl -XPUT $ELASTICSEARCH_URL'/enums/_mapping/metrics' -d @metrics_mapping_enums.json
 
 #add mappings to graphite_event index
-curl -XDELETE 'http://localhost:9200/events/_mapping/graphite_event' >& /dev/null
-curl -XPUT 'http://localhost:9200/events/_mapping/graphite_event' -d @events_mapping.json
+curl -XDELETE $ELASTICSEARCH_URL'/events/_mapping/graphite_event' >& /dev/null
+curl -XPUT $ELASTICSEARCH_URL'/events/_mapping/graphite_event' -d @events_mapping.json
 


### PR DESCRIPTION
This changes the init-es.sh script so it can take command line args in case our elasticsearch server isnt on localhost.
We want to try running blueflood with objectrockets ES offering instead of local ES.