### PR TITLE
Adding verification to the attribute 'timestamp' in a client's aggregated ingestion request & 'when' for annotations request.

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
@@ -26,7 +26,6 @@ import org.codehaus.jackson.annotate.JsonIgnore;
 import org.joda.time.DateTime;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
@@ -16,29 +16,43 @@
 
 package com.rackspacecloud.blueflood.http;
 
+import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainerTest;
+import com.rackspacecloud.blueflood.inputs.handlers.wrappers.AggregatedPayload;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.EnumValidator;
 import com.rackspacecloud.blueflood.types.Locator;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertTrue;
 
 public class HttpEnumIntegrationTest extends HttpIntegrationTestBase {
 
     @Test
     public void testMetricIngestionWithEnum() throws Exception {
+
         // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
         final String tenant_id = "333333";
-        final String metric_name = "enum_metric_test";
+
+        String prefix = getPrefix();
+        final String metric_name = prefix + "enum_metric_test";
+
         Set<Locator> locators = new HashSet<Locator>();
         locators.add(Locator.createLocatorFromPathComponents(tenant_id, metric_name));
 
         // post enum metric for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_enums_payload.json");
-        Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_enums_payload.json", prefix );
+        assertEquals( "Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode() );
         EntityUtils.consume(response.getEntity());
 
         // execute EnumValidator
@@ -50,12 +64,56 @@ public class HttpEnumIntegrationTest extends HttpIntegrationTestBase {
 
         // query for metric and assert results
         HttpResponse query_response = queryMetricIncludeEnum(tenant_id, metric_name);
-        Assert.assertEquals("Should get status 200 from query server for GET", 200, query_response.getStatusLine().getStatusCode());
+        assertEquals( "Should get status 200 from query server for GET", 200, query_response.getStatusLine().getStatusCode() );
 
         // assert response content
         String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
-        Assert.assertEquals(String.format("[{\"metric\":\"%s\",\"enum_values\":[\"v1\",\"v2\",\"v3\"]}]", metric_name), responseContent);
+        assertEquals( String.format( "[{\"metric\":\"%s\",\"enum_values\":[\"v1\",\"v2\",\"v3\"]}]", metric_name ), responseContent );
         EntityUtils.consume(query_response.getEntity());
     }
 
+    @Test
+    public void testHttpEnumIngestionInvalidPastCollectionTime() throws IOException, URISyntaxException {
+
+        long timestamp = System.currentTimeMillis() - TIME_DIFF - Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
+
+        // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
+        final String tenant_id = "333333";
+
+        String prefix = getPrefix();
+
+        final String metric_name = prefix + "enum_metric_test";
+        Set<Locator> locators = new HashSet<Locator>();
+        locators.add(Locator.createLocatorFromPathComponents(tenant_id, metric_name));
+
+        // post enum metric for ingestion and verify
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_enums_payload.json", timestamp, prefix );
+
+        String[] errors = getBodyArray( response );
+
+        assertEquals( 400, response.getStatusLine().getStatusCode() );
+        assertTrue( Pattern.matches( JSONMetricsContainerTest.PAST_COLLECTION_TIME_REGEX, errors[ 1 ] ) );
+    }
+
+    @Test
+    public void testHttpEnumIngestionInvalidFutureCollectionTime() throws IOException, URISyntaxException {
+
+        long timestamp = System.currentTimeMillis() + TIME_DIFF + Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
+
+        // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
+        final String tenant_id = "333333";
+
+        String prefix = getPrefix();
+        final String metric_name = prefix + "enum_metric_test";
+        Set<Locator> locators = new HashSet<Locator>();
+        locators.add(Locator.createLocatorFromPathComponents(tenant_id, metric_name));
+
+        // post enum metric for ingestion and verify
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_enums_payload.json", timestamp, prefix );
+
+        String[] errors = getBodyArray( response );
+
+        assertEquals( 400, response.getStatusLine().getStatusCode() );
+        assertTrue( Pattern.matches( JSONMetricsContainerTest.FUTURE_COLLECTION_TIME_REGEX, errors[ 1 ] ) );
+    }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
@@ -17,44 +17,55 @@
 package com.rackspacecloud.blueflood.http;
 
 import com.github.tlrx.elasticsearch.test.EsSetup;
+import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainerTest;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpEventsIngestionHandler;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpMetricsIngestionServer;
 import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.service.*;
+import com.rackspacecloud.blueflood.types.Event;
 import com.rackspacecloud.blueflood.utils.ModuleLoader;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.junit.*;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Random;
 
+import static com.rackspacecloud.blueflood.inputs.handlers.wrappers.TestGsonParsing.getJsonFromFile;
 import static org.mockito.Mockito.spy;
 
 public class HttpIntegrationTestBase {
+
+    public static final long TIME_DIFF = 2000;
+
+    protected static HttpClient client;
+    protected static ScheduleContext context;
+    protected static EventsIO eventsSearchIO;
+    protected static EsSetup esSetup;
+
     private static HttpIngestionService httpIngestionService;
     private static HttpQueryService httpQueryService;
     private static HttpClientVendor vendor;
-    private static DefaultHttpClient client;
     private static Collection<Integer> manageShards = new HashSet<Integer>();
     private static int httpPortIngest;
     private static int httpPortQuery;
-    private static ScheduleContext context;
-    private static EventsIO eventsSearchIO;
-    private static EsSetup esSetup;
 
+    public final String postPath = "/v2.0/%s/ingest";
+    public final String postEventsPath = "/v2.0/%s/events";
+    public final String postMultiPath = "/v2.0/%s/ingest/multi";
     public final String postAggregatedPath = "/v2.0/%s/ingest/aggregated";
     public final String postAggregatedMultiPath = "/v2.0/%s/ingest/aggregated/multi";
+    private Random random = new Random( System.currentTimeMillis() );
 
     @BeforeClass
     public static void setUp() throws Exception{
@@ -130,32 +141,60 @@ public class HttpIntegrationTestBase {
         }
     }
 
-    public HttpResponse postMetric(String tenantId, String urlPath, String payloadFilePath) throws URISyntaxException, IOException {
+    public HttpResponse postGenMetric( String tenantId, String prefix, String url ) throws Exception {
+
+        return httpPost( tenantId, url,  JSONMetricsContainerTest.generateJSONMetricsData( prefix ) );
+    }
+
+    public HttpResponse postGenMetric( String tenantId, String prefix, String url, long time ) throws Exception {
+
+        return httpPost( tenantId, url,  JSONMetricsContainerTest.generateJSONMetricsData( prefix, time ) );
+    }
+
+    public HttpResponse postMetric(String tenantId, String urlPath, String payloadFilePath, String prefix) throws URISyntaxException, IOException {
         // post metric to ingestion server for a tenantId
         // urlPath is path for url ingestion after the hostname
         // payloadFilepath is location of the payload for the POST content entity
 
-        // get payload
-        StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(
-                                    new InputStreamReader(
-                                        getClass().getClassLoader().getResourceAsStream(payloadFilePath)));
-        String curLine = reader.readLine();
-        while (curLine != null) {
-            sb = sb.append(curLine);
-            curLine = reader.readLine();
-        }
-        String json = sb.toString();
+        String json = getJsonFromFile( new InputStreamReader( getClass().getClassLoader().getResourceAsStream( payloadFilePath ) ), prefix );
+        return httpPost( tenantId, urlPath, json );
+    }
 
+    public HttpResponse postMetric(String tenantId, String urlPath, String payloadFilePath, long timestamp, String prefix ) throws URISyntaxException, IOException {
+        // post metric to ingestion server for a tenantId
+        // urlPath is path for url ingestion after the hostname
+        // payloadFilepath is location of the payload for the POST content entity
+
+        String json = getJsonFromFile( new InputStreamReader( getClass().getClassLoader().getResourceAsStream( payloadFilePath ) ), timestamp, prefix );
+        return httpPost( tenantId, urlPath, json );
+    }
+
+
+    public HttpResponse postEvent( String tenantId, String requestBody ) throws Exception {
+
+
+        HttpPost post = getHttpPost( tenantId, postEventsPath, requestBody );
+
+        post.setHeader( Event.FieldLabels.tenantId.name(), tenantId);
+        HttpResponse response = client.execute(post);
+        return response;
+    }
+
+    public HttpResponse httpPost( String tenantId, String urlPath, String json ) throws URISyntaxException, IOException {
+
+        HttpPost post = getHttpPost( tenantId, urlPath, json );
+
+        return client.execute(post);
+    }
+
+    private HttpPost getHttpPost( String tenantId, String urlPath, String json ) throws URISyntaxException {
         // build url to aggregated ingestion endpoint
         URIBuilder builder = getMetricsURIBuilder()
                 .setPath(String.format(urlPath, tenantId));
         HttpPost post = new HttpPost(builder.build());
         HttpEntity entity = new StringEntity(json, ContentType.APPLICATION_JSON);
         post.setEntity(entity);
-
-        // post and return response
-        return client.execute(post);
+        return post;
     }
 
     public HttpResponse queryMetricIncludeEnum(String tenantId, String metricName) throws URISyntaxException, IOException {
@@ -234,4 +273,14 @@ public class HttpIntegrationTestBase {
                 .setParameter("to", "200000000");
     }
 
+    protected String[] getBodyArray( HttpResponse response ) throws IOException {
+        StringWriter sw = new StringWriter();
+        IOUtils.copy( response.getEntity().getContent(), sw );
+        IOUtils.closeQuietly( response.getEntity().getContent() );
+        return sw.toString().split( System.lineSeparator() );
+    }
+
+    protected String getPrefix() {
+        return random.nextInt( 99999 ) + ".";
+    }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerAnnotationIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerAnnotationIntegrationTest.java
@@ -1,0 +1,224 @@
+package com.rackspacecloud.blueflood.inputs.handlers;
+
+import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.types.Event;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static com.rackspacecloud.blueflood.TestUtils.*;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * Testing posting annotations to blueflood.
+ */
+public class HttpHandlerAnnotationIntegrationTest extends HttpIntegrationTestBase {
+
+    private final String INVALID_DATA = "Invalid Data: " + ERROR_TITLE;
+
+    //A time stamp 2 days ago
+    private final long baseMillis = System.currentTimeMillis() - 172800000;
+
+    @Test
+    public void testHttpAnnotationsIngestionHappyCase() throws Exception {
+        final int batchSize = 1;
+        final String tenant_id = "333333";
+        String event = createTestEvent(batchSize);
+        HttpResponse response = postEvent( tenant_id, event );
+
+        try {
+            assertEquals( 200, response.getStatusLine().getStatusCode() );
+        }
+        finally {
+            EntityUtils.consume( response.getEntity() ); // Releases connection apparently
+        }
+
+        //Sleep for a while
+        Thread.sleep( 1200 );
+        Map<String, List<String>> query = new HashMap<String, List<String>>();
+        query.put( Event.tagsParameterName, Arrays.asList( "deployment" ));
+        List<Map<String, Object>> results = eventsSearchIO.search(tenant_id, query);
+        assertEquals( batchSize, results.size() );
+
+        query = new HashMap<String, List<String>>();
+        query.put(Event.fromParameterName, Arrays.asList(String.valueOf(baseMillis - 86400000)));
+        query.put(Event.untilParameterName, Arrays.asList(String.valueOf(baseMillis + (86400000*3))));
+        results = eventsSearchIO.search(tenant_id, query);
+        assertEquals( batchSize, results.size() );
+    }
+
+    @Test
+    public void testHttpAnnotationsIngestionMultiEvents() throws Exception {
+        final int batchSize = 5;
+        final String tenant_id = "333444";
+        String event = createTestEvent(batchSize);
+        HttpResponse response = postEvent( tenant_id, event );
+
+        try {
+            assertEquals( 200, response.getStatusLine().getStatusCode() );
+        }
+        finally {
+            EntityUtils.consume( response.getEntity() ); // Releases connection apparently
+        }
+
+        //Sleep for a while
+        Thread.sleep(1200);
+        Map<String, List<String>> query = new HashMap<String, List<String>>();
+        query.put(Event.tagsParameterName, Arrays.asList("deployment"));
+        List<Map<String, Object>> results = eventsSearchIO.search(tenant_id, query);
+        assertFalse( batchSize == results.size() ); //Only saving the first event of the batch, so the result size will be 1.
+        assertTrue( results.size() == 1 );
+
+        query = new HashMap<String, List<String>>();
+        query.put(Event.fromParameterName, Arrays.asList(String.valueOf(baseMillis - 86400000)));
+        query.put(Event.untilParameterName, Arrays.asList(String.valueOf(baseMillis + (86400000*3))));
+        results = eventsSearchIO.search(tenant_id, query);
+        assertFalse( batchSize == results.size() );
+        assertTrue( results.size() == 1 );
+    }
+
+    @Test
+    public void testHttpAnnotationsIngestionDuplicateEvents() throws Exception {
+        int batchSize = 5; // To create duplicate events
+        String tenant_id = "444444";
+
+        createAndInsertTestEvents(tenant_id, batchSize);
+        esSetup.client().admin().indices().prepareRefresh().execute().actionGet();
+
+        Map<String, List<String>> query = new HashMap<String, List<String>>();
+        query.put( Event.tagsParameterName, Arrays.asList( "deployment" ) );
+
+        List<Map<String, Object>> results = eventsSearchIO.search(tenant_id, query);
+        assertEquals( batchSize, results.size() );
+
+        query = new HashMap<String, List<String>>();
+        query.put( Event.fromParameterName, Arrays.asList( String.valueOf( baseMillis - 86400000 ) ) );
+        query.put( Event.untilParameterName, Arrays.asList( String.valueOf( baseMillis + ( 86400000 * 3 ) ) ) );
+
+        results = eventsSearchIO.search(tenant_id, query);
+        assertEquals( batchSize, results.size() );
+    }
+
+    @Test
+    public void testHttpAnnotationIngestionInvalidPastCollectionTime() throws Exception {
+
+        long timestamp = System.currentTimeMillis() - TIME_DIFF_MS - Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS  );
+
+        final int batchSize = 1;
+        final String tenant_id = "333333";
+        String event = createTestEvent( batchSize, timestamp );
+        HttpResponse response = postEvent( tenant_id, event );
+
+        String[] errors = getBodyArray( response );
+
+        assertEquals( 400, response.getStatusLine().getStatusCode() );
+        assertEquals( 2, errors.length );
+        assertEquals( INVALID_DATA, errors[ 0 ] );
+        assertTrue( Pattern.matches( PAST_COLLECTION_TIME_REGEX, errors[ 1 ] ) );
+    }
+
+    @Test
+    public void testHttpAnnotationIngestionInvalidFutureCollectionTime() throws Exception {
+
+        long timestamp = System.currentTimeMillis() + TIME_DIFF_MS + Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS  );
+
+        final int batchSize = 1;
+        final String tenant_id = "333333";
+        String event = createTestEvent( batchSize, timestamp );
+        HttpResponse response = postEvent( tenant_id, event );
+
+        String[] errors = getBodyArray( response );
+
+        assertEquals( 400, response.getStatusLine().getStatusCode() );
+        assertEquals( 2, errors.length );
+        assertEquals( INVALID_DATA, errors[ 0 ] );
+        assertTrue( Pattern.matches( FUTURE_COLLECTION_TIME_REGEX, errors[ 1 ] ) );
+    }
+
+    @Test
+    public void testHttpAnnotationIngestionMultiEventsInvalidPastCollectionTime() throws Exception {
+
+        long timestamp = System.currentTimeMillis() - TIME_DIFF_MS - Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS  );
+
+        final int batchSize = 5;
+        final String tenant_id = "333444";
+        String event = createTestEvent(batchSize, timestamp);
+        HttpResponse response = postEvent( tenant_id, event );
+
+        String[] errors = getBodyArray( response );
+
+        assertEquals( 400, response.getStatusLine().getStatusCode() );
+        assertEquals( 2, errors.length );
+        assertEquals( INVALID_DATA, errors[ 0 ] );
+        assertTrue( Pattern.matches( PAST_COLLECTION_TIME_REGEX, errors[ 1 ] ) );
+    }
+
+
+    @Test
+    public void testIngestingInvalidJAnnotationsJSON() throws Exception {
+
+        String requestBody = //Invalid JSON with single inverted commas instead of double.
+                "{'when':346550008," +
+                        "'what':'Dummy Event'," +
+                        "'data':'Dummy Data'," +
+                        "'tags':'deployment'}";
+
+        HttpResponse response = postEvent( "456854", requestBody );
+
+        String responseString = EntityUtils.toString(response.getEntity());
+        assertEquals( 400, response.getStatusLine().getStatusCode() );
+        assertTrue( responseString.contains( "Invalid Data:" ) );
+    }
+
+    @Test
+    public void testIngestingInvalidAnnotationsData() throws Exception {
+
+        String requestBody = //Invalid Data.
+                "{\"how\":346550008," +
+                        "\"why\":\"Dummy Event\"," +
+                        "\"info\":\"Dummy Data\"," +
+                        "\"tickets\":\"deployment\"}";
+
+        HttpResponse response = postEvent( "456854", requestBody );
+
+        String responseString = EntityUtils.toString(response.getEntity());
+        assertEquals( 400, response.getStatusLine().getStatusCode() );
+        assertTrue( responseString.contains( "Invalid Data:" ) );
+    }
+
+    @Test
+    public void testHttpAnnotationIngestionMultiEventsInvalidFutureCollectionTime() throws Exception {
+
+        long timestamp = System.currentTimeMillis() + TIME_DIFF_MS + Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS  );
+
+        final int batchSize = 5;
+        final String tenant_id = "333444";
+        String event = createTestEvent(batchSize, timestamp);
+        HttpResponse response = postEvent( tenant_id, event );
+
+        String[] errors = getBodyArray( response );
+
+        assertEquals( 400, response.getStatusLine().getStatusCode() );
+        assertEquals( 2, errors.length );
+        assertEquals( INVALID_DATA, errors[ 0 ] );
+        assertTrue( Pattern.matches( FUTURE_COLLECTION_TIME_REGEX, errors[ 1 ] ) );
+    }
+
+    private void createAndInsertTestEvents(final String tenant, int eventCount) throws Exception {
+        ArrayList<Map<String, Object>> eventList = new ArrayList<Map<String, Object>>();
+        for (int i=0; i<eventCount; i++) {
+            Event event = new Event();
+            event.setWhat("deployment");
+            event.setWhen(Calendar.getInstance().getTimeInMillis());
+            event.setData("deploying prod");
+            event.setTags("deployment");
+
+            eventList.add(event.toMap());
+        }
+        eventsSearchIO.insert(tenant, eventList);
+    }
+}

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
@@ -19,7 +19,6 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
-import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainerTest;
 import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
@@ -42,6 +41,7 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import static org.mockito.Mockito.*;
+import static com.rackspacecloud.blueflood.TestUtils.*;
 
 public class HttpMetricsIngestionServerShutdownIntegrationTest {
 
@@ -85,13 +85,13 @@ public class HttpMetricsIngestionServerShutdownIntegrationTest {
 
         // given
         HttpPost post = new HttpPost(getMetricsURI());
-        HttpEntity entity = new StringEntity(JSONMetricsContainerTest.generateJSONMetricsData(),
+        HttpEntity entity = new StringEntity( generateJSONMetricsData(),
                 ContentType.APPLICATION_JSON);
         post.setEntity(entity);
         HttpResponse response = client.execute(post);
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());
         HttpPost post2 = new HttpPost(getMetricsURI());
-        HttpEntity entity2 = new StringEntity(JSONMetricsContainerTest.generateJSONMetricsData(),
+        HttpEntity entity2 = new StringEntity( generateJSONMetricsData(),
                 ContentType.APPLICATION_JSON);
         post2.setEntity(entity2);
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -20,12 +20,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
-import com.rackspacecloud.blueflood.service.Configuration;
-import com.rackspacecloud.blueflood.service.CoreConfig;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.*;
@@ -46,16 +43,16 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
         long start = System.currentTimeMillis() - TIME_DIFF;
         long end = System.currentTimeMillis() + TIME_DIFF;
 
-        String prefix = getPrefix();
+        String postfix = getPostfix();
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json", prefix);
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json", postfix);
         assertEquals( "Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode() );
         EntityUtils.consume(response.getEntity());
 
         // query for multiplot metric and assert results
         HttpResponse query_response = queryMultiplot(tenant_id, start, end, "200", "FULL", "",
-                "['" + prefix + "3333333.G1s','" + prefix + "3333333.G10s']");
+                "['3333333.G1s" + postfix + "','3333333.G10s" + postfix + "']");
         assertEquals( "Should get status 200 from query server for multiplot POST", 200, query_response.getStatusLine().getStatusCode() );
 
         // assert response content
@@ -74,7 +71,7 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
         JsonObject metric1 = metrics.get( 1 ).getAsJsonObject();
         metricMap.put(  metric1.get( "metric" ).getAsString(), metric1 );
 
-        JsonObject metricCheck1 = metricMap.get( prefix + "3333333.G1s" );
+        JsonObject metricCheck1 = metricMap.get( "3333333.G1s" + postfix );
         assertNotNull( metricCheck1 );
 
         assertEquals( "unknown", metricCheck1.get( "unit" ).getAsString() );
@@ -88,7 +85,7 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
         assertEquals( 397, data0a.get( "latest" ).getAsInt() );
 
 
-        JsonObject metricCheck2 = metricMap.get( prefix + "3333333.G10s" );
+        JsonObject metricCheck2 = metricMap.get( "3333333.G10s" + postfix );
         assertNotNull( metricCheck2 );
 
         assertEquals( "unknown", metricCheck2.get( "unit" ).getAsString() );
@@ -108,14 +105,14 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
         long start = System.currentTimeMillis() - TIME_DIFF;
         long end = System.currentTimeMillis() + TIME_DIFF;
 
-        String prefix = getPrefix();
+        String postfix = getPostfix();
 
         // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
         final String tenant_id = "99988877";
-        final String metric_name = prefix + "call_xyz_api";
+        final String metric_name = "call_xyz_api" + postfix;
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedMultiPath, "sample_multi_enums_payload.json", prefix);
+        HttpResponse response = postMetric(tenant_id, postAggregatedMultiPath, "sample_multi_enums_payload.json", postfix);
         assertEquals( "Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode() );
         EntityUtils.consume(response.getEntity());
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.outputs.handlers;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
@@ -23,27 +24,39 @@ import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
-import org.junit.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+
 public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestBase {
-    private final long fromTime = 1389124830L;
-    private final long toTime = 1439231325000L;
+
+    private static final long TIME_DIFF = 2000;
 
     @Test
     public void testMultiplotQuery() throws Exception {
         // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
         final String tenant_id = "333333";
 
+        long start = System.currentTimeMillis() - TIME_DIFF;
+        long end = System.currentTimeMillis() + TIME_DIFF;
+
+        String prefix = getPrefix();
+
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json");
-        Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json", prefix);
+        assertEquals( "Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode() );
         EntityUtils.consume(response.getEntity());
 
         // query for multiplot metric and assert results
-        HttpResponse query_response = queryMultiplot(tenant_id, fromTime, toTime, "200", "FULL", "", "['3333333.G1s','3333333.G10s']");
-        Assert.assertEquals("Should get status 200 from query server for multiplot POST", 200, query_response.getStatusLine().getStatusCode());
+        HttpResponse query_response = queryMultiplot(tenant_id, start, end, "200", "FULL", "",
+                "['" + prefix + "3333333.G1s','" + prefix + "3333333.G10s']");
+        assertEquals( "Should get status 200 from query server for multiplot POST", 200, query_response.getStatusLine().getStatusCode() );
 
         // assert response content
         String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
@@ -51,54 +64,64 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
         JsonParser jsonParser = new JsonParser();
         JsonObject responseObject = jsonParser.parse(responseContent).getAsJsonObject();
 
-        String expectedResponse = "{\n" +
-                "  \"metrics\": [\n" +
-                "    {\n" +
-                "      \"unit\": \"unknown\",\n" +
-                "      \"metric\": \"3333333.G1s\",\n" +
-                "      \"data\": [\n" +
-                "        {\n" +
-                "          \"numPoints\": 1,\n" +
-                "          \"timestamp\": 1382400000,\n" +
-                "          \"latest\": 397\n" +
-                "        }\n" +
-                "      ],\n" +
-                "      \"type\": \"number\"\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"unit\": \"unknown\",\n" +
-                "      \"metric\": \"3333333.G10s\",\n" +
-                "      \"data\": [\n" +
-                "        {\n" +
-                "          \"numPoints\": 1,\n" +
-                "          \"timestamp\": 1382400000,\n" +
-                "          \"latest\": 56\n" +
-                "        }\n" +
-                "      ],\n" +
-                "      \"type\": \"number\"\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
-        JsonObject expectedObject = jsonParser.parse(expectedResponse).getAsJsonObject();
+        JsonArray metrics = responseObject.getAsJsonArray( "metrics" );
+        assertEquals( 2, metrics.size() );
 
-        Assert.assertEquals(expectedObject, responseObject);
-        EntityUtils.consume(query_response.getEntity());
+        Map<String, JsonObject> metricMap = new HashMap<String, JsonObject>();
+        JsonObject metric0 = metrics.get( 0 ).getAsJsonObject();
+        metricMap.put( metric0.get( "metric" ).getAsString(), metric0 );
+
+        JsonObject metric1 = metrics.get( 1 ).getAsJsonObject();
+        metricMap.put(  metric1.get( "metric" ).getAsString(), metric1 );
+
+        JsonObject metricCheck1 = metricMap.get( prefix + "3333333.G1s" );
+        assertNotNull( metricCheck1 );
+
+        assertEquals( "unknown", metricCheck1.get( "unit" ).getAsString() );
+        assertEquals( "number", metricCheck1.get( "type" ).getAsString() );
+        JsonArray data0 = metricCheck1.getAsJsonArray( "data" );
+        assertEquals( 1, data0.size() );
+
+        JsonObject data0a = data0.get( 0 ).getAsJsonObject();
+        assertTrue( data0a.has( "timestamp" ) );
+        assertEquals( 1, data0a.get( "numPoints" ).getAsInt() );
+        assertEquals( 397, data0a.get( "latest" ).getAsInt() );
+
+
+        JsonObject metricCheck2 = metricMap.get( prefix + "3333333.G10s" );
+        assertNotNull( metricCheck2 );
+
+        assertEquals( "unknown", metricCheck2.get( "unit" ).getAsString() );
+        assertEquals( "number", metricCheck2.get( "type" ).getAsString() );
+
+        JsonArray data1 = metricCheck2.getAsJsonArray( "data" );
+        assertEquals( 1, data1.size() );
+
+        JsonObject data1a = data1.get( 0 ).getAsJsonObject();
+        assertTrue( data1a.has( "timestamp" ) );
+        assertEquals( 1, data1a.get( "numPoints" ).getAsInt() );
+        assertEquals( 56, data1a.get( "latest" ).getAsInt() );
     }
 
     @Test
     public void testMultiplotQueryWithEnum() throws Exception {
+        long start = System.currentTimeMillis() - TIME_DIFF;
+        long end = System.currentTimeMillis() + TIME_DIFF;
+
+        String prefix = getPrefix();
+
         // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
         final String tenant_id = "99988877";
-        final String metric_name = "call_xyz_api";
+        final String metric_name = prefix + "call_xyz_api";
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedMultiPath, "sample_multi_enums_payload.json");
-        Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
+        HttpResponse response = postMetric(tenant_id, postAggregatedMultiPath, "sample_multi_enums_payload.json", prefix);
+        assertEquals( "Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode() );
         EntityUtils.consume(response.getEntity());
 
         // query for multiplot metric and assert results
-        HttpResponse query_response = queryMultiplot(tenant_id, fromTime, toTime, "", "FULL", "enum_values", String.format("['%s']", metric_name));
-        Assert.assertEquals("Should get status 200 from query server for multiplot POST", 200, query_response.getStatusLine().getStatusCode());
+        HttpResponse query_response = queryMultiplot(tenant_id, start, end, "", "FULL", "enum_values", String.format("['%s']", metric_name));
+        assertEquals( "Should get status 200 from query server for multiplot POST", 200, query_response.getStatusLine().getStatusCode() );
 
         // assert response content
         String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
@@ -106,33 +129,19 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
         JsonParser jsonParser = new JsonParser();
         JsonObject responseObject = jsonParser.parse(responseContent).getAsJsonObject();
 
-        String expectedResponse = String.format("{\n" +
-                "  \"metrics\": [\n" +
-                "    {\n" +
-                "      \"unit\": \"unknown\",\n" +
-                "      \"metric\": \"%s\",\n" +
-                "      \"data\": [\n" +
-                "        {\n" +
-                "          \"timestamp\": 1439231324001,\n" +
-                "          \"enum_values\": {\n" +
-                "            \"OK\": 1\n" +
-                "          }\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"timestamp\": 1439231324003,\n" +
-                "          \"enum_values\": {\n" +
-                "            \"ERROR\": 1\n" +
-                "          }\n" +
-                "        }\n" +
-                "      ],\n" +
-                "      \"type\": \"enum\"\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}", metric_name);
+        JsonArray metrics = responseObject.getAsJsonArray( "metrics" );
+        assertEquals( 1, metrics.size() );
 
-        JsonObject expectedObject = jsonParser.parse(expectedResponse).getAsJsonObject();
+        JsonObject metric = metrics.get( 0 ).getAsJsonObject();
+        assertEquals( "unknown", metric.get( "unit" ).getAsString() );
+        assertEquals( metric_name, metric.get( "metric" ).getAsString() );
+        assertEquals( "enum", metric.get( "type" ).getAsString() );
 
-        Assert.assertEquals(expectedObject, responseObject);
-        EntityUtils.consume(query_response.getEntity());
+        JsonArray data = metric.getAsJsonArray( "data" );
+        assertEquals( 2, data.size() );
+
+        JsonObject data1 = data.get( 0 ).getAsJsonObject();
+        assertTrue( data1.has( "timestamp" ) );
+        assertEquals( 1, data1.getAsJsonObject( "enum_values" ).get( "OK" ).getAsInt() );
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
@@ -16,32 +16,38 @@
 
 package com.rackspacecloud.blueflood.outputs.handlers;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.*;
+
 public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestBase {
-    private final long fromTime = 1389124830L;
-    private final long toTime = 1389211230L;
 
     @Test
     public void testSingleplotQuery() throws Exception {
+
+        long start = System.currentTimeMillis() - TIME_DIFF;
+        long end = System.currentTimeMillis() + TIME_DIFF;
+
+        String prefix = getPrefix();
+
         // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
         final String tenant_id = "333333";
-        final String metric_name = "3333333.G1s";
+        final String metric_name = prefix + "3333333.G1s";
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json");
-        Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json", prefix );
+        assertEquals( "Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode() );
         EntityUtils.consume(response.getEntity());
 
         // query for multiplot metric and assert results
-        HttpResponse query_response = querySingleplot(tenant_id, metric_name, fromTime, toTime, "", "FULL", "");
-        Assert.assertEquals("Should get status 200 from query server for single view GET", 200, query_response.getStatusLine().getStatusCode());
+        HttpResponse query_response = querySingleplot(tenant_id, metric_name, start, end, "", "FULL", "");
+        assertEquals( "Should get status 200 from query server for single view GET", 200, query_response.getStatusLine().getStatusCode() );
 
         // assert response content
         String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
@@ -49,42 +55,43 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
         JsonParser jsonParser = new JsonParser();
         JsonObject responseObject = jsonParser.parse(responseContent).getAsJsonObject();
 
-        String expectedResponse = "{\n" +
-                "  \"unit\": \"unknown\",\n" +
-                "  \"values\": [\n" +
-                "    {\n" +
-                "      \"numPoints\": 1,\n" +
-                "      \"timestamp\": 1389211230,\n" +
-                "      \"latest\": 397\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"metadata\": {\n" +
-                "    \"limit\": null,\n" +
-                "    \"next_href\": null,\n" +
-                "    \"count\": 1,\n" +
-                "    \"marker\": null\n" +
-                "  }\n" +
-                "}";
-        JsonObject expectedObject = jsonParser.parse(expectedResponse).getAsJsonObject();
+        assertEquals( "unknown", responseObject.get( "unit" ).getAsString() );
 
-        Assert.assertEquals(expectedObject, responseObject);
-        EntityUtils.consume(query_response.getEntity());
+        JsonArray values = responseObject.getAsJsonArray( "values" );
+        assertEquals( 1, values.size() );
+
+        JsonObject value = values.get( 0 ).getAsJsonObject();
+        assertEquals( 1, value.get( "numPoints" ).getAsInt() );
+        assertTrue( value.has( "timestamp" ) );
+        assertEquals( 397, value.get( "latest" ).getAsInt() );
+
+        JsonObject meta = responseObject.get( "metadata" ).getAsJsonObject();
+        assertTrue( meta.get( "limit" ).isJsonNull() );
+        assertTrue( meta.get( "next_href" ).isJsonNull() );
+        assertEquals( 1,  meta.get( "count" ).getAsInt() );
+        assertTrue( meta.get( "marker" ).isJsonNull() );
     }
 
     @Test
     public void testSingleplotQueryWithEnum() throws Exception {
+
+        long start = System.currentTimeMillis() - TIME_DIFF;
+        long end = System.currentTimeMillis() + TIME_DIFF;
+
+        String prefix = getPrefix();
+
         // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
         final String tenant_id = "333333";
-        final String metric_name = "enum_metric_test";
+        final String metric_name = prefix + "enum_metric_test";
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_enums_payload.json");
-        Assert.assertEquals("Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode());
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_enums_payload.json", prefix );
+        assertEquals( "Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode() );
         EntityUtils.consume(response.getEntity());
 
         // query for multiplot metric and assert results
-        HttpResponse query_response = querySingleplot(tenant_id, metric_name, fromTime, toTime, "", "FULL", "");
-        Assert.assertEquals("Should get status 200 from query server for single view GET", 200, query_response.getStatusLine().getStatusCode());
+        HttpResponse query_response = querySingleplot(tenant_id, metric_name, start, end, "", "FULL", "");
+        assertEquals( "Should get status 200 from query server for single view GET", 200, query_response.getStatusLine().getStatusCode() );
 
         // assert response content
         String responseContent = EntityUtils.toString(query_response.getEntity(), "UTF-8");
@@ -92,28 +99,23 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
         JsonParser jsonParser = new JsonParser();
         JsonObject responseObject = jsonParser.parse(responseContent).getAsJsonObject();
 
-        String expectedResponse = "{\n" +
-                "  \"unit\": \"unknown\",\n" +
-                "  \"values\": [\n" +
-                "    {\n" +
-                "      \"numPoints\": 1,\n" +
-                "      \"timestamp\": 1389211230,\n" +
-                "      \"enum_values\": {\n" +
-                "        \"v3\": 1\n" +
-                "      },\n" +
-                "      \"type\": \"enum\"\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"metadata\": {\n" +
-                "    \"limit\": null,\n" +
-                "    \"next_href\": null,\n" +
-                "    \"count\": 1,\n" +
-                "    \"marker\": null\n" +
-                "  }\n" +
-                "}";
-        JsonObject expectedObject = jsonParser.parse(expectedResponse).getAsJsonObject();
+        assertEquals( "unknown", responseObject.get( "unit" ).getAsString() );
 
-        Assert.assertEquals(expectedObject, responseObject);
-        EntityUtils.consume(query_response.getEntity());
+        JsonArray values = responseObject.getAsJsonArray( "values" );
+        assertEquals( 1, values.size() );
+
+        JsonObject value = values.get( 0 ).getAsJsonObject();
+
+        assertEquals( 1, value.get( "numPoints" ).getAsInt() );
+        assertTrue( value.has( "timestamp" ) );
+        assertEquals( 1, value.getAsJsonObject( "enum_values" ).get( "v3" ).getAsInt() );
+        assertEquals( "enum", value.get( "type").getAsString() );
+
+        JsonObject meta = responseObject.getAsJsonObject( "metadata" );
+        assertTrue( meta.get( "limit" ).isJsonNull() );
+        assertTrue( meta.get( "next_href" ).isJsonNull() );
+        assertEquals( 1,  meta.get( "count" ).getAsInt() );
+        assertTrue( meta.get( "marker" ).isJsonNull() );
+
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
@@ -31,17 +31,17 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
     @Test
     public void testSingleplotQuery() throws Exception {
 
-        long start = System.currentTimeMillis() - TIME_DIFF;
-        long end = System.currentTimeMillis() + TIME_DIFF;
+        long start = System.currentTimeMillis() - TIME_DIFF_MS;
+        long end = System.currentTimeMillis() + TIME_DIFF_MS;
 
-        String prefix = getPrefix();
+        String postfix = getPostfix();
 
         // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
         final String tenant_id = "333333";
-        final String metric_name = prefix + "3333333.G1s";
+        final String metric_name = "3333333.G1s" + postfix;
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json", prefix );
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json", postfix );
         assertEquals( "Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode() );
         EntityUtils.consume(response.getEntity());
 
@@ -75,17 +75,17 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
     @Test
     public void testSingleplotQueryWithEnum() throws Exception {
 
-        long start = System.currentTimeMillis() - TIME_DIFF;
-        long end = System.currentTimeMillis() + TIME_DIFF;
+        long start = System.currentTimeMillis() - TIME_DIFF_MS;
+        long end = System.currentTimeMillis() + TIME_DIFF_MS;
 
-        String prefix = getPrefix();
+        String postfix = getPostfix();
 
         // ingest and rollup metrics with enum values and verify CF points and elastic search indexes
         final String tenant_id = "333333";
-        final String metric_name = prefix + "enum_metric_test";
+        final String metric_name = "enum_metric_test" + postfix;
 
         // post multi metrics for ingestion and verify
-        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_enums_payload.json", prefix );
+        HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_enums_payload.json", postfix );
         assertEquals( "Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode() );
         EntityUtils.consume(response.getEntity());
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
@@ -48,6 +48,9 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 public class HttpMetricsIngestionHandler implements HttpRequestHandler {
+
+    public static final String ERROR_HEADER = "The following errors have been encountered:";
+
     private static final Logger log = LoggerFactory.getLogger(HttpMetricsIngestionHandler.class);
     private static final Counter requestCount = Metrics.counter(HttpMetricsIngestionHandler.class, "HTTP Request Count");
 
@@ -63,7 +66,7 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
 
     public static String getResponseBody( List<String> errors ) {
         StringBuilder sb = new StringBuilder();
-        sb.append( "The following errors have been encountered:" + System.lineSeparator() );
+        sb.append( ERROR_HEADER + System.lineSeparator() );
 
         for( String error : errors ) {
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
@@ -61,6 +61,18 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
     private static final Timer jsonTimer = Metrics.timer(HttpMetricsIngestionHandler.class, "HTTP Ingestion json processing timer");
     private static final Timer persistingTimer = Metrics.timer(HttpMetricsIngestionHandler.class, "HTTP Ingestion persisting timer");
 
+    public static String getResponseBody( List<String> errors ) {
+        StringBuilder sb = new StringBuilder();
+        sb.append( "The following errors have been encountered:" + System.lineSeparator() );
+
+        for( String error : errors ) {
+
+            sb.append( error + System.lineSeparator() );
+        }
+        return sb.toString();
+    }
+
+
     public HttpMetricsIngestionHandler(HttpMetricsIngestionServer.Processor processor, TimeValue timeout) {
         this.mapper = new ObjectMapper();
         this.typeFactory = TypeFactory.defaultInstance();
@@ -180,17 +192,6 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
         } finally {
             requestCount.dec();
         }
-    }
-
-    private String getResponseBody( List<String> errors ) {
-        StringBuilder sb = new StringBuilder();
-        sb.append( "The following errors have been encountered:" + System.lineSeparator() );
-
-        for( String error : errors ) {
-
-            sb.append( error + System.lineSeparator() );
-        }
-        return sb.toString();
     }
 
     private void forceTTLsIfConfigured(List<Metric> containerMetrics) {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/wrappers/AggregatedPayload.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/wrappers/AggregatedPayload.java
@@ -16,6 +16,8 @@
 
 package com.rackspacecloud.blueflood.inputs.handlers.wrappers;
 
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.*;
 
 import java.util.AbstractList;
@@ -25,6 +27,9 @@ import java.util.Map;
 
 // Using nested classes for now. Expect this to be cleaned up.
 public class AggregatedPayload {
+    private static final long pastDiff = Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
+    private static final long futureDiff = Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
+
     private String tenantId;
     private long timestamp; // millis since epoch.
     
@@ -56,6 +61,19 @@ public class AggregatedPayload {
     public Collection<BluefloodSet> getSets() { return safeAsList(sets); }
     public Collection<BluefloodEnum> getEnums() { return safeAsList(enums); }
 
+
+    public List<String> getValidationErrors() {
+
+        List<String> errors = new java.util.ArrayList<String>();
+        long current = System.currentTimeMillis();
+
+        if( timestamp > current + futureDiff )
+            errors.add( "'timestamp' '" + timestamp + "' is more than '" + futureDiff + "' milliseconds into the future." );
+        else if( timestamp < current - pastDiff )
+            errors.add( "'timestamp' '" + timestamp + "' is more than '" + pastDiff + "' milliseconds into the past." );
+
+        return errors;
+    }
 
     //@SafeVarargs (1.7 only doge)
     public static <T> List<T> safeAsList(final T... a) {

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/TestUtils.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/TestUtils.java
@@ -1,0 +1,213 @@
+package com.rackspacecloud.blueflood;
+
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import org.apache.commons.io.IOUtils;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * A collection of static fields & methods which are useful in testing blueflood.  Most of these methods are involved with
+ * generating data for the JSON API.
+ */
+public class TestUtils {
+
+    public static final String ERROR_TITLE = "The following errors have been encountered:";
+    public static final String PAST_COLLECTION_TIME_REGEX = ".* is more than '" + Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS ) + "' milliseconds into the past\\.$";
+    public static final String FUTURE_COLLECTION_TIME_REGEX = ".* is more than '" + Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS ) + "' milliseconds into the future\\.$";
+    public static final String NO_TENANT_ID_REGEX = ".* No tenantId is provided for the metric\\.";
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final String TIMESTAMP = "\"%TIMESTAMP%\"";
+    private static final String POSTFIX = "%POSTFIX%";
+
+    // making this just a static class, no instantiations
+    private TestUtils() {}
+
+    /**
+     * Generate multi-tenant metrics data using:
+     * <li>current timestamp
+     * <li>tenant ids of tenantOne and tennatTwo
+     * <li>random metric name postfix
+     *
+     * @return
+     * @throws Exception
+     */
+    public static String generateMultitenantJSONMetricsData() throws Exception {
+        long collectionTime = System.currentTimeMillis();
+
+        List<Map<String, Object>> dataOut = new ArrayList<Map<String, Object>>();
+        for (Map<String, Object> stringObjectMap : generateMetricsData( "", collectionTime )) {
+            stringObjectMap.put("tenantId", "tenantOne");
+            dataOut.add(stringObjectMap);
+        }
+        for (Map<String, Object> stringObjectMap : generateMetricsData( "", collectionTime )) {
+            stringObjectMap.put("tenantId", "tenantTwo");
+            dataOut.add(stringObjectMap);
+        }
+
+        return mapper.writeValueAsString(dataOut);
+    }
+
+    /**
+     * Generate a single metric data using:
+     * <li>current timestamp
+     * <li>random metric name postfix
+     *
+     * @return
+     * @throws Exception
+     */
+    public static String generateJSONMetricsData() throws Exception {
+        return generateJSONMetricsData( System.currentTimeMillis() );
+    }
+
+    /**
+     * Generate single metric data using:
+     * <li> provided timestamp
+     * <li> provided metric name postfix
+     *
+     * @param metricPostfix
+     * @param collectionTime
+     * @return
+     * @throws Exception
+     */
+    public static String generateJSONMetricsData( String metricPostfix, long collectionTime ) throws Exception {
+
+        StringWriter writer = new StringWriter();
+        mapper.writeValue(writer, generateMetricsData( metricPostfix, collectionTime ));
+
+        return writer.toString();
+    }
+
+    /**
+     * Generate single metric data using:
+     * <li> current timestamp
+     * <li> provided metric name postfix
+     *
+     * @param metricPostfix
+     * @return
+     * @throws Exception
+     */
+    public static String generateJSONMetricsData( String metricPostfix ) throws Exception {
+        return generateJSONMetricsData( metricPostfix, System.currentTimeMillis() );
+    }
+
+    /**
+     * Given a Reader object pointing to a blueflood ingestion payload, replace all TIMESTAMP & POSTFIX patterns with:
+     * <li> current timestamp
+     * <li> provided metric name postfix
+     *
+     * @param reader
+     * @param postfix
+     * @return
+     * @throws IOException
+     */
+    public static String getJsonFromFile( Reader reader, String postfix ) throws IOException {
+
+        return getJsonFromFile( reader, System.currentTimeMillis(), postfix );
+    }
+
+    /**
+     * Given a Reader object pointing to a blueflood ingestion payload, replace all TIMESTAMP & POSTFIX patterns with:
+     * <li> provided timestamp
+     * <li> provided metric name postfix
+     *
+     * @param reader
+     * @param timestamp
+     * @param postfix
+     * @return
+     * @throws IOException
+     */
+    public static String getJsonFromFile( Reader reader, long timestamp, String postfix ) throws IOException {
+        StringWriter writer = new StringWriter();
+
+        IOUtils.copy( reader, writer );
+        IOUtils.closeQuietly( reader );
+
+        String json = writer.toString();
+
+        // JSON might have several entries for the same metric.  If they have the same timestamp, they coudl overwrite
+        // each other in the case of enums.  Not using sleep() here to increment the time as to not have to deal with
+        // interruptedexception.  Rather, incrementing the time by 1 ms.
+
+        long increment = 0;
+
+        while( json.contains( TIMESTAMP ) ) {
+
+            json = json.replaceFirst( TIMESTAMP, Long.toString( timestamp + increment++ ) );
+        }
+
+        json = json.replace( POSTFIX, postfix );
+
+        return json;
+    }
+
+
+    /**
+     * Generate single metric data using:
+     * <li> provided timestamp
+     * <li> random generated metric name postfix
+     *
+     * @param collectionTime
+     * @return
+     * @throws Exception
+     */
+    private static String generateJSONMetricsData( long collectionTime ) throws Exception {
+
+        StringWriter writer = new StringWriter();
+        mapper.writeValue(writer, generateMetricsData( "", collectionTime ));
+
+        return writer.toString();
+    }
+
+    /**
+     * Returns a list of list of maps which represent metrics, each metric uses:
+     * <li> provided timestamp
+     * <li> metric name postfix
+     *
+     * @param metricPostfix
+     * @param collectionTime
+     * @return
+     */
+    private static List<Map<String, Object>> generateMetricsData( String metricPostfix, long collectionTime ) {
+
+        List<Map<String, Object>> metricsList = new ArrayList<Map<String, Object>>();
+
+        // Long metric value
+        Map<String, Object> testMetric = new TreeMap<String, Object>();
+        testMetric.put("metricName", "mzord.duration" + metricPostfix );
+        testMetric.put("ttlInSeconds", 1234566);
+        testMetric.put("unit", "milliseconds");
+        testMetric.put("metricValue", Long.MAX_VALUE);
+        testMetric.put("collectionTime", collectionTime );
+        metricsList.add(testMetric);
+
+        // String metric value
+        testMetric = new TreeMap<String, Object>();
+        testMetric.put("metricName", "mzord.status" + metricPostfix );
+        testMetric.put("ttlInSeconds", 1234566);
+        testMetric.put("unit", "unknown");
+        testMetric.put("metricValue", "Website is up");
+        testMetric.put("collectionTime", collectionTime );
+        metricsList.add(testMetric);
+
+        // null metric value. This shouldn't be in the final list of metrics because we ignore null valued metrics.
+        testMetric = new TreeMap<String, Object>();
+        testMetric.put("metricName", "mzord.hipster" + metricPostfix );
+        testMetric.put("ttlInSeconds", 1234566);
+        testMetric.put("unit", "unknown");
+        testMetric.put("metricValue", null);
+        testMetric.put("collectionTime", collectionTime );
+        metricsList.add(testMetric);
+
+        return metricsList;
+
+    }
+}

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainerTest.java
@@ -24,17 +24,13 @@ import org.codehaus.jackson.map.type.TypeFactory;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
+import static com.rackspacecloud.blueflood.TestUtils.*;
 
 public class JSONMetricsContainerTest {
-
-    public static final String PAST_COLLECTION_TIME_REGEX = ".* is more than '259200000' milliseconds into the past\\.$";
-    public static final String FUTURE_COLLECTION_TIME_REGEX = ".* is more than '600000' milliseconds into the future\\.$";
-    public static final String NO_TENANT_ID_REGEX = ".* No tenantId is provided for the metric\\.";
 
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final long MINUTE = 60000;
@@ -176,102 +172,4 @@ public class JSONMetricsContainerTest {
         return new JSONMetricsContainer( name, jsonMetrics);
     }
 
-    public static List<Map<String, Object>> generateMetricsData( String metricPrefix, long collectionTime ) {
-
-        List<Map<String, Object>> metricsList = new ArrayList<Map<String, Object>>();
-
-        // Long metric value
-        Map<String, Object> testMetric = new TreeMap<String, Object>();
-        testMetric.put("metricName", metricPrefix + "mzord.duration");
-        testMetric.put("ttlInSeconds", 1234566);
-        testMetric.put("unit", "milliseconds");
-        testMetric.put("metricValue", Long.MAX_VALUE);
-        testMetric.put("collectionTime", collectionTime );
-        metricsList.add(testMetric);
-
-        // String metric value
-        testMetric = new TreeMap<String, Object>();
-        testMetric.put("metricName", metricPrefix + "mzord.status");
-        testMetric.put("ttlInSeconds", 1234566);
-        testMetric.put("unit", "unknown");
-        testMetric.put("metricValue", "Website is up");
-        testMetric.put("collectionTime", collectionTime );
-        metricsList.add(testMetric);
-
-        // null metric value. This shouldn't be in the final list of metrics because we ignore null valued metrics.
-        testMetric = new TreeMap<String, Object>();
-        testMetric.put("metricName", metricPrefix + "mzord.hipster");
-        testMetric.put("ttlInSeconds", 1234566);
-        testMetric.put("unit", "unknown");
-        testMetric.put("metricValue", null);
-        testMetric.put("collectionTime", collectionTime );
-        metricsList.add(testMetric);
-
-        return metricsList;
-
-    }
-
-    public static List<Map<String, Object>> generateAnnotationsData() throws Exception {
-        List<Map<String, Object>> annotationsList = new ArrayList<Map<String, Object>>();
-
-        // Long metric value
-        Map<String, Object> testAnnotation = new TreeMap<String, Object>();
-        testAnnotation.put("what","deployment");
-        testAnnotation.put("when", Calendar.getInstance().getTimeInMillis());
-        testAnnotation.put("tags","prod");
-        testAnnotation.put("data","app00.restart");
-
-        annotationsList.add(testAnnotation);
-        return annotationsList;
-    }
-
-    public static String generateJSONAnnotationsData() throws Exception {
-
-        StringWriter writer = new StringWriter();
-        mapper.writeValue(writer, generateAnnotationsData());
-
-        return writer.toString();
-    }
-
-    public static String generateJSONMetricsData( long collectionTime ) throws Exception {
-
-        StringWriter writer = new StringWriter();
-        mapper.writeValue(writer, generateMetricsData( "", collectionTime ));
-
-        return writer.toString();
-    }
-
-    public static String generateJSONMetricsData( String metricPrefix, long collectionTime ) throws Exception {
-
-        StringWriter writer = new StringWriter();
-        mapper.writeValue(writer, generateMetricsData( metricPrefix, collectionTime ));
-
-        return writer.toString();
-    }
-
-
-    public static String generateJSONMetricsData( String metricPrefix ) throws Exception {
-        return generateJSONMetricsData( metricPrefix, System.currentTimeMillis() );
-    }
-
-
-    public static String generateJSONMetricsData() throws Exception {
-        return generateJSONMetricsData( System.currentTimeMillis() );
-    }
-
-    public static String generateMultitenantJSONMetricsData() throws Exception {
-        long collectionTime = System.currentTimeMillis();
-
-        List<Map<String, Object>> dataOut = new ArrayList<Map<String, Object>>();
-        for (Map<String, Object> stringObjectMap : generateMetricsData( "", collectionTime )) {
-            stringObjectMap.put("tenantId", "tenantOne");
-            dataOut.add(stringObjectMap);
-        }
-        for (Map<String, Object> stringObjectMap : generateMetricsData( "", collectionTime )) {
-            stringObjectMap.put("tenantId", "tenantTwo");
-            dataOut.add(stringObjectMap);
-        }
-
-        return mapper.writeValueAsString(dataOut);
-    }
 }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionTests.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionTests.java
@@ -18,33 +18,36 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.google.gson.internal.LazilyParsedNumber;
 import com.netflix.astyanax.serializers.AbstractSerializer;
+import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainerTest;
 import com.rackspacecloud.blueflood.inputs.handlers.wrappers.AggregatedPayload;
+import com.rackspacecloud.blueflood.inputs.handlers.wrappers.TestGsonParsing;
 import com.rackspacecloud.blueflood.io.serializers.NumericSerializer;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.PreaggregatedMetric;
-import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static junit.framework.Assert.*;
+
 
 public class HttpAggregatedIngestionTests {
-    
+
+    public static final long TIME_DIFF = 2000;
+
     private AggregatedPayload payload;
-    
+
+    private final String  prefix = "pref.";
+
     @Before
     public void buildPayload() throws IOException {
-        StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/test/resources/sample_payload.json")));
-        String curLine = reader.readLine();
-        while (curLine != null) {
-            sb = sb.append(curLine);
-            curLine = reader.readLine();
-        }
-        String json = sb.toString();
+
+        String json = TestGsonParsing.getJsonFromFile( new InputStreamReader(new FileInputStream("src/test/resources/sample_payload.json")), prefix );
         payload = HttpAggregatedIngestionHandler.createPayload(json);
     }
     
@@ -56,45 +59,77 @@ public class HttpAggregatedIngestionTests {
     @Test
     public void testGsonNumberConversions() {
         Number doubleNum = new LazilyParsedNumber("2.321");
-        Assert.assertEquals(Double.parseDouble("2.321"), PreaggregateConversions.resolveNumber(doubleNum));
+        assertEquals( Double.parseDouble( "2.321" ), PreaggregateConversions.resolveNumber( doubleNum ) );
         
         Number longNum = new LazilyParsedNumber("12345");
-        Assert.assertEquals(Long.parseLong("12345"), PreaggregateConversions.resolveNumber(longNum));
+        assertEquals( Long.parseLong( "12345" ), PreaggregateConversions.resolveNumber( longNum ) );
     }
     
     @Test
     public void testCounters() {
         Collection<PreaggregatedMetric> counters = PreaggregateConversions.convertCounters("1", 1, 15000, payload.getCounters());
-        Assert.assertEquals(6, counters.size());
+        assertEquals( 6, counters.size() );
         ensureSerializability(counters);
     }
     
     @Test
     public void testGauges() {
         Collection<PreaggregatedMetric> gauges = PreaggregateConversions.convertGauges("1", 1, payload.getGauges());
-        Assert.assertEquals(4, gauges.size());
+        assertEquals( 4, gauges.size() );
         ensureSerializability(gauges);
     }
      
     @Test
     public void testSets() {
         Collection<PreaggregatedMetric> sets = PreaggregateConversions.convertSets("1", 1, payload.getSets());
-        Assert.assertEquals(2, sets.size());
+        assertEquals( 2, sets.size() );
         ensureSerializability(sets);
     }
     
     @Test
     public void testTimers() {
         Collection<PreaggregatedMetric> timers = PreaggregateConversions.convertTimers("1", 1, payload.getTimers());
-        Assert.assertEquals(4, timers.size());
+        assertEquals( 4, timers.size() );
         ensureSerializability(timers);
     }
 
     @Test
     public void testEnums() {
         Collection<PreaggregatedMetric> enums = PreaggregateConversions.convertEnums("1", 1, payload.getEnums());
-        Assert.assertEquals(1, enums.size());
+        assertEquals( 1, enums.size() );
         ensureSerializability(enums);
+    }
+
+    @Test
+    public void testTimestampInTheFuture() throws IOException {
+
+        long timestamp = System.currentTimeMillis() + TIME_DIFF
+                + Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
+
+        String json = TestGsonParsing.getJsonFromFile( new InputStreamReader(new FileInputStream("src/test/resources/sample_payload.json")),
+                timestamp, prefix );
+        payload = HttpAggregatedIngestionHandler.createPayload(json );
+
+        List<String> errors = payload.getValidationErrors();
+
+        assertEquals( 1, errors.size() );
+        assertTrue( Pattern.matches( JSONMetricsContainerTest.FUTURE_COLLECTION_TIME_REGEX, errors.get( 0 ) ) );
+    }
+
+    @Test
+    public void testTimestampInThePast() throws IOException {
+
+        long timestamp = System.currentTimeMillis() - TIME_DIFF
+                - Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
+
+        String json = TestGsonParsing.getJsonFromFile( new InputStreamReader(new FileInputStream("src/test/resources/sample_payload.json")),
+                timestamp, prefix );
+        payload = HttpAggregatedIngestionHandler.createPayload(json );
+
+        List<String> errors = payload.getValidationErrors();
+
+        assertEquals( 1, errors.size() );
+        assertTrue( Pattern.matches( JSONMetricsContainerTest.PAST_COLLECTION_TIME_REGEX, errors.get( 0 ) ) );
     }
 
     // ok. while we're out it, let's test serialization. Just for fun. The reasoning is that these metrics

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionTest.java
@@ -24,28 +24,26 @@ import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
-public class HttpAggregatedMultiIngestionTests {
+import static com.rackspacecloud.blueflood.TestUtils.*;
+
+
+public class HttpAggregatedMultiIngestionTest {
     
     private List<AggregatedPayload> bundleList;
-    
+
+    private final String postfix = ".pref";
+
     @Before
     public void buildBundle() throws IOException {
-        StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/test/resources/sample_multi_aggregated_payload.json")));
-        String curLine = reader.readLine();
-        while (curLine != null) {
-            sb = sb.append(curLine);
-            curLine = reader.readLine();
-        }
-        String json = sb.toString();
+
+        String json = getJsonFromFile( new InputStreamReader( getClass().getClassLoader().getResourceAsStream( "sample_multi_aggregated_payload.json" ) ),
+                postfix );
         bundleList = HttpAggregatedMultiIngestionHandler.createBundleList(json);
     }
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/wrappers/TestGsonParsing.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/wrappers/TestGsonParsing.java
@@ -4,32 +4,61 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.rackspacecloud.blueflood.types.BluefloodTimer;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpAggregatedIngestionHandler;
-import junit.framework.Assert;
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
 
 public class TestGsonParsing {
-    
-    private String json;
-    
-    @Before
-    public void readJsonFile() throws IOException {
-        StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/test/resources/sample_payload.json")));
-        String curLine = reader.readLine();
-        while (curLine != null) {
-            sb = sb.append(curLine);
-            curLine = reader.readLine();
+
+    private static final String TIMESTAMP = "\"%TIMESTAMP%\"";
+    private static final String PREFIX = "%PREFIX%";
+
+    private String prefix = "prefix";
+
+    public static String getJsonFromFile( Reader reader, String prefix ) throws IOException {
+
+        return getJsonFromFile( reader, System.currentTimeMillis(), prefix );
+    }
+
+    public static String getJsonFromFile( Reader reader, long timestamp, String prefix ) throws IOException {
+        StringWriter writer = new StringWriter();
+
+        IOUtils.copy( reader, writer );
+        IOUtils.closeQuietly( reader );
+
+        String json = writer.toString();
+
+        // JSON might have several entries for the same metric.  If they have the same timestamp, they coudl overwrite
+        // each other in the case of enums.  Not using sleep() here to increment the time as to not have to deal with
+        // interruptedexception.  Rather, incrementing the time by 1 ms.
+
+        long increment = 0;
+
+        while( json.contains( TIMESTAMP ) ) {
+
+            json = json.replaceFirst( TIMESTAMP, Long.toString( timestamp + increment++ ) );
         }
-        json = sb.toString();
+
+        json = json.replace( PREFIX, prefix );
+
+        return json;
+    }
+
+    private String json;
+    private long current = System.currentTimeMillis();
+
+    @Before
+    public void readJsonFile() throws IOException, InterruptedException {
+
+        json = getJsonFromFile( new InputStreamReader(new FileInputStream("src/test/resources/sample_payload.json")), prefix );
     }
     
     @Test
@@ -49,45 +78,45 @@ public class TestGsonParsing {
         Gson gson = new Gson();
         AggregatedPayload payload = gson.fromJson(json, AggregatedPayload.class);
 
-        Assert.assertNotNull(payload);
-        Assert.assertEquals("333333", payload.getTenantId());
-        Assert.assertEquals(1389211230L, payload.getTimestamp());
-        Assert.assertEquals(15000L, payload.getFlushIntervalMillis());
+        assertNotNull(payload);
+        assertEquals("333333", payload.getTenantId());
+        assertEquals(current, payload.getTimestamp(), 120000 );
+        assertEquals(15000L, payload.getFlushIntervalMillis());
         
-        Assert.assertEquals(4, payload.getGauges().size());
-        Assert.assertEquals(6, payload.getCounters().size());
-        Assert.assertEquals(4, payload.getTimers().size());
-        Assert.assertEquals(2, payload.getSets().size());
-        Assert.assertEquals(1, payload.getEnums().size());
+        assertEquals(4, payload.getGauges().size());
+        assertEquals(6, payload.getCounters().size());
+        assertEquals(4, payload.getTimers().size());
+        assertEquals(2, payload.getSets().size());
+        assertEquals(1, payload.getEnums().size());
     }
 
     @Test
     public void testHistograms() {
         AggregatedPayload payload = new Gson().fromJson(json, AggregatedPayload.class);
         
-        Assert.assertNotNull(payload);
+        assertNotNull(payload);
         Map<String, BluefloodTimer> timers = asMap(payload.getTimers());
         
-        Assert.assertEquals(4, timers.get("4444444.T1s").getHistogram().size());
-        Assert.assertEquals(11, timers.get("3333333.T29s").getHistogram().size());
-        Assert.assertEquals(11, timers.get("3333333.T200ms").getHistogram().size());
+        assertEquals(4, timers.get( prefix + "4444444.T1s").getHistogram().size());
+        assertEquals(11, timers.get( prefix + "3333333.T29s").getHistogram().size());
+        assertEquals(11, timers.get( prefix + "3333333.T200ms").getHistogram().size());
         
         // this one is non-existant in the json, but we do not want a null map.
-        Assert.assertNotNull(timers.get("3333333.T10s").getHistogram());
-        Assert.assertEquals(0, timers.get("3333333.T10s").getHistogram().size());
+        assertNotNull(timers.get( prefix + "3333333.T10s").getHistogram());
+        assertEquals(0, timers.get( prefix + "3333333.T10s").getHistogram().size());
     }
     
     @Test
     public void testPercentiles() {
         AggregatedPayload payload = new Gson().fromJson(json, AggregatedPayload.class);
         
-        Assert.assertNotNull(payload);
+        assertNotNull(payload);
         Map<String, BluefloodTimer> timers = asMap(payload.getTimers());
         
-        Assert.assertEquals(5, timers.get("4444444.T1s").getPercentiles().size());
-        Assert.assertEquals(5, timers.get("3333333.T29s").getPercentiles().size());
-        Assert.assertEquals(5, timers.get("3333333.T10s").getPercentiles().size());
-        Assert.assertEquals(5, timers.get("3333333.T200ms").getPercentiles().size());
+        assertEquals(5, timers.get( prefix + "4444444.T1s").getPercentiles().size());
+        assertEquals(5, timers.get( prefix + "3333333.T29s").getPercentiles().size());
+        assertEquals(5, timers.get( prefix + "3333333.T10s").getPercentiles().size());
+        assertEquals(5, timers.get( prefix + "3333333.T200ms").getPercentiles().size());
     }
     
     private static Map<String, BluefloodTimer> asMap(Collection<BluefloodTimer> timers) {

--- a/blueflood-http/src/test/resources/sample_enums_payload.json
+++ b/blueflood-http/src/test/resources/sample_enums_payload.json
@@ -3,23 +3,23 @@
     "timestamp":"%TIMESTAMP%",
     "enums": [
         {
-            "name": "%PREFIX%enum_metric_test",
+            "name": "enum_metric_test%POSTFIX%",
             "value": "v3"
         },
         {
-            "name": "%PREFIX%enum_metric_test",
+            "name": "enum_metric_test%POSTFIX%",
             "value": "v1"
         },
         {
-            "name": "%PREFIX%enum_metric_test",
+            "name": "enum_metric_test%POSTFIX%",
             "value": "v1"
         },
         {
-            "name": "%PREFIX%enum_metric_test",
+            "name": "enum_metric_test%POSTFIX%",
             "value": "v2"
         },
         {
-            "name": "%PREFIX%enum_metric_test",
+            "name": "enum_metric_test%POSTFIX%",
             "value": "v3"
         }
     ]

--- a/blueflood-http/src/test/resources/sample_enums_payload.json
+++ b/blueflood-http/src/test/resources/sample_enums_payload.json
@@ -1,25 +1,25 @@
 {
     "tenantId":"333333",
-    "timestamp":1389211230,
+    "timestamp":"%TIMESTAMP%",
     "enums": [
         {
-            "name": "enum_metric_test",
+            "name": "%PREFIX%enum_metric_test",
             "value": "v3"
         },
         {
-            "name": "enum_metric_test",
+            "name": "%PREFIX%enum_metric_test",
             "value": "v1"
         },
         {
-            "name": "enum_metric_test",
+            "name": "%PREFIX%enum_metric_test",
             "value": "v1"
         },
         {
-            "name": "enum_metric_test",
+            "name": "%PREFIX%enum_metric_test",
             "value": "v2"
         },
         {
-            "name": "enum_metric_test",
+            "name": "%PREFIX%enum_metric_test",
             "value": "v3"
         }
     ]

--- a/blueflood-http/src/test/resources/sample_multi_aggregated_payload.json
+++ b/blueflood-http/src/test/resources/sample_multi_aggregated_payload.json
@@ -1,108 +1,108 @@
 [
     {
         "tenantId":"5405532",
-        "timestamp":1439231324000,
+        "timestamp":"%TIMESTAMP%",
         "gauges":[
             {
-                "name":"G200ms",
+                "name":"%PREFIX%G200ms",
                 "value":145
             }
         ],
         "counters":[
             {
-                "name":"internal.bad_lines_seen",
+                "name":"%PREFIX%internal.bad_lines_seen",
                 "value":0,
                 "rate":0
             }
         ],
         "timers":[
             {
-                "name":"T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+                "name":"%PREFIX%T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
                 "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
                 "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
             }
         ],
         "sets":[
             {
-                "name":"S500ms",
+                "name":"%PREFIX%S500ms",
                 "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
             }
         ],
         "enums": [
             {
-                "name": "call_xyz_api",
+                "name": "%PREFIX%call_xyz_api",
                 "value": "OK"
             }
         ]
     },
     {
         "tenantId":"5405577",
-        "timestamp":1439231324001,
+        "timestamp":"%TIMESTAMP%",
         "gauges":[
             {
-                "name":"G200ms",
+                "name":"%PREFIX%G200ms",
                 "value":145
             }
         ],
         "counters":[
             {
-                "name":"internal.bad_lines_seen",
+                "name":"%PREFIX%internal.bad_lines_seen",
                 "value":0,
                 "rate":0
             }
         ],
         "timers":[
             {
-                "name":"T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+                "name":"%PREFIX%T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
                 "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
                 "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
             }
         ],
         "sets":[
             {
-                "name":"S500ms",
+                "name":"%PREFIX%S500ms",
                 "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
             }
         ],
         "enums": [
             {
-                "name": "call_xyz_api",
+                "name": "%PREFIX%call_xyz_api",
                 "value": "OK"
             }
         ]
     },
     {
         "tenantId":"1234567",
-        "timestamp":1449241324001,
+        "timestamp":"%TIMESTAMP%",
         "gauges":[
             {
-                "name":"G200ms",
+                "name":"%PREFIX%G200ms",
                 "value":145
             }
         ],
         "counters":[
             {
-                "name":"internal.bad_lines_seen",
+                "name":"%PREFIX%internal.bad_lines_seen",
                 "value":0,
                 "rate":0
             }
         ],
         "timers":[
             {
-                "name":"T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+                "name":"%PREFIX%T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
                 "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
                 "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
             }
         ],
         "sets":[
             {
-                "name":"S500ms",
+                "name":"%PREFIX%S500ms",
                 "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
             }
         ],
         "enums": [
             {
-                "name": "call_xyz_api",
+                "name": "%PREFIX%call_xyz_api",
                 "value": "OK"
             }
         ]

--- a/blueflood-http/src/test/resources/sample_multi_aggregated_payload.json
+++ b/blueflood-http/src/test/resources/sample_multi_aggregated_payload.json
@@ -4,33 +4,33 @@
         "timestamp":"%TIMESTAMP%",
         "gauges":[
             {
-                "name":"%PREFIX%G200ms",
+                "name":"G200ms%POSTFIX%",
                 "value":145
             }
         ],
         "counters":[
             {
-                "name":"%PREFIX%internal.bad_lines_seen",
+                "name":"internal.bad_lines_seen%POSTFIX%",
                 "value":0,
                 "rate":0
             }
         ],
         "timers":[
             {
-                "name":"%PREFIX%T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+                "name":"T1s%POSTFIX%","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
                 "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
                 "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
             }
         ],
         "sets":[
             {
-                "name":"%PREFIX%S500ms",
+                "name":"S500ms%POSTFIX%",
                 "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
             }
         ],
         "enums": [
             {
-                "name": "%PREFIX%call_xyz_api",
+                "name": "call_xyz_api%POSTFIX%",
                 "value": "OK"
             }
         ]
@@ -40,33 +40,33 @@
         "timestamp":"%TIMESTAMP%",
         "gauges":[
             {
-                "name":"%PREFIX%G200ms",
+                "name":"G200ms%POSTFIX%",
                 "value":145
             }
         ],
         "counters":[
             {
-                "name":"%PREFIX%internal.bad_lines_seen",
+                "name":"internal.bad_lines_seen%POSTFIX%",
                 "value":0,
                 "rate":0
             }
         ],
         "timers":[
             {
-                "name":"%PREFIX%T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+                "name":"T1s%POSTFIX%","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
                 "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
                 "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
             }
         ],
         "sets":[
             {
-                "name":"%PREFIX%S500ms",
+                "name":"%POSTFIX%S500ms",
                 "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
             }
         ],
         "enums": [
             {
-                "name": "%PREFIX%call_xyz_api",
+                "name": "call_xyz_api%POSTFIX%",
                 "value": "OK"
             }
         ]
@@ -76,33 +76,33 @@
         "timestamp":"%TIMESTAMP%",
         "gauges":[
             {
-                "name":"%PREFIX%G200ms",
+                "name":"G200ms%POSTFIX%",
                 "value":145
             }
         ],
         "counters":[
             {
-                "name":"%PREFIX%internal.bad_lines_seen",
+                "name":"internal.bad_lines_seen%POSTFIX%",
                 "value":0,
                 "rate":0
             }
         ],
         "timers":[
             {
-                "name":"%PREFIX%T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+                "name":"T1s%POSTFIX%","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
                 "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
                 "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
             }
         ],
         "sets":[
             {
-                "name":"%PREFIX%S500ms",
+                "name":"S500ms%POSTFIX%",
                 "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
             }
         ],
         "enums": [
             {
-                "name": "%PREFIX%call_xyz_api",
+                "name": "call_xyz_api%POSTFIX%",
                 "value": "OK"
             }
         ]

--- a/blueflood-http/src/test/resources/sample_multi_enums_payload.json
+++ b/blueflood-http/src/test/resources/sample_multi_enums_payload.json
@@ -4,7 +4,7 @@
         "timestamp":"%TIMESTAMP%",
         "enums": [
             {
-                "name": "%PREFIX%call_xyz_api",
+                "name": "call_xyz_api%POSTFIX%",
                 "value": "OK"
             }
         ]
@@ -14,7 +14,7 @@
         "timestamp":"%TIMESTAMP%",
         "enums": [
             {
-                "name": "%PREFIX%call_xyz_api",
+                "name": "call_xyz_api%POSTFIX%",
                 "value": "OK"
             }
         ]
@@ -24,7 +24,7 @@
         "timestamp":"%TIMESTAMP%",
         "enums": [
             {
-                "name": "%PREFIX%call_xyz_api",
+                "name": "call_xyz_api%POSTFIX%",
                 "value": "ERROR"
             }
         ]

--- a/blueflood-http/src/test/resources/sample_multi_enums_payload.json
+++ b/blueflood-http/src/test/resources/sample_multi_enums_payload.json
@@ -1,30 +1,30 @@
 [
     {
         "tenantId":"5405532",
-        "timestamp":1439231324000,
+        "timestamp":"%TIMESTAMP%",
         "enums": [
             {
-                "name": "call_xyz_api",
+                "name": "%PREFIX%call_xyz_api",
                 "value": "OK"
             }
         ]
     },
     {
         "tenantId":"99988877",
-        "timestamp":1439231324001,
+        "timestamp":"%TIMESTAMP%",
         "enums": [
             {
-                "name": "call_xyz_api",
+                "name": "%PREFIX%call_xyz_api",
                 "value": "OK"
             }
         ]
     },
     {
         "tenantId":"99988877",
-        "timestamp":1439231324003,
+        "timestamp":"%TIMESTAMP%",
         "enums": [
             {
-                "name": "call_xyz_api",
+                "name": "%PREFIX%call_xyz_api",
                 "value": "ERROR"
             }
         ]

--- a/blueflood-http/src/test/resources/sample_payload.json
+++ b/blueflood-http/src/test/resources/sample_payload.json
@@ -4,49 +4,49 @@
     "flushInterval": 15000,
     "gauges":[
         {
-            "name":"%PREFIX%4444444.G200ms",
+            "name":"4444444.G200ms%POSTFIX%",
             "value":145
         },{
-            "name":"%PREFIX%3333333.G1s",
+            "name":"3333333.G1s%POSTFIX%",
             "value":397
         },{
-            "name":"%PREFIX%3333333.G10s",
+            "name":"3333333.G10s%POSTFIX%",
             "value":56
         },{
-            "name":"%PREFIX%internal.timestamp_lag",
+            "name":"internal.timestamp_lag%POSTFIX%",
             "value":0
         }
     ],
     "counters":[
         {
-            "name":"%PREFIX%internal.bad_lines_seen",
+            "name":"internal.bad_lines_seen%POSTFIX%",
             "value":0,
             "rate":0
         },{
-            "name":"%PREFIX%internal.packets_received",
+            "name":"internal.packets_received%POSTFIX%",
             "value":317,
             "rate":21.133333333333333
         },{
-            "name":"%PREFIX%3333333.C200ms",
+            "name":"3333333.C200ms%POSTFIX%",
             "value":74,
             "rate":4.933333333333334
         },{
-            "name":"%PREFIX%3333333.C1s",
+            "name":"3333333.C1s%POSTFIX%",
             "value":15,
             "rate":1
         },{
-            "name":"%PREFIX%3333333.C29s",
+            "name":"3333333.C29s%POSTFIX%",
             "value":1,
             "rate":0.06666666666666667
         },{
-            "name":"%PREFIX%4444444.C10s",
+            "name":"4444444.C10s%POSTFIX%",
             "value":1,
             "rate":0.06666666666666667
         }
     ],
     "timers":[
         {
-            "name":"%PREFIX%3333333.T200ms",
+            "name":"3333333.T200ms%POSTFIX%",
             "count":74,
             "rate":4.933333333333334,
             "min":1,
@@ -80,30 +80,30 @@
                 "bin_inf":0
             }
         },{
-            "name":"%PREFIX%4444444.T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+            "name":"4444444.T1s%POSTFIX%","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
             "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
             "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
         },{
-            "name":"%PREFIX%3333333.T29s","count":1,"rate":0.06666666666666667,"min":321,"max":321,"sum":321,"avg":321,"median":321,"std":0,
+            "name":"3333333.T29s%POSTFIX%","count":1,"rate":0.06666666666666667,"min":321,"max":321,"sum":321,"avg":321,"median":321,"std":0,
             "percentiles":{"50":{"avg":321,"max":321,"sum":321},"75":{"avg":321,"max":321,"sum":321},"98":{"avg":321,"max":321,"sum":321},"99":{"avg":321,"max":321,"sum":321},"999":{"avg":321,"max":321,"sum":321}},
             "histogram":{"bin_50":0,"bin_100":0,"bin_150":0,"bin_200":0,"bin_250":0,"bin_300":0,"bin_350":1,"bin_400":0,"bin_450":0,"bin_500":0,"bin_inf":0}
         },{
-            "name":"%PREFIX%3333333.T10s","count":1,"rate":0.06666666666666667,"min":214,"max":214,"sum":214,"avg":214,"median":214,"std":0,
+            "name":"3333333.T10s%POSTFIX%","count":1,"rate":0.06666666666666667,"min":214,"max":214,"sum":214,"avg":214,"median":214,"std":0,
             "percentiles":{"50":{"avg":214,"max":214,"sum":214},"75":{"avg":214,"max":214,"sum":214},"98":{"avg":214,"max":214,"sum":214},"99":{"avg":214,"max":214,"sum":214},"999":{"avg":214,"max":214,"sum":214}}
         }
     ],
     "sets":[
         {
-            "name":"%PREFIX%3333333.S500ms",
+            "name":"3333333.S500ms%POSTFIX%",
             "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
         }, {
-            "name":"%PREFIX%4444444.S1s",
+            "name":"4444444.S1s%POSTFIX%",
             "values":["platypus","dog","pangolin","loris","chicken","narwhal","cow","cat","nutria"]
         }
     ],
     "enums":[
         {
-            "name":"%PREFIX%call_xyz_api",
+            "name":"call_xyz_api%POSTFIX%",
             "value":"400"
         }
     ]

--- a/blueflood-http/src/test/resources/sample_payload.json
+++ b/blueflood-http/src/test/resources/sample_payload.json
@@ -1,52 +1,52 @@
 {
     "tenantId":"333333",
-    "timestamp":1389211230,
+    "timestamp":"%TIMESTAMP%",
     "flushInterval": 15000,
     "gauges":[
         {
-            "name":"4444444.G200ms",
+            "name":"%PREFIX%4444444.G200ms",
             "value":145
         },{
-            "name":"3333333.G1s",
+            "name":"%PREFIX%3333333.G1s",
             "value":397
         },{
-            "name":"3333333.G10s",
+            "name":"%PREFIX%3333333.G10s",
             "value":56
         },{
-            "name":"internal.timestamp_lag",
+            "name":"%PREFIX%internal.timestamp_lag",
             "value":0
         }
     ],
     "counters":[
         {
-            "name":"internal.bad_lines_seen",
+            "name":"%PREFIX%internal.bad_lines_seen",
             "value":0,
             "rate":0
         },{
-            "name":"internal.packets_received",
+            "name":"%PREFIX%internal.packets_received",
             "value":317,
             "rate":21.133333333333333
         },{
-            "name":"3333333.C200ms",
+            "name":"%PREFIX%3333333.C200ms",
             "value":74,
             "rate":4.933333333333334
         },{
-            "name":"3333333.C1s",
+            "name":"%PREFIX%3333333.C1s",
             "value":15,
             "rate":1
         },{
-            "name":"3333333.C29s",
+            "name":"%PREFIX%3333333.C29s",
             "value":1,
             "rate":0.06666666666666667
         },{
-            "name":"4444444.C10s",
+            "name":"%PREFIX%4444444.C10s",
             "value":1,
             "rate":0.06666666666666667
         }
     ],
     "timers":[
         {
-            "name":"3333333.T200ms",
+            "name":"%PREFIX%3333333.T200ms",
             "count":74,
             "rate":4.933333333333334,
             "min":1,
@@ -80,30 +80,30 @@
                 "bin_inf":0
             }
         },{
-            "name":"4444444.T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+            "name":"%PREFIX%4444444.T1s","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
             "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
             "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
         },{
-            "name":"3333333.T29s","count":1,"rate":0.06666666666666667,"min":321,"max":321,"sum":321,"avg":321,"median":321,"std":0,
+            "name":"%PREFIX%3333333.T29s","count":1,"rate":0.06666666666666667,"min":321,"max":321,"sum":321,"avg":321,"median":321,"std":0,
             "percentiles":{"50":{"avg":321,"max":321,"sum":321},"75":{"avg":321,"max":321,"sum":321},"98":{"avg":321,"max":321,"sum":321},"99":{"avg":321,"max":321,"sum":321},"999":{"avg":321,"max":321,"sum":321}},
             "histogram":{"bin_50":0,"bin_100":0,"bin_150":0,"bin_200":0,"bin_250":0,"bin_300":0,"bin_350":1,"bin_400":0,"bin_450":0,"bin_500":0,"bin_inf":0}
         },{
-            "name":"3333333.T10s","count":1,"rate":0.06666666666666667,"min":214,"max":214,"sum":214,"avg":214,"median":214,"std":0,
+            "name":"%PREFIX%3333333.T10s","count":1,"rate":0.06666666666666667,"min":214,"max":214,"sum":214,"avg":214,"median":214,"std":0,
             "percentiles":{"50":{"avg":214,"max":214,"sum":214},"75":{"avg":214,"max":214,"sum":214},"98":{"avg":214,"max":214,"sum":214},"99":{"avg":214,"max":214,"sum":214},"999":{"avg":214,"max":214,"sum":214}}
         }
     ],
     "sets":[
         {
-            "name":"3333333.S500ms",
+            "name":"%PREFIX%3333333.S500ms",
             "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
         }, {
-            "name":"4444444.S1s",
+            "name":"%PREFIX%4444444.S1s",
             "values":["platypus","dog","pangolin","loris","chicken","narwhal","cow","cat","nutria"]
         }
     ],
     "enums":[
         {
-            "name":"call_xyz_api",
+            "name":"%PREFIX%call_xyz_api",
             "value":"400"
         }
     ]


### PR DESCRIPTION
This PR verifies all aggregated metrics which use the ```timestamp``` attribute that the the timestamp is not older then current time - ```BEFORE_CURRRENT_COLLECTIONTIME_MS``` or newer than current time + ```AFTER_CURRENT_COLLECTIONTIME_MS```.

This PR verifies all annotation events which use the ```when``` attribute that the the timestamp is not older then current time - ```BEFORE_CURRRENT_COLLECTIONTIME_MS``` or newer than current time + ```AFTER_CURRENT_COLLECTIONTIME_MS```.

Also adding random prefix to all metric names which are ingested through common payload files.  This keeps tests from overwriting eachother's data.  This became an issue when all tests started ingesting at current time, rather than a hardcoded time.

