### PR TITLE
configure finder code to be able to package and upload to pypi

### DIFF
--- a/contrib/graphite/LICENSE.txt
+++ b/contrib/graphite/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright (C) 2015 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/contrib/graphite/README.md
+++ b/contrib/graphite/README.md
@@ -5,7 +5,12 @@ The BF finder is the graphite plugin that allows graphite and grafana to use blu
 
 ### Setup
 
-Get the [blueflood](https://github.com/rackerlabs/blueflood) repo from github. Execute the following commands
+To install package from pypi using pip:
+
+    pip install blueflood-graphite-finder
+
+To install manually with code from github repo:
+    Get the [blueflood](https://github.com/rackerlabs/blueflood) repo from github. Execute the following commands
 
     cd $BLUEFLOOD_REPO_LOCATION/contrib/graphite
     virtualenv bf-finder

--- a/contrib/graphite/setup.cfg
+++ b/contrib/graphite/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/contrib/graphite/setup.py
+++ b/contrib/graphite/setup.py
@@ -4,15 +4,14 @@ from setuptools import setup
 version = '0.0.1'
 
 setup(
-  name='blueflood',
+  name='blueflood-graphite-finder',
   version=version,
-  url='https://github.com/rackerlabs/blueflood',
+  url='https://github.com/rackerlabs/blueflood/tree/master/contrib/graphite',
   license='APL2',
-  keywords='blueflood graphite metrics',
-  author='Gary Dusbabek',
-  author_email='gdusbabek@gmail.com',
-  description=('A plugin for using graphite-web with the cassandra-based '
-               'Blueflood storage backend'),
+  keywords='blueflood graphite finder metrics',
+  author='Rackspace Metrics',
+  author_email='cloudMetrics-dev@lists.rackspace.com',
+  description=('A plugin for using graphite-web and graphite-api with Blueflood'),
   py_modules=('blueflood','auth','rax_auth'),
   zip_safe=False,
   include_package_data=True,


### PR DESCRIPTION
Add configuration files and modify setup.py to package and upload to https://pypi.python.org so that package can be installed using `pip install blueflood-graphite-finder`.

See feedback/request @ https://feedback.rackspace.com/forums/345663-metrics-as-a-service/suggestions/12353130-get-the-blueflood-python-module-required-by-grap
