### PR TITLE
feat(add-auth-to-es): Add authentication to elastic search connector

### DIFF
--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -38,6 +38,19 @@
     </plugins>
   </build>
 
+  <repositories>
+    <repository>
+      <id>elasticsearch-releases</id>
+      <url>http://maven.elasticsearch.org/releases</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
 
     <dependency>
@@ -49,7 +62,22 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>1.7.1</version>
+      <version>1.7.4</version>
+    </dependency>
+
+    <!-- add the Shield jar as a dependency -->
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch-shield</artifactId>
+      <version>1.3.3</version>
+    </dependency>
+
+    <!-- add the License jar as a dependency -->
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch-license-plugin</artifactId>
+      <version>1.0.0</version>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/ElasticIOConfig.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/ElasticIOConfig.java
@@ -17,6 +17,9 @@
 package com.rackspacecloud.blueflood.service;
 
 public enum ElasticIOConfig implements ConfigDefaults {
+    ELASTICSEARCH_USERNAME("Admin"),
+    ELASTICSEARCH_PASSWORD("password"),
+    ELASTICSEARCH_USE_AUTH("false"),
     ELASTICSEARCH_HOSTS("127.0.0.1:9300"),
     ELASTICSEARCH_CLUSTERNAME("elasticsearch"),
     ELASTICSEARCH_INDEX_NAME_WRITE("metric_metadata"),

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/RemoteElasticSearchServer.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/RemoteElasticSearchServer.java
@@ -21,9 +21,8 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
-
 import java.util.List;
-
+import java.net.URL;
 
 public class RemoteElasticSearchServer implements ElasticClientManager {
     private static final RemoteElasticSearchServer INSTANCE = new RemoteElasticSearchServer();
@@ -38,15 +37,48 @@ public class RemoteElasticSearchServer implements ElasticClientManager {
         Configuration config = Configuration.getInstance();
         List<String> hosts = config.getListProperty(ElasticIOConfig.ELASTICSEARCH_HOSTS);
         String clusterName = config.getStringProperty(ElasticIOConfig.ELASTICSEARCH_CLUSTERNAME);
-        Settings settings = ImmutableSettings.settingsBuilder()
-                .put("cluster.name", clusterName)
-                .build();
+        Settings settings;
+        Boolean useAuth =  config.getBooleanProperty(ElasticIOConfig.ELASTICSEARCH_USE_AUTH);
+        if (useAuth.equals(false)) {
+            settings = ImmutableSettings.settingsBuilder()
+                    .put("cluster.name", clusterName)
+                    .build();
+        } else {
+            // Objectrocket docs all use curl -u
+            // curl -u base64 encodes username:password and glues it to header: Authorization: Basic
+            // Shield from ES does the same or should, saving us the hassle of base64 encoding
+            // and setting headers
+            String username = config.getStringProperty(ElasticIOConfig.ELASTICSEARCH_USERNAME);
+            String passwd = config.getStringProperty(ElasticIOConfig.ELASTICSEARCH_PASSWORD);
+            settings = ImmutableSettings.settingsBuilder()
+                    .put("cluster.name", clusterName)
+                    .put("shield.user", username + ":" + passwd)
+                    .put("shield:enabled", true) // may not be necessary
+                    .build();
+        }
         TransportClient tc = new TransportClient(settings);
+        // We used to assume hosts looked like
+        //      127.0.0.1:9300 or localhost:9300
+        // but remote ES using users can have host urls like
+        //      http://foo.bar:9300
         for (String host : hosts) {
-            String[] parts = host.split(":");
-            String address = parts[0];
-            Integer port = Integer.parseInt(parts[1]);
-            tc.addTransportAddress(new InetSocketTransportAddress(address, port));
+            String address = null;
+            Integer port = null;
+            try {
+                URL url = new URL(host);
+                address = url.getHost() + url.getFile(); // URL<"a.com/foo?a=b">.getFile() => /foo?a=b
+                port = url.getPort();
+            } catch ( Exception MalformedURLException ) {
+                // we tried, default to old ways
+                String[] parts = host.split(":");
+                address = parts[0];
+                port = Integer.parseInt(parts[1]);
+            } finally {
+                // Hopefully both methods didnt fail but better safe than sorry
+                if (address != null && port != null) {
+                    tc.addTransportAddress(new InetSocketTransportAddress(address, port));
+                }
+            }
         }
         client = tc;
     }

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticIOTest.java
@@ -22,6 +22,7 @@ import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import junit.framework.Assert;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -100,7 +101,9 @@ public class ElasticIOTest {
 
     @Before
     public void setup() throws IOException {
-        esSetup = new EsSetup();
+        esSetup = new EsSetup(ImmutableSettings.settingsBuilder()
+                .put("shield.enabled", false)
+                .build());
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/EnumElasticIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/EnumElasticIOTest.java
@@ -25,6 +25,7 @@ import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import junit.framework.Assert;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.junit.After;
 import org.junit.Before;
@@ -66,7 +67,9 @@ public class EnumElasticIOTest {
 
     @Before
     public void setup() throws IOException {
-        esSetup = new EsSetup();
+        esSetup = new EsSetup(ImmutableSettings.settingsBuilder()
+                .put("shield.enabled", false)
+                .build());
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/EventElasticSearchIOTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/EventElasticSearchIOTest.java
@@ -19,6 +19,7 @@ package com.rackspacecloud.blueflood.io;
 import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.types.Event;
 import junit.framework.Assert;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -118,10 +119,10 @@ public class EventElasticSearchIOTest {
 
     @Before
     public void setup() throws Exception {
-        esSetup = new EsSetup();
-        esSetup.execute(EsSetup.deleteAll());
-        esSetup.execute(EsSetup
-                .createIndex(EventElasticSearchIO.EVENT_INDEX)
+        esSetup = new EsSetup(ImmutableSettings.settingsBuilder()
+                .put("shield.enabled", false)
+                .build());
+        esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
                 .withMapping(EventElasticSearchIO.ES_TYPE, EsSetup.fromClassPath("events_mapping.json")));
         searchIO = new EventElasticSearchIO(esSetup.client());
 

--- a/blueflood-elasticsearch/src/test/resources/elasticsearch.yml
+++ b/blueflood-elasticsearch/src/test/resources/elasticsearch.yml
@@ -5,3 +5,4 @@ path.work: /tmp/elasticsearch-for-bf/work
 
 path.logs: /tmp/elasticsearch-for-bf/logs
 
+shield.enabled: false

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
@@ -17,6 +17,7 @@
 package com.rackspacecloud.blueflood.http;
 
 import com.github.tlrx.elasticsearch.test.EsSetup;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpEventsIngestionHandler;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpMetricsIngestionServer;
 import com.rackspacecloud.blueflood.io.*;
@@ -72,7 +73,9 @@ public class HttpIntegrationTestBase {
         context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
 
         // setup elasticsearch
-        esSetup = new EsSetup();
+        esSetup = new EsSetup(ImmutableSettings.settingsBuilder()
+                .put("shield.enabled", false)
+                .build());
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndTest.java
@@ -33,6 +33,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -69,7 +70,9 @@ public class HttpAnnotationsEndToEndTest {
         manageShards.add(1); manageShards.add(5); manageShards.add(6);
         context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
 
-        esSetup = new EsSetup();
+        esSetup = new EsSetup(ImmutableSettings.settingsBuilder()
+                .put("shield.enabled", false)
+                .build());
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndTest.java
@@ -16,6 +16,7 @@
 package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.github.tlrx.elasticsearch.test.EsSetup;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
 import com.rackspacecloud.blueflood.io.AstyanaxMetricsWriter;
 import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
@@ -33,7 +34,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.elasticsearch.common.settings.ImmutableSettings;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
@@ -17,6 +17,7 @@
 package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.github.tlrx.elasticsearch.test.EsSetup;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
 import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainerTest;
 import com.rackspacecloud.blueflood.io.*;
@@ -65,7 +66,9 @@ public class HttpHandlerIntegrationTest {
         manageShards.add(1); manageShards.add(5); manageShards.add(6);
         context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
 
-        esSetup = new EsSetup();
+        esSetup = new EsSetup(ImmutableSettings.settingsBuilder()
+                .put("shield.enabled", false)
+                .build());
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
@@ -18,6 +18,7 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 
 
 import com.github.tlrx.elasticsearch.test.EsSetup;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
 import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainerTest;
 import com.rackspacecloud.blueflood.io.*;
@@ -71,7 +72,9 @@ public class HttpMetricsIngestionServerShutdownIntegrationTest {
         manageShards.add(1); manageShards.add(5); manageShards.add(6);
         context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
 
-        esSetup = new EsSetup();
+        esSetup = new EsSetup(ImmutableSettings.settingsBuilder()
+                .put("shield.enabled", false)
+                .build());
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpAnnotationsIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpAnnotationsIntegrationTest.java
@@ -24,6 +24,7 @@ import com.rackspacecloud.blueflood.types.Event;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.junit.*;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -49,7 +50,10 @@ public class HttpAnnotationsIntegrationTest {
         queryPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT);
         vendor = new HttpClientVendor();
         client = vendor.getClient();
-        esSetup = new EsSetup();
+
+        esSetup = new EsSetup(ImmutableSettings.settingsBuilder()
+                .put("shield.enabled", false)
+                .build());
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -31,6 +31,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.junit.*;
 
 import java.net.URI;
@@ -64,7 +65,9 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
         vendor = new HttpClientVendor();
         client = vendor.getClient();
 
-        esSetup = new EsSetup();
+        esSetup = new EsSetup(ImmutableSettings.settingsBuilder()
+                .put("shield.enabled", false)
+                .build());
         esSetup.execute(EsSetup.deleteAll());
         esSetup.execute(EsSetup.createIndex(ElasticIO.INDEX_NAME_WRITE)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))


### PR DESCRIPTION
This PR attempts to add authentication to the ES transport connector thingy so it can work with SaaS ES providers like ObjectRocket.

This PR is still very WIP, please don't merge. 