### PR TITLE
add jdk18 build to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ jdk:
   - oraclejdk7
   - openjdk7
   - oraclejdk8
-  - openjdk8
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 jdk:
   - oraclejdk7
   - openjdk7
+  - oraclejdk8
+  - openjdk8
 
 sudo: false
 


### PR DESCRIPTION
Let's add the jdk 1.8 builds to Travis so at least we start building the code using those. We will catch future check-ins that might not be jdk 1.8 compatible.