### PR TITLE
jdk18 doesnt like the private interface

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
@@ -162,4 +162,4 @@ public class Instrumentation implements InstrumentationMBean {
     }
 }
 
-interface InstrumentationMBean {}
+

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/InstrumentationMBean.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/InstrumentationMBean.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2013 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.io;
+
+public interface InstrumentationMBean {}


### PR DESCRIPTION
When I run blueflood with JDK1.8, I got this exception:
```
2016-02-29 12:58:28 ERROR Instrumentation     :67  - Unable to register mbean for Instrumentation
javax.management.NotCompliantMBeanException: Interface is not public: com.rackspacecloud.blueflood.io.InstrumentationMBean
	at com.sun.jmx.mbeanserver.MBeanAnalyzer.<init>(MBeanAnalyzer.java:114)
	at com.sun.jmx.mbeanserver.MBeanAnalyzer.analyzer(MBeanAnalyzer.java:102)
	at com.sun.jmx.mbeanserver.StandardMBeanIntrospector.getAnalyzer(StandardMBeanIntrospector.java:67)
	at com.sun.jmx.mbeanserver.MBeanIntrospector.getPerInterface(MBeanIntrospector.java:192)
	at com.sun.jmx.mbeanserver.MBeanSupport.<init>(MBeanSupport.java:138)
	at com.sun.jmx.mbeanserver.StandardMBeanSupport.<init>(StandardMBeanSupport.java:60)
	at com.sun.jmx.mbeanserver.Introspector.makeDynamicMBean(Introspector.java:192)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerObject(DefaultMBeanServerInterceptor.java:898)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:324)
	at com.sun.jmx.mbeanserver.JmxMBeanServer.registerMBean(JmxMBeanServer.java:522)
	at com.rackspacecloud.blueflood.io.Instrumentation.<clinit>(Instrumentation.java:65)
	at com.rackspacecloud.blueflood.io.AstyanaxReader.getShardState(AstyanaxReader.java:211)
	at com.rackspacecloud.blueflood.io.AstyanaxShardStateIO.getShardState(AstyanaxShardStateIO.java:19)
	at com.rackspacecloud.blueflood.service.ShardStatePuller.performOperation(ShardStatePuller.java:42)
	at com.rackspacecloud.blueflood.service.ShardStateWorker.run(ShardStateWorker.java:88)
	at java.lang.Thread.run(Thread.java:745)
```

This PR fixes the above exception by defining the ```InstrumentationMBean``` as a public interface.