### PR TITLE
Fix Tracker.trackDelayedMetricsTenant

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
@@ -88,6 +88,10 @@ public class JSONMetricsContainer {
         return delayedMetrics.size() > 0;
     }
 
+    public List<Metric> getDelayedMetrics() {
+        return delayedMetrics;
+    }
+
     // Jackson compatible class. Jackson uses reflection to call these methods and so they have to match JSON keys.
     public static class JSONMetric {
         private String metricName;

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -72,6 +72,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.14.1</version>
         <configuration>
+          <forkMode>always</forkMode>
           <!-- Skips unit tests if the value of skip.unit.tests property is true -->
           <skipTests>${skip.unit.tests}</skipTests>
           <!-- Excludes integration tests when unit tests are run. -->
@@ -96,6 +97,7 @@
               <goal>integration-test</goal>
             </goals>
             <configuration>
+              <forkMode>always</forkMode>
               <systemPropertyVariables>
                 <CASSANDRA_HOSTS>${cassandra.listenAddress}:${cassandra.rpcPort}</CASSANDRA_HOSTS>
                 <DEFAULT_CASSANDRA_PORT>${cassandra.rpcPort}</DEFAULT_CASSANDRA_PORT>
@@ -177,11 +179,11 @@
       <version>4.3.3</version>
     </dependency>
 
-      <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-io</artifactId>
-          <version>1.3.2</version>
-      </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>1.3.2</version>
+    </dependency>
 
       <!-- testing dependencies -->
     <dependency>
@@ -195,9 +197,21 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.8.4</version>
+      <version>1.10.19</version>
       <scope>test</scope>
       <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.6.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.6.2</version>
     </dependency>
 
     <dependency>

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -97,7 +97,6 @@
               <goal>integration-test</goal>
             </goals>
             <configuration>
-              <forkMode>always</forkMode>
               <systemPropertyVariables>
                 <CASSANDRA_HOSTS>${cassandra.listenAddress}:${cassandra.rpcPort}</CASSANDRA_HOSTS>
                 <DEFAULT_CASSANDRA_PORT>${cassandra.rpcPort}</DEFAULT_CASSANDRA_PORT>
@@ -205,13 +204,13 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.4</version>
     </dependency>
 
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.4</version>
     </dependency>
 
     <dependency>

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
@@ -145,7 +145,7 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
                 forceTTLsIfConfigured(containerMetrics);
 
                 if (jsonMetricsContainer.areDelayedMetricsPresent()) {
-                    Tracker.getInstance().trackDelayedMetricsTenant(tenantId);
+                    Tracker.getInstance().trackDelayedMetricsTenant(tenantId, jsonMetricsContainer.getDelayedMetrics());
                 }
             } catch (InvalidDataException ex) {
                 // todo: we should measure these. if they spike, we track down the bad client.

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
@@ -18,6 +18,7 @@ package com.rackspacecloud.blueflood.tracker;
 
 import com.rackspacecloud.blueflood.http.HTTPRequestWithDecodedQueryParams;
 import com.rackspacecloud.blueflood.io.Constants;
+import com.rackspacecloud.blueflood.types.Metric;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -36,8 +37,9 @@ import java.util.regex.Pattern;
 
 public class Tracker implements TrackerMBean {
 
+    public static final String trackerName = String.format("com.rackspacecloud.blueflood.tracker:type=%s", Tracker.class.getSimpleName());
+
     private static final Logger log = LoggerFactory.getLogger(Tracker.class);
-    private static final String trackerName = String.format("com.rackspacecloud.blueflood.tracker:type=%s", Tracker.class.getSimpleName());
     private final Pattern patternGetTid = Pattern.compile( "/v\\d+\\.\\d+/([^/]+)/.*" );
 
     // Tracker is a singleton
@@ -68,30 +70,16 @@ public class Tracker implements TrackerMBean {
             }
 
             isRegistered = true;
+            log.info("MBean registered as " + trackerName);
 
         } catch (Exception exc) {
-            log.error("Unable to register mbean for " + instance.getClass().getSimpleName(), exc);
+            log.error("Unable to register MBean " + trackerName, exc);
         }
     }
 
     public void addTenant(String tenantId) {
         tenantIds.add(tenantId);
         log.info("[TRACKER] tenantId " + tenantId + " added.");
-    }
-
-    public void addMetricName(String metricName) {
-        metricNames.add(metricName);
-        log.info("[TRACKER] Metric name "+ metricName + " added.");
-    }
-
-    public void setIsTrackingDelayedMetrics() {
-        isTrackingDelayedMetrics = true;
-        log.info("[TRACKER] Tracking delayed metrics started");
-    }
-
-    public void resetIsTrackingDelayedMetrics() {
-        isTrackingDelayedMetrics = false;
-        log.info("[TRACKER] Tracking delayed metrics stopped");
     }
 
     public void removeTenant(String tenantId) {
@@ -104,6 +92,15 @@ public class Tracker implements TrackerMBean {
         log.info("[TRACKER] all tenants removed.");
     }
 
+    public Set getTenants() {
+        return tenantIds;
+    }
+
+    public void addMetricName(String metricName) {
+        metricNames.add(metricName);
+        log.info("[TRACKER] Metric name "+ metricName + " added.");
+    }
+
     public void removeMetricName(String metricName) {
         metricNames.remove(metricName);
         log.info("[TRACKER] Metric name "+ metricName + " removed.");
@@ -112,6 +109,24 @@ public class Tracker implements TrackerMBean {
     public void removeAllMetricNames() {
         metricNames.clear();
         log.info("[TRACKER] All metric names removed.");
+    }
+
+    public Set<String> getMetricNames() {
+        return this.metricNames;
+    }
+
+    public void setIsTrackingDelayedMetrics() {
+        isTrackingDelayedMetrics = true;
+        log.info("[TRACKER] Tracking delayed metrics started");
+    }
+
+    public void resetIsTrackingDelayedMetrics() {
+        isTrackingDelayedMetrics = false;
+        log.info("[TRACKER] Tracking delayed metrics stopped");
+    }
+
+    public boolean getIsTrackingDelayedMetrics() {
+        return this.isTrackingDelayedMetrics;
     }
 
     public boolean isTracking(String tenantId) {
@@ -133,10 +148,6 @@ public class Tracker implements TrackerMBean {
             }
         }
         return toLog;
-    }
-
-    public Set getTenants() {
-        return tenantIds;
     }
 
     public void track(HttpRequest request) {
@@ -174,30 +185,13 @@ public class Tracker implements TrackerMBean {
         }
     }
 
-    String findTid( String uri ) {
-
-        Matcher m = patternGetTid.matcher( uri );
-
-        if( m.matches() )
-            return m.group( 1 );
-        else
-            return null;
-    }
-
-    public void trackDelayedMetricsTenant(String tenantid) {
-        if (isTrackingDelayedMetrics) {
-            String logMessage = String.format("[TRACKER][DELAYED METRIC] Tenant sending delayed metrics %s",tenantid);
-            log.info(logMessage);
-        }
-    }
-
     public void trackResponse(HttpRequest request, HttpResponse response) {
         // check if tenantId is being tracked by JMX TenantTrackerMBean and log the response if it is
         // HttpRequest is needed for original request uri and tenantId
         if (request == null) return;
         if (response == null) return;
 
-        String tenantId = request.getHeader("tenantId");
+        String tenantId = findTid( request.getUri() );
         if (isTracking(tenantId)) {
             HttpResponseStatus status = response.getStatus();
             String messageBody = response.getContent().toString(Constants.DEFAULT_CHARSET);
@@ -221,6 +215,16 @@ public class Tracker implements TrackerMBean {
 
     }
 
+    public void trackDelayedMetricsTenant(String tenantid, List<Metric> delayedMetrics) {
+        if (isTrackingDelayedMetrics) {
+            String logMessage = String.format("[TRACKER][DELAYED METRIC] Tenant sending delayed metrics %s\n",tenantid);
+            for (Metric metric : delayedMetrics) {
+                logMessage += String.format("%s has collectionTime %d\n", metric.getLocator().toString(), metric.getCollectionTime());
+            }
+            log.info(logMessage);
+        }
+    }
+
     String getQueryParameters(HttpRequest httpRequest) {
         String params = "";
         Map<String, List<String>> parameters = ((HTTPRequestWithDecodedQueryParams) httpRequest).getQueryParams();
@@ -241,4 +245,13 @@ public class Tracker implements TrackerMBean {
         return params;
     }
 
+    String findTid( String uri ) {
+
+        Matcher m = patternGetTid.matcher( uri );
+
+        if( m.matches() )
+            return m.group( 1 );
+        else
+            return null;
+    }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/TrackerMBean.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/TrackerMBean.java
@@ -27,6 +27,8 @@ public interface TrackerMBean {
     public void removeMetricName(String metricName);
     public void removeAllMetricNames();
     public Set getTenants();
+    public Set<String> getMetricNames();
     public void setIsTrackingDelayedMetrics();
     public void resetIsTrackingDelayedMetrics();
+    public boolean getIsTrackingDelayedMetrics();
 }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
@@ -1,22 +1,104 @@
 package com.rackspacecloud.blueflood.tracker;
 
+import com.rackspacecloud.blueflood.http.HTTPRequestWithDecodedQueryParams;
+import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.types.Metric;
+import com.rackspacecloud.blueflood.utils.TimeValue;
+import junit.framework.Assert;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import javax.servlet.http.HttpServletRequest;
-import java.util.Set;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.matchers.JUnitMatchers.containsString;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({LoggerFactory.class})
+@PowerMockIgnore( {"javax.management.*"})
 public class TrackerTest {
-    Tracker tracker;
+    Tracker tracker = Tracker.getInstance();
     String testTenant1 = "tenant1";
     String testTenant2 = "tenant2";
+    String tenantId = "121212";
+
+    private static Logger loggerMock;
+    private HTTPRequestWithDecodedQueryParams httpRequestMock;
+    private HttpMethod httpMethodMock;
+    private ChannelBuffer channelBufferMock;
+    private HttpResponse httpResponseMock;
+    private HttpResponseStatus httpResponseStatusMock;
+    private Map<String, List<String>> queryParams;
+    private List<Metric> delayedMetrics;
+    private long collectionTime;
+
+    @Captor
+    ArgumentCaptor argCaptor;
+
+    @BeforeClass
+    public static void setupClass() {
+        // mock logger
+        PowerMockito.mockStatic(LoggerFactory.class);
+        loggerMock = mock(Logger.class);
+        when(LoggerFactory.getLogger(any(Class.class))).thenReturn(loggerMock);
+    }
 
     @Before
     public void setUp() {
-        tracker = Tracker.getInstance();
+        // mock HttpRequest, method, queryParams, channelBuffer, responseStatus
+        httpRequestMock = mock(HTTPRequestWithDecodedQueryParams.class);
+        httpMethodMock = mock(HttpMethod.class);
+        channelBufferMock = mock(ChannelBuffer.class);
+        queryParams = new HashMap<String, List<String>>();
+
+        // mock HttpResponse and HttpResponseStatus
+        httpResponseMock = mock(HttpResponse.class);
+        httpResponseStatusMock = mock(HttpResponseStatus.class);
+
+        // mock headers
+        Set<String> headerNames = new HashSet<String>();
+        headerNames.add("X-Auth-Token");
+        when(httpRequestMock.getHeaderNames()).thenReturn(headerNames);
+        when(httpRequestMock.getHeader("X-Auth-Token")).thenReturn("AUTHTOKEN");
+
+        // setup delayed metrics
+        Locator locator1 = Locator.createLocatorFromPathComponents(tenantId, "delayed", "metric1");
+        Locator locator2 = Locator.createLocatorFromPathComponents(tenantId, "delayed", "metric2");
+        collectionTime = 1451606400000L;      // Jan 1, 2016
+        TimeValue ttl = new TimeValue(3, TimeUnit.DAYS);
+        Metric delayMetric1 = new Metric(locator1, 123, collectionTime, ttl, "");
+        Metric delayMetric2 = new Metric(locator2, 456, collectionTime, ttl, "");
+        delayedMetrics = new ArrayList<Metric>();
+        delayedMetrics.add(delayMetric1);
+        delayedMetrics.add(delayMetric2);
+    }
+
+    @Test
+    public void testRegister() {
+        // register the tracker and verify
+        tracker.register();
+        verify(loggerMock, times(1)).info("MBean registered as com.rackspacecloud.blueflood.tracker:type=Tracker");
     }
 
     @Test
@@ -54,20 +136,27 @@ public class TrackerTest {
 
     @Test
     public void testAddAndRemoveMetricName() {
-        tracker.addMetricName("metricName");
-        assertTrue("metricName not added",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+        String metric1 = "metricName";
+        String metric2 = "anotherMetricName";
 
-        tracker.addMetricName("anotherMetricNom");
-        assertTrue("metricName not being logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
-        assertTrue("anotherMetricNom not being logged",tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
+        tracker.addMetricName(metric1);
+        assertTrue(metric1 + " not added", tracker.doesMessageContainMetricNames("Track.this." + metric1));
+
+        tracker.addMetricName(metric2);
+        assertTrue(metric1 + " not being logged", tracker.doesMessageContainMetricNames("Track.this." + metric1));
+        assertTrue(metric2 + "not being logged", tracker.doesMessageContainMetricNames("Track.this." + metric2));
         assertFalse("randomMetricNameNom should not be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
 
-        tracker.removeMetricName("metricName");
-        assertFalse("metricName should not be logged",tracker.doesMessageContainMetricNames("Track.this.metricName"));
+        Set<String> metricNames = tracker.getMetricNames();
+        assertTrue("metricNames should contain " + metric1, metricNames.contains(metric1));
+        assertTrue("metricNames should contain " + metric2, metricNames.contains(metric2));
 
-        tracker.removeMetricName("anotherMetricNom");
-        assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.anotherMetricNom"));
-        assertTrue("Everything should be logged", tracker.doesMessageContainMetricNames("Track.this.randomMetricNameNom"));
+        tracker.removeMetricName(metric1);
+        assertFalse(metric1 + " should not be logged", tracker.doesMessageContainMetricNames("Track.this." + metric1));
+
+        metricNames = tracker.getMetricNames();
+        assertFalse("metricNames should not contain " + metric1, metricNames.contains(metric1));
+        assertTrue("metricNames should contain " + metric2, metricNames.contains(metric2));
     }
 
     @Test
@@ -103,25 +192,202 @@ public class TrackerTest {
 
     @Test
     public void testFindTidFound() {
-
         assertEquals( tracker.findTid( "/v2.0/6000/views" ), "6000" );
     }
 
     @Test
-         public void testTrackTenantNoVersion() {
-
+     public void testTrackTenantNoVersion() {
         assertEquals( tracker.findTid( "/6000/views" ), null );
     }
 
     @Test
     public void testTrackTenantBadVersion() {
-
         assertEquals( tracker.findTid( "blah/6000/views" ), null );
     }
 
     @Test
     public void testTrackTenantTrailingSlash() {
-
         assertEquals( tracker.findTid( "/v2.0/6000/views/" ), "6000" );
     }
+
+    @Test
+    public void testSetIsTrackingDelayedMetrics() {
+        tracker.resetIsTrackingDelayedMetrics();
+        tracker.setIsTrackingDelayedMetrics();
+        Assert.assertTrue("isTrackingDelayedMetrics should be true from setIsTrackingDelayedMetrics", tracker.getIsTrackingDelayedMetrics());
+    }
+
+    @Test
+    public void testResetIsTrackingDelayedMetricss() {
+        tracker.setIsTrackingDelayedMetrics();
+        tracker.resetIsTrackingDelayedMetrics();
+        Assert.assertFalse("isTrackingDelayedMetrics should be false from resetIsTrackingDelayedMetrics", tracker.getIsTrackingDelayedMetrics());
+    }
+
+    @Test
+    public void testTrackTenant() {
+
+        // setup mock returns for ingest POST
+        when(httpRequestMock.getUri()).thenReturn("/v2.0/" + tenantId + "/ingest");
+        when(httpMethodMock.toString()).thenReturn("POST");
+        when(httpRequestMock.getMethod()).thenReturn(httpMethodMock);
+
+        List<String> paramValues = new ArrayList<String>();
+        paramValues.add("value1");
+        paramValues.add("value2");
+        queryParams.put("param1", paramValues);
+        when((httpRequestMock).getQueryParams()).thenReturn(queryParams);
+
+        when(channelBufferMock.toString(any(Charset.class))).thenReturn("[\n" +
+                "      {\n" +
+                "        \"collectionTime\": 1376509892612,\n" +
+                "        \"ttlInSeconds\": 172800,\n" +
+                "        \"metricValue\": 65,\n" +
+                "        \"metricName\": \"example.metric.one\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"collectionTime\": 1376509892612,\n" +
+                "        \"ttlInSeconds\": 172800,\n" +
+                "        \"metricValue\": 66,\n" +
+                "        \"metricName\": \"example.metric.two\"\n" +
+                "      },\n" +
+                "    ]'");
+        when(httpRequestMock.getContent()).thenReturn(channelBufferMock);
+
+        // add tenant and track
+        tracker.addTenant(tenantId);
+        tracker.track(httpRequestMock);
+
+        // verify
+        verify(loggerMock, atLeastOnce()).info("[TRACKER] tenantId " + tenantId + " added.");
+        verify(loggerMock, atLeastOnce()).info((String)argCaptor.capture());
+        assertThat(argCaptor.getValue().toString(), containsString("[TRACKER] POST request for tenantId " + tenantId + ": /v2.0/" + tenantId + "/ingest?param1=value1&param1=value2\n" +
+                "HEADERS: \n" +
+                "X-Auth-Token\tAUTHTOKEN\n" +
+                "REQUEST_CONTENT:\n" +
+                "[\n" +
+                "      {\n" +
+                "        \"collectionTime\": 1376509892612,\n" +
+                "        \"ttlInSeconds\": 172800,\n" +
+                "        \"metricValue\": 65,\n" +
+                "        \"metricName\": \"example.metric.one\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"collectionTime\": 1376509892612,\n" +
+                "        \"ttlInSeconds\": 172800,\n" +
+                "        \"metricValue\": 66,\n" +
+                "        \"metricName\": \"example.metric.two\"\n" +
+                "      },\n" +
+                "    ]'"));
+    }
+
+    @Test
+    public void testTrackNullRequest() {
+        tracker.addTenant(tenantId);
+        tracker.track(null);
+        verify(loggerMock, atLeastOnce()).info((String)argCaptor.capture());
+        assertThat(argCaptor.getValue().toString(), not(containsString("[TRACKER] POST request for tenantId " + tenantId)));
+        assertThat(argCaptor.getValue().toString(), not(containsString("[TRACKER] GET request for tenantId " + tenantId)));
+        assertThat(argCaptor.getValue().toString(), not(containsString("[TRACKER] PUT request for tenantId " + tenantId)));
+    }
+
+    @Test
+    public void testDoesNotTrackTenant() {
+        // setup mock returns URI
+        when(httpRequestMock.getUri()).thenReturn("/v2.0/" + tenantId + "/ingest");
+
+        // make sure tenantId is removed and track
+        tracker.removeTenant(tenantId);
+        tracker.track(httpRequestMock);
+
+        // verify does not log for tenantId
+        verify(loggerMock, atLeastOnce()).info((String)argCaptor.capture());
+        assertThat(argCaptor.getValue().toString(), not(containsString("[TRACKER] POST request for tenantId " + tenantId)));
+        assertThat(argCaptor.getValue().toString(), not(containsString("[TRACKER] GET request for tenantId " + tenantId)));
+        assertThat(argCaptor.getValue().toString(), not(containsString("[TRACKER] PUT request for tenantId " + tenantId)));
+    }
+
+    @Test
+    public void testTrackResponse() {
+
+        // setup mock returns for query POST
+        String requestUri = "/v2.0/" + tenantId + "/metrics/search";
+        when(httpRequestMock.getUri()).thenReturn(requestUri);
+        when(httpMethodMock.toString()).thenReturn("GET");
+        when(httpRequestMock.getMethod()).thenReturn(httpMethodMock);
+
+        List<String> paramValues = new ArrayList<String>();
+        paramValues.add("locator1");
+        queryParams.put("query", paramValues);
+        when((httpRequestMock).getQueryParams()).thenReturn(queryParams);
+
+        when(httpResponseStatusMock.getCode()).thenReturn(200);
+        when(httpResponseMock.getStatus()).thenReturn(httpResponseStatusMock);
+
+        when(channelBufferMock.toString(any(Charset.class))).thenReturn("[TRACKER] Response for tenantId " + tenantId);
+        when(httpResponseMock.getContent()).thenReturn(channelBufferMock);
+
+        // add tenant and track
+        tracker.addTenant(tenantId);
+        tracker.trackResponse(httpRequestMock, httpResponseMock);
+
+        // verify
+        verify(loggerMock, atLeastOnce()).info("[TRACKER] tenantId " + tenantId + " added.");
+        verify(loggerMock, times(1)).info("[TRACKER] Response for tenantId " + tenantId + " request " + requestUri + "?query=locator1\n" +
+                "RESPONSE_STATUS: 200\n" +
+                "RESPONSE_CONTENT:\n" +
+                "[TRACKER] Response for tenantId " + tenantId);
+    }
+
+    @Test
+    public void testTrackNullResponse() {
+        tracker.addTenant(tenantId);
+        tracker.trackResponse(httpRequestMock, null);
+        verify(loggerMock, atLeastOnce()).info((String)argCaptor.capture());
+        assertThat(argCaptor.getValue().toString(), not(containsString("[TRACKER] Response for tenantId " + tenantId)));
+    }
+
+    @Test
+    public void testDoesNotTrackTenantResponse() {
+        // setup mock returns URI
+        when(httpRequestMock.getUri()).thenReturn("/v2.0/" + tenantId + "/metrics/search");
+
+        // make sure tenantId is removed and track
+        tracker.removeTenant(tenantId);
+        tracker.trackResponse(httpRequestMock, httpResponseMock);
+
+        // verify does not log for tenantId
+        verify(loggerMock, atLeastOnce()).info((String)argCaptor.capture());
+        assertThat(argCaptor.getValue().toString(), not(containsString("[TRACKER] Response for tenantId  " + tenantId)));
+    }
+
+    @Test
+    public void testTrackDelayedMetricsTenant() {
+        // enable tracking delayed metrics and track
+        tracker.setIsTrackingDelayedMetrics();
+        tracker.trackDelayedMetricsTenant(tenantId, delayedMetrics);
+
+        // verify
+        verify(loggerMock, atLeastOnce()).info("[TRACKER] Tracking delayed metrics started");
+        verify(loggerMock, atLeastOnce()).info((String) argCaptor.capture());
+        assertThat(argCaptor.getValue().toString(), containsString(
+                "[TRACKER][DELAYED METRIC] Tenant sending delayed metrics " + tenantId + "\n" +
+                        tenantId + ".delayed.metric1 has collectionTime " + collectionTime + "\n" +
+                        tenantId + ".delayed.metric2 has collectionTime " + collectionTime + "\n"));
+
+    }
+
+    @Test
+    public void testDoesNotTrackDelayedMetricsTenant() {
+        // disable tracking delayed metrics and track
+        tracker.resetIsTrackingDelayedMetrics();
+        tracker.trackDelayedMetricsTenant(tenantId, delayedMetrics);
+
+        // verify
+        verify(loggerMock, atLeastOnce()).info("[TRACKER] Tracking delayed metrics stopped");
+        verify(loggerMock, atLeastOnce()).info((String)argCaptor.capture());
+        assertThat(argCaptor.getValue().toString(), not(containsString(
+                "[TRACKER][DELAYED METRIC] Tenant sending delayed metrics " + tenantId + "\n")));
+    }
+
 }


### PR DESCRIPTION
# What
Modify tracker so that the trackDelayedMetricsTenant, when enabled, also log the delayed metric names and collection time.

# How
Modify Tracker.trackDelayedMetricsTenant to also log the name and collectionTime of the delayed metrics that triggered the tracking.

# Why
For easier investigation of delayed metrics when we're receiving them.

# How to test
Enable the delayed metrics tracking using 
```
blueflood-chef/contrib/blueflood_tenant_tracker.sh myusername track_delayed_start node.hostname
```
Ingest metrics with collectionTime < ingestionTime by DELAYED_METRICS_MILLIS interval, verify that the delayed metrics names and collectionTimes are logged after line prefixed with "[TRACKER][DELAYED METRIC] Tenant sending delayed metrics <tenantId>".
