### PR TITLE
fixing ROR when TURN_OFF_RR_MPLOT is true

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -102,13 +102,11 @@ public class RollupHandler {
             rollupsOnReadExecutor = MoreExecutors.listeningDecorator(rollupsOnReadExecutors);
         }
 
-        if (!Configuration.getInstance().getBooleanProperty(CoreConfig.TURN_OFF_RR_MPLOT)) {
-            ThreadPoolExecutor rollupsOnReadExecutors = new ThreadPoolBuilder().withUnboundedQueue()
-                    .withCorePoolSize( Configuration.getInstance().getIntegerProperty(CoreConfig.ROLLUP_ON_READ_REPAIR_THREADS ))
-                    .withMaxPoolSize( Configuration.getInstance().getIntegerProperty( CoreConfig.ROLLUP_ON_READ_REPAIR_THREADS ) )
-                    .withName( "Create Repair Points Rollups on Read Executors" ).build();
-            createRepairPointsExecutor = MoreExecutors.listeningDecorator(rollupsOnReadExecutors);
-        }
+        ThreadPoolExecutor createRepairrollupsOnReadExecutors = new ThreadPoolBuilder().withUnboundedQueue()
+                .withCorePoolSize( Configuration.getInstance().getIntegerProperty(CoreConfig.ROLLUP_ON_READ_REPAIR_THREADS ))
+                .withMaxPoolSize( Configuration.getInstance().getIntegerProperty( CoreConfig.ROLLUP_ON_READ_REPAIR_THREADS ) )
+                .withName( "Create Repair Points Rollups on Read Executors" ).build();
+        createRepairPointsExecutor = MoreExecutors.listeningDecorator(createRepairrollupsOnReadExecutors);
     }
 
     private enum plotTimers {
@@ -343,6 +341,8 @@ public class RollupHandler {
                 repairedPoints.addAll( subList );
             }
         } catch (Exception e) {
+            aggregateFuture.cancel(true);
+            exceededQueryTimeout.mark();
             log.warn("Exception encountered while doing rollups on read, incomplete rollups will be returned.", e);
         }
 


### PR DESCRIPTION
The ```createRepairPointsExecutor``` is used when ```TURN_OFF_RR_MPLOT``` is ```true``` or ```false```.  Ensuring that this object is always created.

Unfortunately, there is no way to verify this in our unit tests since the configuration is pulled from the ```Configuration``` singleton.  We could pull the singleton references out and pass in the constructor, but I think that is more than we want to do now as the ```RollupHandler``` is sub-classed a few times.

Verified this on perf01 with ```TURN_OFF_RR_MPLOT``` as ```true```.