### PR TITLE
make integration tests work within intellij

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/cache/MetadataCacheIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/cache/MetadataCacheIntegrationTest.java
@@ -16,22 +16,16 @@
 
 package com.rackspacecloud.blueflood.cache;
 
-import com.google.common.base.Supplier;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Table;
-import com.google.common.collect.Tables;
+import org.junit.runner.RunWith;
+
 import com.rackspacecloud.blueflood.io.AstyanaxMetadataIO;
 import com.rackspacecloud.blueflood.io.MetadataIO;
-import com.rackspacecloud.blueflood.service.Configuration;
-import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.io.IntegrationTestBase;
 import com.rackspacecloud.blueflood.types.MetricMetadata;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import com.rackspacecloud.blueflood.utils.InMemoryMetadataIO;
 
@@ -40,7 +34,6 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -38,10 +38,9 @@
   <build>
     <testResources>
       <testResource>
-        <directory>src/integration-test/java</directory>
+        <directory>src/test/resources</directory>
       </testResource>
     </testResources>
-
 
     <plugins>
       <!-- Used to add source directories to our build. -->
@@ -197,7 +196,6 @@
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
@@ -37,7 +37,7 @@ public class HttpEnumIntegrationTest extends HttpIntegrationTestBase {
         locators.add(Locator.createLocatorFromPathComponents(tenant_id, metric_name));
 
         // post enum metric for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "src/test/resources/sample_enums_payload.json");
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_enums_payload.json");
         Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
         EntityUtils.consume(response.getEntity());
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
@@ -30,11 +30,9 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.*;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
@@ -102,7 +100,6 @@ public class HttpIntegrationTestBase {
         client = vendor.getClient();
     }
 
-
     @AfterClass
     public static void shutdown() {
         Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(), "");
@@ -136,7 +133,9 @@ public class HttpIntegrationTestBase {
 
         // get payload
         StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(payloadFilePath)));
+        BufferedReader reader = new BufferedReader(
+                                    new InputStreamReader(
+                                        getClass().getClassLoader().getResourceAsStream(payloadFilePath)));
         String curLine = reader.readLine();
         while (curLine != null) {
             sb = sb.append(curLine);

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
@@ -210,7 +210,8 @@ public class HttpHandlerIntegrationTest {
     @Test
     public void testHttpAggregatedIngestionHappyCase() throws Exception {
         StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/test/resources/sample_payload.json")));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(
+                                        getClass().getClassLoader().getResourceAsStream("sample_payload.json")));
         String curLine = reader.readLine();
         while (curLine != null) {
             sb = sb.append(curLine);
@@ -238,7 +239,8 @@ public class HttpHandlerIntegrationTest {
     @Test
     public void testHttpAggregatedMultiIngestionHappyCase() throws Exception {
         StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/test/resources/sample_multi_aggregated_payload.json")));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(
+                                            getClass().getClassLoader().getResourceAsStream("sample_multi_aggregated_payload.json")));
         String curLine = reader.readLine();
         while (curLine != null) {
             sb = sb.append(curLine);
@@ -276,7 +278,8 @@ public class HttpHandlerIntegrationTest {
     @Test
     public void testHttpAggregatedMultiIngestion_WithMultipleEnumPoints() throws Exception {
         StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/test/resources/sample_multi_enums_payload.json")));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(
+                                        getClass().getClassLoader().getResourceAsStream("sample_multi_enums_payload.json")));
         String curLine = reader.readLine();
         while (curLine != null) {
             sb = sb.append(curLine);

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
@@ -21,12 +21,10 @@ import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
 import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainerTest;
 import com.rackspacecloud.blueflood.io.*;
-import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.HttpConfig;
 import com.rackspacecloud.blueflood.service.ScheduleContext;
-import com.rackspacecloud.blueflood.types.*;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -34,9 +32,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.util.EntityUtils;
 import org.junit.*;
-import org.junit.rules.ExpectedException;
 
 import java.net.ConnectException;
 import java.net.URI;
@@ -45,8 +41,6 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashSet;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.*;
 
 public class HttpMetricsIngestionServerShutdownIntegrationTest {

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -89,7 +89,7 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
         final String metric_name = "call_xyz_api";
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedMultiPath, "src/test/resources/sample_multi_enums_payload.json");
+        HttpResponse response = postMetric(tenant_id, postAggregatedMultiPath, "sample_multi_enums_payload.json");
         Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
         EntityUtils.consume(response.getEntity());
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -16,8 +16,6 @@
 
 package com.rackspacecloud.blueflood.outputs.handlers;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
@@ -36,7 +34,7 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
         final String tenant_id = "333333";
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "src/test/resources/sample_payload.json");
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json");
         Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
         EntityUtils.consume(response.getEntity());
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
@@ -35,7 +35,7 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
         final String metric_name = "3333333.G1s";
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "src/test/resources/sample_payload.json");
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json");
         Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
         EntityUtils.consume(response.getEntity());
 
@@ -78,7 +78,7 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
         final String metric_name = "enum_metric_test";
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "src/test/resources/sample_enums_payload.json");
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_enums_payload.json");
         Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
         EntityUtils.consume(response.getEntity());
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,41 @@
     <slf4j.version>1.7.6</slf4j.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.netflix.astyanax</groupId>
+        <artifactId>astyanax-core</artifactId>
+        <version>1.56.34</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>1.10</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cassandra-maven-plugin</artifactId>
+          <version>${cassandra.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.14.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>2.15</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Before we start adding more integration tests, we thought it would be nice to have a mechanism to run these tests from IntelliJ.

The main changes to make that possible are:
* adding ```src/test/resources``` directory to Maven's test resources. This will cause files in that directory to be copied to ```target/test-classes```, which then we can load the files from classpath, instead of relative path. The relative path breaks because you have to manually set the Working Directory setting of each test that you are running from IntelliJ to the submodule directory. 
* leverage pluginManagement and dependencyManagement so that all integration tests across multiple submodules share the same versions of plugins/dependency.