### PR TITLE
make Tracker a singleton class and register it for DataQueryServer also.

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/DefaultHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/DefaultHandler.java
@@ -56,7 +56,7 @@ public class DefaultHandler implements HttpRequestHandler {
                 response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
             }
 
-            Tracker.trackResponse(request, response);
+            Tracker.getInstance().trackResponse(request, response);
             HttpResponder.respond(channel, request, response);
         } finally {
             sendResponseTimerContext.stop();

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandler.java
@@ -65,7 +65,7 @@ public class HttpAggregatedIngestionHandler implements HttpRequestHandler {
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
 
-        Tracker.track(request);
+        Tracker.getInstance().track(request);
 
         final Timer.Context timerContext = handlerTimer.time();
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
@@ -58,7 +58,7 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
 
-        Tracker.track(request);
+        Tracker.getInstance().track(request);
 
         final Timer.Context timerContext = handlerTimer.time();
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
@@ -97,7 +97,7 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
         try {
 
-            Tracker.track(request);
+            Tracker.getInstance().track(request);
 
             requestCount.inc();
             final String tenantId = request.getHeader("tenantId");
@@ -145,7 +145,7 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
                 forceTTLsIfConfigured(containerMetrics);
 
                 if (jsonMetricsContainer.areDelayedMetricsPresent()) {
-                    Tracker.trackDelayedMetricsTenant(tenantId);
+                    Tracker.getInstance().trackDelayedMetricsTenant(tenantId);
                 }
             } catch (InvalidDataException ex) {
                 // todo: we should measure these. if they spike, we track down the bad client.

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -32,7 +32,6 @@ import com.rackspacecloud.blueflood.io.EventsIO;
 import com.rackspacecloud.blueflood.io.IMetricsWriter;
 import com.rackspacecloud.blueflood.service.*;
 import com.rackspacecloud.blueflood.tracker.Tracker;
-import com.rackspacecloud.blueflood.tracker.TrackerMBean;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.MetricsCollection;
 import com.rackspacecloud.blueflood.utils.ModuleLoader;
@@ -74,8 +73,6 @@ public class HttpMetricsIngestionServer {
 
     private ChannelGroup allOpenChannels = new DefaultChannelGroup("allOpenChannels");
 
-    public TrackerMBean tracker;
-
     public HttpMetricsIngestionServer(ScheduleContext context, IMetricsWriter writer) {
         this.httpIngestPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_INGESTION_PORT);
         this.httpIngestHost = Configuration.getInstance().getStringProperty(HttpConfig.HTTP_INGESTION_HOST);
@@ -111,10 +108,10 @@ public class HttpMetricsIngestionServer {
         Channel serverChannel = server.bind(new InetSocketAddress(httpIngestHost, httpIngestPort));
         allOpenChannels.add(serverChannel);
 
-        log.info("Starting tracker service");
-        tracker = new Tracker();
+        //register the tracker MBean for JMX/jolokia
+        log.info("Registering tracker service");
+        Tracker.getInstance().register();
     }
-
 
     private class MetricsHttpServerPipelineFactory implements ChannelPipelineFactory {
         private RouteMatcher router;

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpHistogramQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpHistogramQueryHandler.java
@@ -86,7 +86,7 @@ public class HttpHistogramQueryHandler extends RollupHandler implements HttpRequ
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
 
-        Tracker.track(request);
+        Tracker.getInstance().track(request);
 
         final String tenantId = request.getHeader("tenantId");
         final String metricName = request.getHeader("metricName");
@@ -136,7 +136,7 @@ public class HttpHistogramQueryHandler extends RollupHandler implements HttpRequ
             response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
 
-        Tracker.trackResponse(request, response);
+        Tracker.getInstance().trackResponse(request, response);
         HttpResponder.respond(channel, request, response);
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricDataQueryServer.java
@@ -24,6 +24,7 @@ import com.rackspacecloud.blueflood.io.EventsIO;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.HttpConfig;
+import com.rackspacecloud.blueflood.tracker.Tracker;
 import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.ChannelPipeline;
@@ -79,6 +80,10 @@ public class HttpMetricDataQueryServer {
                         Executors.newFixedThreadPool(workerThreads)));
         server.setPipelineFactory(new MetricsHttpServerPipelineFactory(router));
         serverChannel =  (ServerChannel) server.bind(new InetSocketAddress(httpQueryHost, httpQueryPort));
+
+        //register the tracker MBean for JMX/jolokia
+        log.info("Registering tracker service");
+        Tracker.getInstance().register();
     }
 
     private class MetricsHttpServerPipelineFactory implements ChannelPipelineFactory {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricTokensHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricTokensHandler.java
@@ -42,7 +42,7 @@ public class HttpMetricTokensHandler implements HttpRequestHandler {
 
         final Timer.Context httpMetricNameTokensHandlerTimerContext = HttpMetricNameTokensHandlerTimer.time();
 
-        Tracker.track(request);
+        Tracker.getInstance().track(request);
 
         final String tenantId = request.getHeader("tenantId");
 
@@ -81,7 +81,7 @@ public class HttpMetricTokensHandler implements HttpRequestHandler {
             response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
 
-        Tracker.trackResponse(request, response);
+        Tracker.getInstance().trackResponse(request, response);
         HttpResponder.respond(channel, request, response);
     }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
@@ -29,7 +29,7 @@ public class HttpMetricsIndexHandler implements HttpRequestHandler {
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
 
-        Tracker.track(request);
+        Tracker.getInstance().track(request);
 
         final String tenantId = request.getHeader("tenantId");
 
@@ -79,7 +79,7 @@ public class HttpMetricsIndexHandler implements HttpRequestHandler {
             response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
 
-        Tracker.trackResponse(request, response);
+        Tracker.getInstance().trackResponse(request, response);
         HttpResponder.respond(channel, request, response);
     }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandler.java
@@ -75,7 +75,7 @@ public class HttpMultiRollupsQueryHandler extends RollupHandler implements HttpR
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
 
-        Tracker.track(request);
+        Tracker.getInstance().track(request);
 
         final String tenantId = request.getHeader("tenantId");
 
@@ -154,7 +154,7 @@ public class HttpMultiRollupsQueryHandler extends RollupHandler implements HttpR
             response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
 
-        Tracker.trackResponse(request, response);
+        Tracker.getInstance().trackResponse(request, response);
         HttpResponder.respond(channel, request, response);
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
@@ -110,7 +110,7 @@ public class HttpRollupsQueryHandler extends RollupHandler
     @Override
     public void handle(ChannelHandlerContext ctx, HttpRequest request) {
 
-        Tracker.track(request);
+        Tracker.getInstance().track(request);
 
         final String tenantId = request.getHeader("tenantId");
         final String metricName = request.getHeader("metricName");
@@ -165,7 +165,7 @@ public class HttpRollupsQueryHandler extends RollupHandler
             response.setContent(ChannelBuffers.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
 
-        Tracker.trackResponse(request, response);
+        Tracker.getInstance().trackResponse(request, response);
         HttpResponder.respond(channel, request, response);
     }
 }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
@@ -16,7 +16,7 @@ public class TrackerTest {
 
     @Before
     public void setUp() {
-        tracker = new Tracker();
+        tracker = Tracker.getInstance();
     }
 
     @Test
@@ -104,24 +104,24 @@ public class TrackerTest {
     @Test
     public void testFindTidFound() {
 
-        assertEquals( Tracker.findTid( "/v2.0/6000/views" ), "6000" );
+        assertEquals( tracker.findTid( "/v2.0/6000/views" ), "6000" );
     }
 
     @Test
          public void testTrackTenantNoVersion() {
 
-        assertEquals( Tracker.findTid( "/6000/views" ), null );
+        assertEquals( tracker.findTid( "/6000/views" ), null );
     }
 
     @Test
     public void testTrackTenantBadVersion() {
 
-        assertEquals( Tracker.findTid( "blah/6000/views" ), null );
+        assertEquals( tracker.findTid( "blah/6000/views" ), null );
     }
 
     @Test
     public void testTrackTenantTrailingSlash() {
 
-        assertEquals( Tracker.findTid( "/v2.0/6000/views/" ), "6000" );
+        assertEquals( tracker.findTid( "/v2.0/6000/views/" ), "6000" );
     }
 }


### PR DESCRIPTION
# What

Modify the TrackerMbean class implementation to be a singleton, and register it on both Ingest and Query server startup.

# How

Magic.

(i.e. look at the code).

## How to test

After deployment, verify that you can perform enabling/disabling the tracker (via the blueflood_tenant_tracker.sh script found in blueflood-chef/contrib) on both the ingest nodes and the query nodes.

# Why

So we can log http requests and responses on both the ingest nodes and the query nodes.