### PR TITLE
Adding verification to the attribute 'collectionTime' in a client's ingestion request

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -152,7 +152,12 @@ public enum CoreConfig implements ConfigDefaults {
     ENUM_VALIDATOR_THREADS("20"),
     ENUM_UNIQUE_VALUES_THRESHOLD("100"),
     ENUM_VALIDATOR_ENABLED("true"),
-    EXCESS_ENUM_READER_SLEEP("600000");
+    EXCESS_ENUM_READER_SLEEP("600000"),
+    // 3 days - this matches the TTL for our metrics_full table, we don't accept anything older than the TTL.
+    BEFORE_CURRENT_COLLECTIONTIME_MS("259200000"),
+    // 10 minutes
+    AFTER_CURRENT_COLLECTIONTIME_MS("600000");
+
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -170,7 +170,13 @@
       <version>4.3.3</version>
     </dependency>
 
-    <!-- testing dependencies -->
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-io</artifactId>
+          <version>1.3.2</version>
+      </dependency>
+
+      <!-- testing dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
The collectionTIme can't be older then ```current time - BEFORE_CURRRENT_COLLECTIONTIME_MS``` or newer than ```current time  + AFTER_CURRENT_COLLECTIONTIME_MS```.

Also added error messages for the HTTP repsonse body which enumerate the following errors:
- no tenantId, when required
- collectionTime too old
- collectionTime too new