### PR TITLE
turn ShardStateIntegration back on

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/ShardStateIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/ShardStateIntegrationTest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-@Ignore
 @RunWith(Parameterized.class)
 public class ShardStateIntegrationTest extends IntegrationTestBase {
     


### PR DESCRIPTION
**Why:**
This test was commented out due to some error when Travis runs it. I was not able to reproduce the error locally on my box.

Turning this one back on, hoping to catch the issue in Travis. It is possible the issue was failsafe plugin or surefire plugin error-ing out due to not enough memory. This not-enough-memory issue was fixed in previous PR.