### PR TITLE
fix jacoco-it javaagent JVM parameter getting overwritten

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -102,9 +102,7 @@
                 <DEFAULT_CASSANDRA_PORT>${cassandra.rpcPort}</DEFAULT_CASSANDRA_PORT>
               </systemPropertyVariables>
               <testSourceDirectory>src/integration-test/java</testSourceDirectory>
-              <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties</argLine>
-              <argLine>${jacoco.agent.it.argLine}</argLine>
-              <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+              <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties ${jacoco.agent.it.argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
               <!-- Skips integration tests if the value of skip.integration.tests property is true -->
               <skipTests>${skip.integration.tests}</skipTests>
               <includes>

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -101,9 +101,7 @@
                 <DEFAULT_CASSANDRA_PORT>${cassandra.rpcPort}</DEFAULT_CASSANDRA_PORT>
               </systemPropertyVariables>
               <testSourceDirectory>src/integration-test/java</testSourceDirectory>
-              <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties</argLine>
-              <argLine>${jacoco.agent.it.argLine}</argLine>
-              <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+              <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties ${jacoco.agent.it.argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
               <!-- Skips integration tests if the value of skip.integration.tests property is true -->
               <skipTests>${skip.integration.tests}</skipTests>
               <includes>


### PR DESCRIPTION
**Why:**
I noticed that we are no longer generating the file ```jacoco-it.exec```, which is the raw coverage output of jacoco-maven-plugin. Our coveralls numbers are also lower, from 70% to now 56%.

**How:**
Fix the maven failsafe plugin configuration so that all JVM arguments is in a single &lt;argLine&gt; parameter. The plugin does not take multiple &lt;argLine&gt; configuration. It just takes the last one. So the last parameter overwrites the jacoco.agent JVM argument.