### PR TITLE
Test RollupBatchWriter

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnable.java
@@ -18,6 +18,7 @@ package com.rackspacecloud.blueflood.service;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.rackspacecloud.blueflood.io.astyanax.AstyanaxWriter;
 import com.rackspacecloud.blueflood.utils.Metrics;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 public class RollupBatchWriteRunnable  implements Runnable {
     private final RollupExecutionContext executionContext;
     private final ArrayList<SingleRollupWriteContext> writeContexts;
+    private final AstyanaxWriter astyanaxWriter;
     private static final Histogram rollupsPerBatch =
             Metrics.histogram(RollupService.class, "Rollups Per Batch");
     private static final Timer batchWriteTimer =
@@ -34,15 +36,22 @@ public class RollupBatchWriteRunnable  implements Runnable {
 
     public RollupBatchWriteRunnable(ArrayList<SingleRollupWriteContext> writeContexts,
                                     RollupExecutionContext executionContext) {
+        this(writeContexts, executionContext, AstyanaxWriter.getInstance());
+    }
+    @VisibleForTesting
+    public RollupBatchWriteRunnable(ArrayList<SingleRollupWriteContext> writeContexts,
+                                    RollupExecutionContext executionContext,
+                                    AstyanaxWriter astyanaxWriter) {
         this.writeContexts = writeContexts;
         this.executionContext = executionContext;
+        this.astyanaxWriter = astyanaxWriter;
     }
 
     @Override
     public void run() {
         Timer.Context ctx = batchWriteTimer.time();
         try {
-            AstyanaxWriter.getInstance().insertRollups(writeContexts);
+            astyanaxWriter.insertRollups(writeContexts);
         } catch (ConnectionException e) {
             executionContext.markUnsuccessful(e);
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnable.java
@@ -27,10 +27,13 @@ import java.util.ArrayList;
 public class RollupBatchWriteRunnable  implements Runnable {
     private final RollupExecutionContext executionContext;
     private final ArrayList<SingleRollupWriteContext> writeContexts;
-    private static final Histogram rollupsPerBatch = Metrics.histogram(RollupService.class, "Rollups Per Batch");
-    private static final Timer batchWriteTimer = Metrics.timer(RollupService.class, "Rollup Batch Write");
+    private static final Histogram rollupsPerBatch =
+            Metrics.histogram(RollupService.class, "Rollups Per Batch");
+    private static final Timer batchWriteTimer =
+            Metrics.timer(RollupService.class, "Rollup Batch Write");
 
-    public RollupBatchWriteRunnable(ArrayList<SingleRollupWriteContext> writeContexts, RollupExecutionContext executionContext) {
+    public RollupBatchWriteRunnable(ArrayList<SingleRollupWriteContext> writeContexts,
+                                    RollupExecutionContext executionContext) {
         this.writeContexts = writeContexts;
         this.executionContext = executionContext;
     }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupBatchWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupBatchWriter.java
@@ -54,7 +54,6 @@ public class RollupBatchWriter {
 
     public synchronized void drainBatch() {
         ArrayList<SingleRollupWriteContext> writeContexts = new ArrayList<SingleRollupWriteContext>();
-        SingleRollupWriteContext ctx;
         try {
             for (int i=0; i<=ROLLUP_BATCH_MAX_SIZE; i++) {
                 writeContexts.add(rollupQueue.remove());

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupBatchWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupBatchWriter.java
@@ -42,9 +42,11 @@ public class RollupBatchWriter {
     public void enqueueRollupForWrite(SingleRollupWriteContext rollupWriteContext) {
         rollupQueue.add(rollupWriteContext);
         context.incrementWriteCounter();
-        // enqueue MIN_SIZE batches only if the threadpool is unsaturated. else, enqueue when we have >= MAX_SIZE pending
+        // enqueue MIN_SIZE batches only if the threadpool is unsaturated.
+        // else, enqueue when we have >= MAX_SIZE pending
         if (rollupQueue.size() >= ROLLUP_BATCH_MIN_SIZE) {
-            if (executor.getActiveCount() < executor.getPoolSize() || rollupQueue.size() >= ROLLUP_BATCH_MAX_SIZE) {
+            if (executor.getActiveCount() < executor.getPoolSize() ||
+                    rollupQueue.size() >= ROLLUP_BATCH_MAX_SIZE) {
                 drainBatch();
             }
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupWriteContext.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupWriteContext.java
@@ -31,6 +31,13 @@ public class SingleRollupWriteContext {
     private final MetricColumnFamily destinationCF;
     private final Granularity granularity;
 
+    public SingleRollupWriteContext(Rollup rollup,
+                                    SingleRollupReadContext singleRollupReadContext,
+                                    MetricColumnFamily dstCF) {
+        this(rollup, singleRollupReadContext.getLocator(),
+                singleRollupReadContext.getRollupGranularity(), dstCF,
+                singleRollupReadContext.getRange().getStart());
+    }
     @VisibleForTesting
     public SingleRollupWriteContext(Rollup rollup, Locator locator,
                                     Granularity granularity,
@@ -40,14 +47,6 @@ public class SingleRollupWriteContext {
         this.granularity = granularity;
         this.destinationCF = destCf;
         this.timestamp = timestamp;
-    }
-
-    public SingleRollupWriteContext(Rollup rollup,
-                                    SingleRollupReadContext singleRollupReadContext,
-                                    MetricColumnFamily dstCF) {
-        this(rollup, singleRollupReadContext.getLocator(),
-                singleRollupReadContext.getRollupGranularity(), dstCF,
-                singleRollupReadContext.getRange().getStart());
     }
 
     public Rollup getRollup() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupWriteContext.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupWriteContext.java
@@ -31,7 +31,9 @@ public class SingleRollupWriteContext {
     private final Granularity granularity;
 
     // public only for tests
-    public SingleRollupWriteContext(Rollup rollup, Locator locator, Granularity granularity, MetricColumnFamily destCf, Long timestamp) {
+    public SingleRollupWriteContext(Rollup rollup, Locator locator,
+                                    Granularity granularity,
+                                    MetricColumnFamily destCf, Long timestamp) {
         this.rollup = rollup;
         this.locator = locator;
         this.granularity = granularity;
@@ -39,8 +41,12 @@ public class SingleRollupWriteContext {
         this.timestamp = timestamp;
     }
 
-    public SingleRollupWriteContext(Rollup rollup, SingleRollupReadContext singleRollupReadContext, MetricColumnFamily dstCF) {
-        this(rollup, singleRollupReadContext.getLocator(), singleRollupReadContext.getRollupGranularity(), dstCF, singleRollupReadContext.getRange().getStart());
+    public SingleRollupWriteContext(Rollup rollup,
+                                    SingleRollupReadContext singleRollupReadContext,
+                                    MetricColumnFamily dstCF) {
+        this(rollup, singleRollupReadContext.getLocator(),
+                singleRollupReadContext.getRollupGranularity(), dstCF,
+                singleRollupReadContext.getRange().getStart());
     }
 
     public Rollup getRollup() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupWriteContext.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/SingleRollupWriteContext.java
@@ -17,6 +17,7 @@
 package com.rackspacecloud.blueflood.service;
 
 
+import com.google.common.annotations.VisibleForTesting;
 import com.netflix.astyanax.model.ColumnFamily;
 import com.rackspacecloud.blueflood.io.CassandraModel.MetricColumnFamily;
 import com.rackspacecloud.blueflood.rollup.Granularity;
@@ -30,7 +31,7 @@ public class SingleRollupWriteContext {
     private final MetricColumnFamily destinationCF;
     private final Granularity granularity;
 
-    // public only for tests
+    @VisibleForTesting
     public SingleRollupWriteContext(Rollup rollup, Locator locator,
                                     Granularity granularity,
                                     MetricColumnFamily destCf, Long timestamp) {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnableTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnableTest.java
@@ -4,14 +4,16 @@ import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.rackspacecloud.blueflood.io.AstyanaxWriter;
 import org.junit.Test;
 import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertSame;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.*;
 
 public class RollupBatchWriteRunnableTest {
@@ -21,9 +23,31 @@ public class RollupBatchWriteRunnableTest {
 
         // given
         ArrayList<SingleRollupWriteContext> wcs = new ArrayList<SingleRollupWriteContext>();
-        ArrayList<SingleRollupWriteContext> wcs2 = new ArrayList<SingleRollupWriteContext>();
+
         RollupExecutionContext ctx = mock(RollupExecutionContext.class);
+        final AtomicLong decrementCount = new AtomicLong(0);
+        Answer contextAnswer = new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                decrementCount.set((Long)invocation.getArguments()[0]);
+                return null;
+            }
+        };
+        doAnswer(contextAnswer).when(ctx).decrementWriteCounter(anyLong());
+
+
         AstyanaxWriter writer = mock(AstyanaxWriter.class);
+        final Object[] insertRollupsArg = new Object[1];
+        Answer writerAnswer = new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                insertRollupsArg[0] = invocation.getArguments()[0];
+                return null;
+            }
+        };
+        doAnswer(writerAnswer).when(writer).insertRollups(
+                Matchers.<ArrayList<SingleRollupWriteContext>>any());
+
         RollupBatchWriteRunnable rbwr = new RollupBatchWriteRunnable(wcs, ctx, writer);
 
         // when
@@ -31,8 +55,10 @@ public class RollupBatchWriteRunnableTest {
 
         // then
         verify(writer).insertRollups(Matchers.<ArrayList<SingleRollupWriteContext>>any());
+        assertSame(wcs, insertRollupsArg[0]);
         verifyNoMoreInteractions(writer);
         verify(ctx).decrementWriteCounter(anyLong());
+        assertEquals(wcs.size(), decrementCount.get());
         verifyNoMoreInteractions(ctx);
     }
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnableTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnableTest.java
@@ -1,7 +1,7 @@
 package com.rackspacecloud.blueflood.service;
 
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
-import com.rackspacecloud.blueflood.io.AstyanaxWriter;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxWriter;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnableTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnableTest.java
@@ -7,12 +7,12 @@ import org.mockito.Matchers;
 
 import java.util.ArrayList;
 
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 public class RollupBatchWriteRunnableTest {
 
@@ -34,5 +34,58 @@ public class RollupBatchWriteRunnableTest {
         verifyNoMoreInteractions(writer);
         verify(ctx).decrementWriteCounter(anyLong());
         verifyNoMoreInteractions(ctx);
+    }
+
+    @Test
+    public void connectionExceptionMarksUnsuccessful() throws ConnectionException {
+
+        // given
+        ArrayList<SingleRollupWriteContext> wcs = new ArrayList<SingleRollupWriteContext>();
+        ArrayList<SingleRollupWriteContext> wcs2 = new ArrayList<SingleRollupWriteContext>();
+        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
+        AstyanaxWriter writer = mock(AstyanaxWriter.class);
+        Throwable cause = new ConnectionException("exception for testing purposes") { };
+        doThrow(cause).when(writer).insertRollups(
+                Matchers.<ArrayList<SingleRollupWriteContext>>any());
+        RollupBatchWriteRunnable rbwr = new RollupBatchWriteRunnable(wcs, ctx, writer);
+
+        // when
+        rbwr.run();
+
+        // then
+        verify(writer).insertRollups(Matchers.<ArrayList<SingleRollupWriteContext>>any());
+        verifyNoMoreInteractions(writer);
+        verify(ctx).markUnsuccessful(Matchers.<Throwable>any());
+        verify(ctx).decrementWriteCounter(anyLong());
+        verifyNoMoreInteractions(ctx);
+    }
+
+    @Test
+    public void otherExceptionBreaksEverything() throws ConnectionException {
+
+        // given
+        ArrayList<SingleRollupWriteContext> wcs = new ArrayList<SingleRollupWriteContext>();
+        ArrayList<SingleRollupWriteContext> wcs2 = new ArrayList<SingleRollupWriteContext>();
+        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
+        AstyanaxWriter writer = mock(AstyanaxWriter.class);
+        Throwable cause = new UnsupportedOperationException("exception for testing purposes");
+        doThrow(cause).when(writer).insertRollups(
+                Matchers.<ArrayList<SingleRollupWriteContext>>any());
+        RollupBatchWriteRunnable rbwr = new RollupBatchWriteRunnable(wcs, ctx, writer);
+
+        // when
+        Throwable caught = null;
+        try {
+            rbwr.run();
+        } catch (Throwable t) {
+            caught = t;
+        }
+
+        // then
+        assertNotNull(caught);
+        assertSame(cause, caught);
+        verify(writer).insertRollups(Matchers.<ArrayList<SingleRollupWriteContext>>any());
+        verifyNoMoreInteractions(writer);
+        verifyZeroInteractions(ctx);
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnableTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnableTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.*;
 public class RollupBatchWriteRunnableTest {
 
     @Test
-    public void runSendsRollupsToWrierAndDecrementsCount() throws ConnectionException {
+    public void runSendsRollupsToWriterAndDecrementsCount() throws ConnectionException {
 
         // given
         ArrayList<SingleRollupWriteContext> wcs = new ArrayList<SingleRollupWriteContext>();

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnableTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriteRunnableTest.java
@@ -1,0 +1,38 @@
+package com.rackspacecloud.blueflood.service;
+
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.rackspacecloud.blueflood.io.AstyanaxWriter;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+import java.util.ArrayList;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class RollupBatchWriteRunnableTest {
+
+    @Test
+    public void runSendsRollupsToWrierAndDecrementsCount() throws ConnectionException {
+
+        // given
+        ArrayList<SingleRollupWriteContext> wcs = new ArrayList<SingleRollupWriteContext>();
+        ArrayList<SingleRollupWriteContext> wcs2 = new ArrayList<SingleRollupWriteContext>();
+        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
+        AstyanaxWriter writer = mock(AstyanaxWriter.class);
+        RollupBatchWriteRunnable rbwr = new RollupBatchWriteRunnable(wcs, ctx, writer);
+
+        // when
+        rbwr.run();
+
+        // then
+        verify(writer).insertRollups(Matchers.<ArrayList<SingleRollupWriteContext>>any());
+        verifyNoMoreInteractions(writer);
+        verify(ctx).decrementWriteCounter(anyLong());
+        verifyNoMoreInteractions(ctx);
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriterTest.java
@@ -1,0 +1,34 @@
+package com.rackspacecloud.blueflood.service;
+
+import org.junit.Test;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.*;
+
+public class RollupBatchWriterTest {
+
+    @Test
+    public void enqueueIncrementsWriterCounter() {
+
+        // given
+        BlockingQueue<Runnable> queue = new ArrayBlockingQueue<Runnable>(5);
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(2, 4, 1000, TimeUnit.MILLISECONDS, queue);
+        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
+        SingleRollupWriteContext srwc = mock(SingleRollupWriteContext.class);
+
+        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
+
+        // when
+        rbw.enqueueRollupForWrite(srwc);
+
+        // then
+        verify(ctx).incrementWriteCounter();
+        verifyNoMoreInteractions(ctx);
+
+        verifyZeroInteractions(srwc);
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriterTest.java
@@ -1,27 +1,33 @@
 package com.rackspacecloud.blueflood.service;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
 
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.*;
 
 public class RollupBatchWriterTest {
 
+    ThreadPoolExecutor executor;
+    RollupExecutionContext ctx;
+
+    RollupBatchWriter rbw;
+
+    @Before
+    public void setUp() {
+
+        executor = mock(ThreadPoolExecutor.class);
+        ctx = mock(RollupExecutionContext.class);
+        rbw = new RollupBatchWriter(executor, ctx);
+    }
+
     @Test
     public void enqueueIncrementsWriterCounter() {
 
         // given
-        BlockingQueue<Runnable> queue = new ArrayBlockingQueue<Runnable>(5);
-        ThreadPoolExecutor executor = new ThreadPoolExecutor(2, 4, 1000, TimeUnit.MILLISECONDS, queue);
-        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
         SingleRollupWriteContext srwc = mock(SingleRollupWriteContext.class);
-
-        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
 
         // when
         rbw.enqueueRollupForWrite(srwc);
@@ -37,15 +43,11 @@ public class RollupBatchWriterTest {
     public void enqueuingLessThanMinSizeDoesNotTriggerBatching() {
 
         // given
-        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
-        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
         SingleRollupWriteContext srwc1 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc2 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc3 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc4 = mock(SingleRollupWriteContext.class);
         // ROLLUP_BATCH_MIN_SIZE default value is 5
-
-        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
 
         // when
         rbw.enqueueRollupForWrite(srwc1);
@@ -69,21 +71,18 @@ public class RollupBatchWriterTest {
     public void enqueuingMinSizeTriggersCheckOnExecutor() {
 
         // given
-        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
+
         // if active count == pool size, the RollupBatchWriter will think the
         // thread pool is saturated, and not drain
         doReturn(1).when(executor).getActiveCount();
         doReturn(1).when(executor).getPoolSize();
 
-        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
         SingleRollupWriteContext srwc1 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc2 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc3 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc4 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc5 = mock(SingleRollupWriteContext.class);
         // ROLLUP_BATCH_MIN_SIZE default value is 5
-
-        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
 
         // when
         rbw.enqueueRollupForWrite(srwc1);
@@ -112,21 +111,17 @@ public class RollupBatchWriterTest {
     public void enqueuingMinSizeAndThreadPoolNotSaturatedTriggersBatching() {
 
         // given
-        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
         // if active count < pool size, the RollupBatchWriter will think the
         // thread pool is NOT saturated, and start batching
         doReturn(0).when(executor).getActiveCount();
         doReturn(1).when(executor).getPoolSize();
 
-        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
         SingleRollupWriteContext srwc1 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc2 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc3 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc4 = mock(SingleRollupWriteContext.class);
         SingleRollupWriteContext srwc5 = mock(SingleRollupWriteContext.class);
         // ROLLUP_BATCH_MIN_SIZE default value is 5
-
-        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
 
         // when
         rbw.enqueueRollupForWrite(srwc1);
@@ -156,21 +151,17 @@ public class RollupBatchWriterTest {
     public void enqueuingMaxSizeTriggersBatching() {
 
         // given
-        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
         // if active count == pool size, the RollupBatchWriter will think the
         // thread pool is saturated, and not drain
         doReturn(1).when(executor).getActiveCount();
         doReturn(1).when(executor).getPoolSize();
 
-        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
         SingleRollupWriteContext[] srwcs = new SingleRollupWriteContext[100];
         int i;
         for (i = 0; i < 100; i++) {
             srwcs[i] = mock(SingleRollupWriteContext.class);
         }
         // ROLLUP_BATCH_MAX_SIZE default value is 100
-
-        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
 
         // when
         for (i = 0; i < 100; i++) {
@@ -195,11 +186,6 @@ public class RollupBatchWriterTest {
     @Test
     public void drainBatchWithNoItemsDoesNotTriggerBatching() {
 
-        // given
-        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
-        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
-        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
-
         // when
         rbw.drainBatch();
 
@@ -213,9 +199,6 @@ public class RollupBatchWriterTest {
     public void drainBatchWithSingleItemTriggersBatching() {
 
         // given
-        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
-        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
-        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
         SingleRollupWriteContext srwc = mock(SingleRollupWriteContext.class);
         rbw.enqueueRollupForWrite(srwc);
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriterTest.java
@@ -191,4 +191,42 @@ public class RollupBatchWriterTest {
         verify(executor).execute(Matchers.<Runnable>any());
         verifyNoMoreInteractions(executor);
     }
+
+    @Test
+    public void drainBatchWithNoItemsDoesNotTriggerBatching() {
+
+        // given
+        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
+        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
+        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
+
+        // when
+        rbw.drainBatch();
+
+        // then
+        verifyZeroInteractions(ctx);
+
+        verifyZeroInteractions(executor);
+    }
+
+    @Test
+    public void drainBatchWithSingleItemTriggersBatching() {
+
+        // given
+        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
+        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
+        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
+        SingleRollupWriteContext srwc = mock(SingleRollupWriteContext.class);
+        rbw.enqueueRollupForWrite(srwc);
+
+        // when
+        rbw.drainBatch();
+
+        // then
+        verify(ctx).incrementWriteCounter();    // this invocation due to setup
+        verifyNoMoreInteractions(ctx);
+
+        verify(executor).execute(Matchers.<Runnable>any());
+        verifyNoMoreInteractions(executor);
+    }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriterTest.java
@@ -1,6 +1,7 @@
 package com.rackspacecloud.blueflood.service;
 
 import org.junit.Test;
+import org.mockito.Matchers;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -30,5 +31,124 @@ public class RollupBatchWriterTest {
         verifyNoMoreInteractions(ctx);
 
         verifyZeroInteractions(srwc);
+    }
+
+    @Test
+    public void enqueuingLessThanMinSizeDoesNotTriggerBatching() {
+
+        // given
+        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
+        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
+        SingleRollupWriteContext srwc1 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc2 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc3 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc4 = mock(SingleRollupWriteContext.class);
+        // ROLLUP_BATCH_MIN_SIZE default value is 5
+
+        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
+
+        // when
+        rbw.enqueueRollupForWrite(srwc1);
+        rbw.enqueueRollupForWrite(srwc2);
+        rbw.enqueueRollupForWrite(srwc3);
+        rbw.enqueueRollupForWrite(srwc4);
+
+        // then
+        verify(ctx, times(4)).incrementWriteCounter();
+        verifyNoMoreInteractions(ctx);
+
+        verifyZeroInteractions(srwc1);
+        verifyZeroInteractions(srwc2);
+        verifyZeroInteractions(srwc3);
+        verifyZeroInteractions(srwc4);
+
+        verifyZeroInteractions(executor);
+    }
+
+    @Test
+    public void enqueuingMinSizeTriggersCheckOnExecutor() {
+
+        // given
+        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
+        // if active count == pool size, the RollupBatchWriter will think the
+        // thread pool is saturated, and not drain
+        doReturn(1).when(executor).getActiveCount();
+        doReturn(1).when(executor).getPoolSize();
+
+        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
+        SingleRollupWriteContext srwc1 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc2 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc3 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc4 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc5 = mock(SingleRollupWriteContext.class);
+        // ROLLUP_BATCH_MIN_SIZE default value is 5
+
+        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
+
+        // when
+        rbw.enqueueRollupForWrite(srwc1);
+        rbw.enqueueRollupForWrite(srwc2);
+        rbw.enqueueRollupForWrite(srwc3);
+        rbw.enqueueRollupForWrite(srwc4);
+        rbw.enqueueRollupForWrite(srwc5);
+
+        // then
+        verify(ctx, times(5)).incrementWriteCounter();
+        verifyNoMoreInteractions(ctx);
+
+        verifyZeroInteractions(srwc1);
+        verifyZeroInteractions(srwc2);
+        verifyZeroInteractions(srwc3);
+        verifyZeroInteractions(srwc4);
+        verifyZeroInteractions(srwc5);
+
+        // if the queue size >= min size, then the executor will be queried
+        verify(executor).getActiveCount();
+        verify(executor).getPoolSize();
+        verifyNoMoreInteractions(executor);
+    }
+
+    @Test
+    public void enqueuingMinSizeAndThreadPoolNotSaturatedTriggersBatching() {
+
+        // given
+        ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
+        // if active count == pool size, the RollupBatchWriter will think the
+        // thread pool is saturated, and not drain
+        doReturn(0).when(executor).getActiveCount();
+        doReturn(1).when(executor).getPoolSize();
+
+        RollupExecutionContext ctx = mock(RollupExecutionContext.class);
+        SingleRollupWriteContext srwc1 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc2 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc3 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc4 = mock(SingleRollupWriteContext.class);
+        SingleRollupWriteContext srwc5 = mock(SingleRollupWriteContext.class);
+        // ROLLUP_BATCH_MIN_SIZE default value is 5
+
+        RollupBatchWriter rbw = new RollupBatchWriter(executor, ctx);
+
+        // when
+        rbw.enqueueRollupForWrite(srwc1);
+        rbw.enqueueRollupForWrite(srwc2);
+        rbw.enqueueRollupForWrite(srwc3);
+        rbw.enqueueRollupForWrite(srwc4);
+        rbw.enqueueRollupForWrite(srwc5);
+
+        // then
+        verify(ctx, times(5)).incrementWriteCounter();
+        verifyNoMoreInteractions(ctx);
+
+        verifyZeroInteractions(srwc1);
+        verifyZeroInteractions(srwc2);
+        verifyZeroInteractions(srwc3);
+        verifyZeroInteractions(srwc4);
+        verifyZeroInteractions(srwc5);
+
+        // if the queue size >= min size, then the executor will be queried
+        verify(executor).getActiveCount();
+        verify(executor).getPoolSize();
+        verify(executor).execute(Matchers.<Runnable>any());
+        verifyNoMoreInteractions(executor);
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/RollupBatchWriterTest.java
@@ -113,8 +113,8 @@ public class RollupBatchWriterTest {
 
         // given
         ThreadPoolExecutor executor = mock(ThreadPoolExecutor.class);
-        // if active count == pool size, the RollupBatchWriter will think the
-        // thread pool is saturated, and not drain
+        // if active count < pool size, the RollupBatchWriter will think the
+        // thread pool is NOT saturated, and start batching
         doReturn(0).when(executor).getActiveCount();
         doReturn(1).when(executor).getPoolSize();
 


### PR DESCRIPTION
This PR adds tests for `RollupBatchWriter` and `RollupBatchWriterRunnable`. This brings the class-specific unit test coverage up to 95% and 90% of lines, respectively. I can't really increase the coverage any more without changing the classes.