### PR TITLE
Test module loader

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/ModuleLoader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/ModuleLoader.java
@@ -37,7 +37,7 @@ public class ModuleLoader {
         List<String> modules = Configuration.getInstance().getListProperty(moduleName);
         if (modules.isEmpty())
             return null;
-        if (!modules.isEmpty() && modules.size() != 1) {
+        if (modules.size() != 1) {
             throw new RuntimeException("Cannot load service with more than one "+moduleName+" module");
         }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/ModuleLoader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/ModuleLoader.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import org.slf4j.Logger;
@@ -63,5 +64,10 @@ public class ModuleLoader {
         }
 
         return moduleInstance;
+    }
+
+    @VisibleForTesting
+    public static void clearCache() {
+        loadedModules.clear();
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO.java
@@ -1,0 +1,33 @@
+package com.rackspacecloud.blueflood.io;
+
+import com.rackspacecloud.blueflood.types.IMetric;
+
+import java.util.List;
+
+public class DummyDiscoveryIO implements DiscoveryIO {
+
+    @Override
+    public void insertDiscovery(IMetric metric) throws Exception {
+
+    }
+
+    @Override
+    public void insertDiscovery(List<IMetric> metrics) throws Exception {
+
+    }
+
+    @Override
+    public List<SearchResult> search(String tenant, String query) throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<SearchResult> search(String tenant, List<String> queries) throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<MetricToken> getMetricTokens(String tenant, String prefix) throws Exception {
+        return null;
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO.java
@@ -4,6 +4,9 @@ import com.rackspacecloud.blueflood.types.IMetric;
 
 import java.util.List;
 
+/**
+ * Used by {@link com.rackspacecloud.blueflood.utils.ModuleLoaderTest}
+ */
 public class DummyDiscoveryIO implements DiscoveryIO {
 
     @Override

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO2.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO2.java
@@ -1,0 +1,33 @@
+package com.rackspacecloud.blueflood.io;
+
+import com.rackspacecloud.blueflood.types.IMetric;
+
+import java.util.List;
+
+public class DummyDiscoveryIO2 implements DiscoveryIO {
+
+    @Override
+    public void insertDiscovery(IMetric metric) throws Exception {
+
+    }
+
+    @Override
+    public void insertDiscovery(List<IMetric> metrics) throws Exception {
+
+    }
+
+    @Override
+    public List<SearchResult> search(String tenant, String query) throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<SearchResult> search(String tenant, List<String> queries) throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<MetricToken> getMetricTokens(String tenant, String prefix) throws Exception {
+        return null;
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO2.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO2.java
@@ -4,6 +4,9 @@ import com.rackspacecloud.blueflood.types.IMetric;
 
 import java.util.List;
 
+/**
+ * Used by {@link com.rackspacecloud.blueflood.utils.ModuleLoaderTest}
+ */
 public class DummyDiscoveryIO2 implements DiscoveryIO {
 
     @Override

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO4.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO4.java
@@ -1,0 +1,39 @@
+package com.rackspacecloud.blueflood.io;
+
+import com.rackspacecloud.blueflood.types.IMetric;
+
+import java.util.List;
+
+/**
+ * Used by {@link com.rackspacecloud.blueflood.utils.ModuleLoaderTest}
+ */
+public class DummyDiscoveryIO4 implements DiscoveryIO {
+
+    public DummyDiscoveryIO4(String parameter) {
+    }
+
+    @Override
+    public void insertDiscovery(IMetric metric) throws Exception {
+
+    }
+
+    @Override
+    public void insertDiscovery(List<IMetric> metrics) throws Exception {
+
+    }
+
+    @Override
+    public List<SearchResult> search(String tenant, String query) throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<SearchResult> search(String tenant, List<String> queries) throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<MetricToken> getMetricTokens(String tenant, String prefix) throws Exception {
+        return null;
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO5.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/DummyDiscoveryIO5.java
@@ -1,0 +1,36 @@
+package com.rackspacecloud.blueflood.io;
+
+import com.rackspacecloud.blueflood.types.IMetric;
+
+import java.util.List;
+
+/**
+ * Used by {@link com.rackspacecloud.blueflood.utils.ModuleLoaderTest}
+ */
+class DummyDiscoveryIO5 implements DiscoveryIO {
+
+    @Override
+    public void insertDiscovery(IMetric metric) throws Exception {
+
+    }
+
+    @Override
+    public void insertDiscovery(List<IMetric> metrics) throws Exception {
+
+    }
+
+    @Override
+    public List<SearchResult> search(String tenant, String query) throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<SearchResult> search(String tenant, List<String> queries) throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<MetricToken> getMetricTokens(String tenant, String prefix) throws Exception {
+        return null;
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/DummyDiscoveryIO3.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/DummyDiscoveryIO3.java
@@ -1,0 +1,39 @@
+package com.rackspacecloud.blueflood.utils;
+
+import com.rackspacecloud.blueflood.io.DiscoveryIO;
+import com.rackspacecloud.blueflood.io.MetricToken;
+import com.rackspacecloud.blueflood.io.SearchResult;
+import com.rackspacecloud.blueflood.types.IMetric;
+
+import java.util.List;
+
+/**
+ * Used by {@link ModuleLoaderTest}
+ */
+public class DummyDiscoveryIO3 implements DiscoveryIO {
+
+    @Override
+    public void insertDiscovery(IMetric metric) throws Exception {
+
+    }
+
+    @Override
+    public void insertDiscovery(List<IMetric> metrics) throws Exception {
+
+    }
+
+    @Override
+    public List<SearchResult> search(String tenant, String query) throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<SearchResult> search(String tenant, List<String> queries) throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<MetricToken> getMetricTokens(String tenant, String prefix) throws Exception {
+        return null;
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
@@ -31,6 +31,22 @@ public class ModuleLoaderTest {
         // given
         Configuration.getInstance().setProperty(
                 CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.utils.DummyDiscoveryIO3");
+
+        // when
+        Object loadedModule = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNotNull(loadedModule);
+        Assert.assertEquals(DummyDiscoveryIO3.class, loadedModule.getClass());
+    }
+
+    @Test
+    public void singleClassInDifferentPackageYieldsThatClass() {
+
+        // given
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
                 "com.rackspacecloud.blueflood.io.DummyDiscoveryIO");
 
         // when

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
@@ -1,0 +1,183 @@
+package com.rackspacecloud.blueflood.utils;
+
+import com.rackspacecloud.blueflood.io.DiscoveryIO;
+import com.rackspacecloud.blueflood.io.DummyDiscoveryIO;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+
+public class ModuleLoaderTest {
+
+    @Before
+    public void setUp() {
+        Configuration.getInstance().clearProperty(CoreConfig.DISCOVERY_MODULES);
+        ModuleLoader.clearCache();
+    }
+
+    @After
+    public void tearDown() {
+        Configuration.getInstance().clearProperty(CoreConfig.DISCOVERY_MODULES);
+        ModuleLoader.clearCache();
+    }
+
+    @Test
+    public void singleClassYieldsThatClass() {
+
+        // given
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.io.DummyDiscoveryIO");
+
+        // when
+        Object loadedModule = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNotNull(loadedModule);
+        Assert.assertEquals(DummyDiscoveryIO.class, loadedModule.getClass());
+    }
+
+    @Test
+    public void emptyStringYieldsNull() {
+
+        // given
+        Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES, "");
+
+        // when
+        Object loadedModule = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNull(loadedModule);
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void multipleClassesCauseAnException() {
+
+        // given
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.io.DummyDiscoveryIO,com.rackspacecloud.blueflood.io.DummyDiscoveryIO2");
+
+        // when
+        Object loadedModule = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        // an exception is thrown
+    }
+
+    @Test
+    public void nonExistentClassYieldsNull() {
+
+        // given
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.NonExistentClass");
+
+        // when
+        Object loadedModule = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNull(loadedModule);
+    }
+
+    @Test
+    public void callingTwiceYieldsTheSameObjectBothTimes() {
+
+        // given
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.io.DummyDiscoveryIO");
+
+        Object loadedModule1 = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // precondition
+        Assert.assertNotNull(loadedModule1);
+        Assert.assertEquals(DummyDiscoveryIO.class, loadedModule1.getClass());
+
+        // when
+        Object loadedModule2 = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNotNull(loadedModule2);
+        Assert.assertSame(loadedModule1, loadedModule2);
+    }
+
+    @Test
+    public void givingDifferentKeysButSameClassYieldsTwoSeparateObjects() {
+
+        // given
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.io.DummyDiscoveryIO");
+        Configuration.getInstance().setProperty(
+                CoreConfig.ENUMS_DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.io.DummyDiscoveryIO");
+
+        // when
+        Object loadedModule1 = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNotNull(loadedModule1);
+        Assert.assertEquals(DummyDiscoveryIO.class, loadedModule1.getClass());
+
+        // when
+        Object loadedModule2 = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.ENUMS_DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNotNull(loadedModule2);
+        Assert.assertEquals(DummyDiscoveryIO.class, loadedModule1.getClass());
+        Assert.assertNotSame(loadedModule1, loadedModule2);
+    }
+
+    @Test
+    public void callingTwiceWithSameKeyButDifferentClassesYieldsTheSameObjectBothTimes() {
+
+        // TODO: This functionality is extremely misleading. It's probably not
+        // what was originally intended, anyways. Basically, if we pass the
+        // same CoreConfig enum field a second time to getInstance after
+        // changing the configuration value for that key, ModuleLoader will
+        // still give us back the object that it loaded the first time. This is
+        // the case even if we specify completely incompatible classes each
+        // time.
+
+        // given
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.io.DummyDiscoveryIO");
+
+        Object loadedModule1 = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // precondition
+        Assert.assertNotNull(loadedModule1);
+        Assert.assertEquals(DummyDiscoveryIO.class, loadedModule1.getClass());
+
+        // when
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.io.DummyDiscoveryIO2");
+        Object loadedModule2 = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNotNull(loadedModule2);
+        Assert.assertSame(loadedModule1, loadedModule2);
+    }
+
+    @Test
+    public void specifyingAnInterfaceYieldsNull() {
+
+        // given
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.io.DiscoveryIO");
+
+        // when
+        Object loadedModule = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNull(loadedModule);
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
@@ -224,6 +224,6 @@ public class ModuleLoaderTest {
         Object loadedModule = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
 
         // then
-        Assert.assertNull(loadedModule); // ClassLoader.loadClass will throw an IllegalAccessException
+        Assert.assertNull(loadedModule); // Class.newInstance will throw an IllegalAccessException
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
@@ -211,4 +211,19 @@ public class ModuleLoaderTest {
         // then
         Assert.assertNull(loadedModule); // ClassLoader.loadClass will throw an InstantiationException
     }
+
+    @Test
+    public void packagePrivateClassYieldsNull() {
+
+        // given
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.io.DummyDiscoveryIO5");
+
+        // when
+        Object loadedModule = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNull(loadedModule); // ClassLoader.loadClass will throw an IllegalAccessException
+    }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
@@ -142,7 +142,7 @@ public class ModuleLoaderTest {
         // changing the configuration value for that key, ModuleLoader will
         // still give us back the object that it loaded the first time. This is
         // the case even if we specify completely incompatible classes each
-        // time.
+        // time, which could lead to runtime casting exceptions.
 
         // given
         Configuration.getInstance().setProperty(

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/utils/ModuleLoaderTest.java
@@ -196,4 +196,19 @@ public class ModuleLoaderTest {
         // then
         Assert.assertNull(loadedModule);
     }
+
+    @Test
+    public void classWithNoParameterlessConstructorYieldsNull() {
+
+        // given
+        Configuration.getInstance().setProperty(
+                CoreConfig.DISCOVERY_MODULES,
+                "com.rackspacecloud.blueflood.io.DummyDiscoveryIO4");
+
+        // when
+        Object loadedModule = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+
+        // then
+        Assert.assertNull(loadedModule); // ClassLoader.loadClass will throw an InstantiationException
+    }
 }


### PR DESCRIPTION
This PR adds tests for the `ModuleLoader` class, in the `blueflood-core` module. There are already tests for it in the `blueflood-http` module, but since that's different than the module that the class is defined in, coverage is being reported as 0% (see [here](https://coveralls.io/builds/5442321/source?filename=blueflood-core%2Fsrc%2Fmain%2Fjava%2Fcom%2Frackspacecloud%2Fblueflood%2Futils%2FModuleLoader.java)). Also, these tests better demonstrate the behavior of the class, and provide pertinent negative test cases.

According to JaCoCo, the test class, by itself, provides coverage for `ModuleLoader` to the tune of:
* 75% for instructions 
* 100% for branches
* 78% for lines
What's not tested is exception handling and the default parameter-less constructor.

On the whole, `ModuleLoader` appears to be a thin, confusing, and broken wrapper around `ClassLoader.loadClass(String)`. I believe it should be refactored away.