### PR TITLE
Test rollup event emitter

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.eventemitter;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.rackspacecloud.blueflood.concurrent.ThreadPoolBuilder;
@@ -73,6 +74,7 @@ public class RollupEventEmitter extends Emitter<RollupEvent> {
                 .withUnboundedQueue()
                 .build());
     }
+    @VisibleForTesting
     public RollupEventEmitter(ExecutorService executor) {
         eventExecutors = executor;
     }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
@@ -37,7 +37,7 @@ public class RollupEventEmitter extends Emitter<RollupEvent> {
     private static ExecutorService eventExecutors;
     private static final RollupEventEmitter instance = new RollupEventEmitter();
 
-    private RollupEventEmitter() {
+    public RollupEventEmitter() {
         eventExecutors = new ThreadPoolBuilder()
                 .withName("RollupEventEmitter ThreadPool")
                 .withCorePoolSize(numberOfWorkers)

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
@@ -34,7 +34,7 @@ public class RollupEventEmitter extends Emitter<RollupEvent> {
     private static final Logger log = LoggerFactory.getLogger(ModuleLoader.class);
     private static final int numberOfWorkers = 5;
     public static final String ROLLUP_EVENT_NAME = "rollup".intern();
-    private static ThreadPoolExecutor eventExecutors;
+    private static ExecutorService eventExecutors;
     private static final RollupEventEmitter instance = new RollupEventEmitter();
 
     private RollupEventEmitter() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
@@ -34,7 +34,7 @@ public class RollupEventEmitter extends Emitter<RollupEvent> {
     private static final Logger log = LoggerFactory.getLogger(ModuleLoader.class);
     private static final int numberOfWorkers = 5;
     public static final String ROLLUP_EVENT_NAME = "rollup".intern();
-    private static ExecutorService eventExecutors;
+    private final ExecutorService eventExecutors;
     private static final RollupEventEmitter instance = new RollupEventEmitter();
 
     public RollupEventEmitter() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
@@ -30,6 +30,34 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.concurrent.*;
 
+/**
+ * @todo {@code RollupEventEmitter} should be modified so that it can be used
+ * as a drop-in replacement for {@link Emitter<RollupEvent>}.
+ *
+ * The {@code RollupEventEmitter} class violates the Liskov substitution
+ * principle, in that it doesn't behave the same as
+ * {@link Emitter<RollupEvent>}. Moreover, the differences in behavior depend
+ * upon particular details of the inputs.
+ *
+ * For example, if there is no listener registered for
+ * {@link RollupEventEmitter#ROLLUP_EVENT_NAME}, then *ALL* events are silently
+ * ignored. No other listeners will ever be notified of their events, even
+ * events of other names.
+ *
+ * Also, if any event doesn't have a {@link RollupEvent#rollup} of type
+ * {@link BasicRollup}, that event will be silently ignored. This is the case
+ * if the event's {@link RollupEvent#rollup} field is {@code null}, or if it's
+ * another rollup type, such as
+ * {@link com.rackspacecloud.blueflood.types.HistogramRollup}
+ *
+ * @todo Merge {@code RollupEventEmitter} and {@link Emitter<>} into a single
+ * class. {@link Emitter<>} doesn't appear to be used anywhere else.
+ *
+ * @todo Change the {@code eventPayload}/{@code args} parameter of
+ * {@link RollupEventEmitter#emit} from an array to a single item. There don't
+ * appear to be any parts of the codebase that use more than a single event
+ * argument.
+ */
 public class RollupEventEmitter extends Emitter<RollupEvent> {
     private static final Logger log = LoggerFactory.getLogger(ModuleLoader.class);
     private static final int numberOfWorkers = 5;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitter.java
@@ -38,12 +38,15 @@ public class RollupEventEmitter extends Emitter<RollupEvent> {
     private static final RollupEventEmitter instance = new RollupEventEmitter();
 
     public RollupEventEmitter() {
-        eventExecutors = new ThreadPoolBuilder()
+        this(new ThreadPoolBuilder()
                 .withName("RollupEventEmitter ThreadPool")
                 .withCorePoolSize(numberOfWorkers)
                 .withMaxPoolSize(numberOfWorkers)
                 .withUnboundedQueue()
-                .build();
+                .build());
+    }
+    public RollupEventEmitter(ExecutorService executor) {
+        eventExecutors = executor;
     }
 
     public static RollupEventEmitter getInstance() { return instance; }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/EmitterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/EmitterTest.java
@@ -88,7 +88,9 @@ public class EmitterTest {
                 return null;
             }
         });
-        Thread.sleep(1000);
+
+        Thread.sleep(1000); // wait for the threads to get to the startLatch.await() calls
+
         //Assert that store is empty before testing emission
         Assert.assertTrue(store.isEmpty());
         startLatch.countDown();

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/EmitterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/EmitterTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class RollupEventEmitterTest {
+public class EmitterTest {
 
     final String testEventName = "test";
     final String testEventName2 = "test2";

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
@@ -95,7 +95,9 @@ public class RollupEventEmitterTest {
                 return null;
             }
         });
-        Thread.sleep(1000);
+
+        Thread.sleep(1000); // wait for the threads to get to the startLatch.await() calls
+
         //Assert that store is empty before testing emission
         Assert.assertTrue(store.isEmpty());
         startLatch.countDown();

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
@@ -276,6 +276,30 @@ public class RollupEventEmitterTest {
         Assert.assertSame(event1, store.get(1));
     }
 
+    @Test
+    public void offOnlyClearsForGivenEvent() {
+
+        // given
+        Emitter.Listener<RollupEvent> listener = new EventListener();
+        RollupEvent event1 = new RollupEvent(null, null, "event1", "gran", 0);
+        RollupEvent event2 = new RollupEvent(null, null, "event2", "gran", 0);
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName2, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.off(testEventName);
+        emitter.emit(testEventName, event1);
+        emitter.emit(testEventName2, event2);
+
+        // then
+        Assert.assertEquals(1, store.size());
+        Assert.assertSame(event2, store.get(0));
+
+    }
+
     private class EventListener implements Emitter.Listener<RollupEvent> {
         @Override
         public void call(RollupEvent... rollupEventObjects) {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
@@ -42,11 +42,18 @@ public class RollupEventEmitterTest {
     }
 
     @Test
-    public void testEmitter() throws Exception {
+    public void testSubscription() {
         EventListener elistener = new EventListener();
         //Test subscription
         emitter.on(testEventName, elistener);
         Assert.assertTrue(emitter.listeners(testEventName).contains(elistener));
+    }
+
+    @Test
+    public void testConcurrentEmission() throws InterruptedException, ExecutionException {
+        EventListener elistener = new EventListener();
+        //Test subscription
+        emitter.on(testEventName, elistener);
         //Test concurrent emission
         ThreadPoolExecutor executors = new ThreadPoolBuilder()
                 .withCorePoolSize(2)
@@ -77,9 +84,15 @@ public class RollupEventEmitterTest {
         startLatch.countDown();
         f1.get();
         f2.get();
-        Assert.assertEquals(store.size(),2);
+        Assert.assertEquals(store.size(), 2);
         Assert.assertTrue(store.contains(obj1));
         Assert.assertTrue(store.contains(obj2));
+    }
+
+    @Test
+    public void testUnsubscription() {
+        EventListener elistener = new EventListener();
+        emitter.on(testEventName, elistener);
         //Test unsubscription
         emitter.off(testEventName, elistener);
         Assert.assertFalse(emitter.listeners(testEventName).contains(elistener));

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
@@ -30,13 +30,15 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class RollupEventEmitterTest {
-    String testEventName;
+
+    final String testEventName = "test";
+    final String testEventName2 = "test2";
+
     List<RollupEvent> store;
     Emitter<RollupEvent> emitter;
 
     @Before
     public void setUp() {
-        testEventName = "test";
         store = Collections.synchronizedList(new ArrayList<RollupEvent>());
         emitter = new Emitter<RollupEvent>();
     }
@@ -184,6 +186,94 @@ public class RollupEventEmitterTest {
 
         // then
         Assert.assertEquals(0, store.size());
+    }
+
+    @Test
+    public void emitOnlyTriggersForGivenEvent1() {
+
+        // given
+        Emitter.Listener<RollupEvent> listener = new EventListener();
+        RollupEvent event1 = new RollupEvent(null, null, "event1", "gran", 0);
+        RollupEvent event2 = new RollupEvent(null, null, "event2", "gran", 0);
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName2, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(1, store.size());
+        Assert.assertSame(event1, store.get(0));
+    }
+
+    @Test
+    public void emitOnlyTriggersForGivenEvent2() {
+
+        // given
+        Emitter.Listener<RollupEvent> listener = new EventListener();
+        RollupEvent event1 = new RollupEvent(null, null, "event1", "gran", 0);
+        RollupEvent event2 = new RollupEvent(null, null, "event2", "gran", 0);
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName2, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.emit(testEventName2, event2);
+
+        // then
+        Assert.assertEquals(1, store.size());
+        Assert.assertSame(event2, store.get(0));
+    }
+
+    @Test
+    public void emitTriggersListenerInSameOrder1() {
+
+        // given
+        Emitter.Listener<RollupEvent> listener = new EventListener();
+        RollupEvent event1 = new RollupEvent(null, null, "event1", "gran", 0);
+        RollupEvent event2 = new RollupEvent(null, null, "event2", "gran", 0);
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName2, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.emit(testEventName, event1);
+        emitter.emit(testEventName2, event2);
+
+        // then
+        Assert.assertEquals(2, store.size());
+        Assert.assertSame(event1, store.get(0));
+        Assert.assertSame(event2, store.get(1));
+    }
+
+    @Test
+    public void emitTriggersListenerInSameOrder2() {
+
+        // given
+        Emitter.Listener<RollupEvent> listener = new EventListener();
+        RollupEvent event1 = new RollupEvent(null, null, "event1", "gran", 0);
+        RollupEvent event2 = new RollupEvent(null, null, "event2", "gran", 0);
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName2, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.emit(testEventName2, event2);
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(2, store.size());
+        Assert.assertSame(event2, store.get(0));
+        Assert.assertSame(event1, store.get(1));
     }
 
     private class EventListener implements Emitter.Listener<RollupEvent> {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2016 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.eventemitter;
+
+import com.rackspacecloud.blueflood.concurrent.ThreadPoolBuilder;
+import com.rackspacecloud.blueflood.types.Points;
+import com.rackspacecloud.blueflood.types.Rollup;
+import com.rackspacecloud.blueflood.types.SimpleNumber;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.*;
+
+public class RollupEventEmitterTest {
+
+    final String testEventName = "test";
+    final String testEventName2 = "test2";
+
+    List<RollupEvent> store;
+    List<RollupEvent> store2;
+    RollupEventEmitter emitter;
+    Emitter.Listener<RollupEvent> listener;
+    Emitter.Listener<RollupEvent> listener2;
+    RollupEvent event1;
+    RollupEvent event2;
+
+    @Before
+    public void setUp() throws IOException {
+        store = Collections.synchronizedList(new ArrayList<RollupEvent>());
+        store2 = Collections.synchronizedList(new ArrayList<RollupEvent>());
+        emitter = new RollupEventEmitter(new SynchronousExecutorService());
+
+        emitter.on(RollupEventEmitter.ROLLUP_EVENT_NAME, new Emitter.Listener() {
+            @Override
+            public void call(Object[] args) {
+                // do nothing
+            }
+        });
+        Points<SimpleNumber> points = new Points<SimpleNumber>();
+        Rollup rollup = Rollup.BasicFromRaw.compute(points);
+
+        listener = new EventListener(store);
+        listener2 = new EventListener(store2);
+        event1 = new RollupEvent(null, rollup, "event1", "gran", 0);
+        event2 = new RollupEvent(null, rollup, "event2", "gran", 0);
+    }
+
+    @Test
+    public void testSubscription() {
+        //Test subscription
+        emitter.on(testEventName, listener);
+        Assert.assertTrue(emitter.listeners(testEventName).contains(listener));
+    }
+
+    @Test
+    public void testConcurrentEmission() throws InterruptedException, ExecutionException {
+        //Test subscription
+        emitter.on(testEventName, listener);
+        //Test concurrent emission
+        ThreadPoolExecutor executors = new ThreadPoolBuilder()
+                .withCorePoolSize(2)
+                .withMaxPoolSize(3)
+                .build();
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        Future<Object> f1 = executors.submit(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                startLatch.await();
+                emitter.emit(testEventName, event1);
+                return null;
+            }
+        });
+        Future<Object> f2 = executors.submit(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                startLatch.await();
+                emitter.emit(testEventName, event2);
+                return null;
+            }
+        });
+        Thread.sleep(1000);
+        //Assert that store is empty before testing emission
+        Assert.assertTrue(store.isEmpty());
+        startLatch.countDown();
+        f1.get();
+        f2.get();
+        Assert.assertEquals(store.size(), 2);
+        Assert.assertTrue(store.contains(event1));
+        Assert.assertTrue(store.contains(event2));
+    }
+
+    @Test
+    public void testUnsubscription() {
+        emitter.on(testEventName, listener);
+        //Test unsubscription
+        emitter.off(testEventName, listener);
+        Assert.assertFalse(emitter.listeners(testEventName).contains(listener));
+        //Clear the store and check if it is not getting filled again
+        store.clear();
+        emitter.emit(testEventName, new RollupEvent(null, null, "payload3", "gran", 0));
+        Assert.assertTrue(store.isEmpty());
+    }
+
+    @Test
+    public void testOnce() throws ExecutionException, InterruptedException {
+        //Test once
+        emitter.once(testEventName, listener);
+        Future f = emitter.emit(testEventName, event1);
+        f.get();
+        Assert.assertEquals(store.size(), 1);
+        store.clear();
+        emitter.emit(testEventName, event2);
+        Assert.assertEquals(store.size(), 0);
+    }
+
+    @Test
+    public void testOn() {
+
+        // given
+        emitter.on(testEventName, listener);
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(1, store.size());
+        Assert.assertSame(event1, store.get(0));
+
+        // when
+        emitter.emit(testEventName, event2);
+
+        // then
+        Assert.assertEquals(2, store.size());
+        Assert.assertSame(event1, store.get(0));
+        Assert.assertSame(event2, store.get(1));
+    }
+
+    @Test
+    public void offClearsRegularCallbacks() {
+
+        // given
+        emitter.on(testEventName, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.off();
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(0, store.size());
+    }
+
+    @Test
+    public void offClearsOnceCallbacks() {
+
+        // given
+        emitter.once(testEventName, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.off();
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(0, store.size());
+    }
+
+    @Test
+    public void emitOnlyTriggersForGivenEvent1() {
+
+        // given
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName2, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(1, store.size());
+        Assert.assertSame(event1, store.get(0));
+    }
+
+    @Test
+    public void emitOnlyTriggersForGivenEvent2() {
+
+        // given
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName2, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.emit(testEventName2, event2);
+
+        // then
+        Assert.assertEquals(1, store.size());
+        Assert.assertSame(event2, store.get(0));
+    }
+
+    @Test
+    public void emitTriggersListenerInSameOrder1() {
+
+        // given
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName2, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.emit(testEventName, event1);
+        emitter.emit(testEventName2, event2);
+
+        // then
+        Assert.assertEquals(2, store.size());
+        Assert.assertSame(event1, store.get(0));
+        Assert.assertSame(event2, store.get(1));
+    }
+
+    @Test
+    public void emitTriggersListenerInSameOrder2() {
+
+        // given
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName2, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.emit(testEventName2, event2);
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(2, store.size());
+        Assert.assertSame(event2, store.get(0));
+        Assert.assertSame(event1, store.get(1));
+    }
+
+    @Test
+    public void offOnlyClearsForGivenEvent() {
+
+        // given
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName2, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.off(testEventName);
+        emitter.emit(testEventName, event1);
+        emitter.emit(testEventName2, event2);
+
+        // then
+        Assert.assertEquals(1, store.size());
+        Assert.assertSame(event2, store.get(0));
+    }
+
+    @Test
+    public void multipleAttachedListenersShouldAllBeTriggeredByOneEvent() {
+
+        // given
+        emitter.on(testEventName, listener);
+        emitter.on(testEventName, listener2);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+        Assert.assertEquals(0, store2.size());
+
+        // when
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(1, store.size());
+        Assert.assertSame(event1, store.get(0));
+
+        Assert.assertEquals(1, store2.size());
+        Assert.assertSame(event1, store2.get(0));
+    }
+
+    private class SynchronousExecutorService extends AbstractExecutorService {
+
+        @Override
+        public void shutdown() {
+            throw new UnsupportedOperationException("method not implemented");
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            throw new UnsupportedOperationException("method not implemented");
+        }
+
+        @Override
+        public boolean isShutdown() {
+            throw new UnsupportedOperationException("method not implemented");
+        }
+
+        @Override
+        public boolean isTerminated() {
+            throw new UnsupportedOperationException("method not implemented");
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            throw new UnsupportedOperationException("method not implemented");
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+    }
+
+    private class EventListener implements Emitter.Listener<RollupEvent> {
+        public EventListener(List<RollupEvent> events) {
+            this.events = events;
+        }
+        final List<RollupEvent> events;
+        @Override
+        public void call(RollupEvent... rollupEventObjects) {
+            events.addAll(Arrays.asList(rollupEventObjects));
+        }
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
@@ -25,6 +25,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.*;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 public class RollupEventEmitterTest {
     String testEventName = "test";
     List<RollupEvent> store = Collections.synchronizedList(new ArrayList<RollupEvent>());
@@ -88,6 +91,40 @@ public class RollupEventEmitterTest {
         store.clear();
         emitter.emit(testEventName, new RollupEvent(null, null, "payload1", "gran", 0));
         Assert.assertEquals(store.size(), 0);
+    }
+
+    @Test
+    public void testOn() {
+
+        // given
+        final List<RollupEvent> events = new ArrayList<RollupEvent>();
+        Emitter.Listener<RollupEvent> listener = new Emitter.Listener<RollupEvent>() {
+            @Override
+            public void call(RollupEvent... args) {
+                Collections.addAll(events, args);
+            }
+        };
+
+        RollupEvent event1 = new RollupEvent(null, null, "event1", "gran", 0);
+        RollupEvent event2 = new RollupEvent(null, null, "event2", "gran", 0);
+
+        emitter.on(testEventName, listener);
+        Assert.assertEquals(0, events.size());
+
+        // when
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(1, events.size());
+        Assert.assertSame(event1, events.get(0));
+
+        // when
+        emitter.emit(testEventName, event2);
+
+        // then
+        Assert.assertEquals(2, events.size());
+        Assert.assertSame(event1, events.get(0));
+        Assert.assertSame(event2, events.get(1));
     }
 
     private class EventListener implements Emitter.Listener<RollupEvent> {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
@@ -135,6 +135,44 @@ public class RollupEventEmitterTest {
         Assert.assertSame(event2, events.get(1));
     }
 
+    @Test
+    public void offClearsRegularCallbacks() {
+
+        // given
+        Emitter.Listener<RollupEvent> listener = new EventListener();
+        RollupEvent event1 = new RollupEvent(null, null, "event1", "gran", 0);
+        emitter.on(testEventName, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.off();
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(0, store.size());
+    }
+
+    @Test
+    public void offClearsOnceCallbacks() {
+
+        // given
+        Emitter.Listener<RollupEvent> listener = new EventListener();
+        RollupEvent event1 = new RollupEvent(null, null, "event1", "gran", 0);
+        emitter.once(testEventName, listener);
+
+        // precondition
+        Assert.assertEquals(0, store.size());
+
+        // when
+        emitter.off();
+        emitter.emit(testEventName, event1);
+
+        // then
+        Assert.assertEquals(0, store.size());
+    }
+
     private class EventListener implements Emitter.Listener<RollupEvent> {
         @Override
         public void call(RollupEvent... rollupEventObjects) {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventEmitterTest.java
@@ -18,6 +18,7 @@ package com.rackspacecloud.blueflood.eventemitter;
 
 import com.rackspacecloud.blueflood.concurrent.ThreadPoolBuilder;
 import junit.framework.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,9 +30,16 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class RollupEventEmitterTest {
-    String testEventName = "test";
-    List<RollupEvent> store = Collections.synchronizedList(new ArrayList<RollupEvent>());
-    Emitter<RollupEvent> emitter = new Emitter<RollupEvent>();
+    String testEventName;
+    List<RollupEvent> store;
+    Emitter<RollupEvent> emitter;
+
+    @Before
+    public void setUp() {
+        testEventName = "test";
+        store = Collections.synchronizedList(new ArrayList<RollupEvent>());
+        emitter = new Emitter<RollupEvent>();
+    }
 
     @Test
     public void testEmitter() throws Exception {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/eventemitter/RollupEventTest.java
@@ -1,0 +1,72 @@
+package com.rackspacecloud.blueflood.eventemitter;
+
+import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.types.Points;
+import com.rackspacecloud.blueflood.types.Rollup;
+import com.rackspacecloud.blueflood.types.SimpleNumber;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class RollupEventTest {
+
+    Locator locator;
+    Rollup rollup;
+    String unit;
+    String granularity;
+    long timestamp;
+
+    RollupEvent event;
+
+    @Before
+    public void setUp() throws IOException {
+
+        locator = Locator.createLocatorFromPathComponents("tenant", "a", "b");
+        Points<SimpleNumber> points = new Points<SimpleNumber>();
+        rollup = Rollup.BasicFromRaw.compute(points);
+        unit = "Some init";
+        granularity = "Some granularity";
+        timestamp = 1451631661000L;     // 2016-01-01 01:01:01 CST
+
+        event = new RollupEvent(locator, rollup, unit, granularity, timestamp);
+    }
+
+    @Test
+    public void locatorGetsSetInConstructor() {
+        Assert.assertSame(locator, event.getLocator());
+    }
+
+    @Test
+    public void rollupGetsSetInConstructor() {
+        Assert.assertSame(rollup, event.getRollup());
+    }
+
+    @Test
+    public void unitGetsSetInConstructor() {
+        Assert.assertEquals(unit, event.getUnit());
+    }
+
+    @Test
+    public void granularityGetsSetInConstructor() {
+        Assert.assertEquals(granularity, event.getGranularityName());
+    }
+
+    @Test
+    public void timestampGetsSetInConstructor() {
+        Assert.assertEquals(timestamp, event.getTimestamp());
+    }
+
+    @Test
+    public void setUnitChangesUnit() {
+        //given
+        String unit2= "Some other unit";
+        // when
+        event.setUnit(unit2);
+        // then
+        assertEquals(unit2, event.getUnit());
+    }
+}


### PR DESCRIPTION
`Emitter<>` serves as a kind of publish/subscribe event notification system. Listeners can be registered to listen for an event of particular name. The `RollupEventEmitter` is a subclass of `EventEmitter<RollupEvent>` that reports events related to rollups. However, the subclass is broken, IMHO.

The main thing is that all events will be silently ignored if there isn't a listener registered for events named `ROLLUP_EVENT_NAME`, which has a value of "rollup". To be clear: even events that have a different name, events that are for some other name, will not be delivered at all, unless a listener is registered for `ROLLUP_EVENT_NAME`.

Additionally, the purpose of the class seems to be to automatically set the unit of any incoming `RollupEvent` and then just pass it on as usual. I honestly don't think that should warrant a separate thread pool. The thread pool business is making it difficult to test.

The specific functionality that `RollupEventEmitter` adds is to check all events to be emitted and make sure that they have the right unit set. However, it is hard-coded to get the unit from the `com.rackspacecloud.blueflood.io.ElasticIO` class, which is in the `blueflood-elasticsearch` module. As such, it is currently infeasible to write unit tests for this functionality. They would have to be integration tests.

This PR adds tests for the `RollupEventEmitter`, `Emitter<T>`, and `RollupEvent` classes. This brings line coverage up to about 65%, 97%, and 100%, respectively. I don't think I can get `RollupEventEmitter` any higher, given the above limitations.