### PR TITLE
fixing blueflood-http travis integration test run

### DIFF
--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -106,6 +106,7 @@
               <argLine>-DZOOKEEPER_CLUSTER=NONE</argLine>
               <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties</argLine>
               <argLine>${jacoco.agent.it.argLine}</argLine>
+              <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
               <!-- Skips integration tests if the value of skip.integration.tests property is true -->
               <skipTests>${skip.integration.tests}</skipTests>
               <includes>


### PR DESCRIPTION
Setting the max heap and permsize to prevent blueflood-http integration tests from failing during travis build.