### PR TITLE
add oraclejdk18 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
   - oraclejdk7
   - openjdk7
+  - oraclejdk8
 
 sudo: false
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
@@ -59,6 +59,10 @@ public class HttpIntegrationTestBase {
     @BeforeClass
     public static void setUp() throws Exception{
         Configuration.getInstance().init();
+        // This is to help with Travis, which intermittently fail the following tests due
+        // to getting TimeoutException. This is done here because it needs to be before
+        // RollupHandler is instantiated.
+        Configuration.getInstance().setProperty(CoreConfig.ROLLUP_ON_READ_TIMEOUT_IN_SECONDS, "20");
         System.setProperty(CoreConfig.DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.ElasticIO");
         System.setProperty(CoreConfig.ENUMS_DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.EnumElasticIO");
         System.setProperty(CoreConfig.EVENTS_MODULES.name(), "com.rackspacecloud.blueflood.io.EventElasticSearchIO");

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -31,13 +31,6 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
     private final long fromTime = 1389124830L;
     private final long toTime = 1439231325000L;
 
-    @Before
-    public void setup() throws Exception {
-        // this is to help with Travis, which intermittently fail the following tests due
-        // to timeout
-        Configuration.getInstance().setProperty(CoreConfig.ROLLUP_ON_READ_TIMEOUT_IN_SECONDS, "20");
-    }
-
     @Test
     public void testMultiplotQuery() throws Exception {
         // ingest and rollup metrics with enum values and verify CF points and elastic search indexes


### PR DESCRIPTION
**What**
Add oraclejdk1.8 to Travis build so we can catch jdk 1.8 build errors during PR. Openjdk18 is not yet supported in Travis:
https://docs.travis-ci.com/user/languages/java#Testing-Against-Multiple-JDKs