### PR TITLE
Test points

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Points.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Points.java
@@ -70,14 +70,9 @@ public class Points<T> {
         public boolean equals(Object obj) {
             if (obj == null || !(obj instanceof Point))
                 return false;
-            try {
-                Point<T> other = (Point<T>)obj;
-                return other.getTimestamp() == this.getTimestamp()
-                        && other.getData().equals(this.getData());
-            } catch (ClassCastException ex) {
-                // not a Point<T>, but a Point<X> instead?
-                return false;
-            }
+            Point<T> other = (Point<T>)obj;
+            return other.getTimestamp() == this.getTimestamp()
+                    && other.getData().equals(this.getData());
         }
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/PointTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/PointTest.java
@@ -1,0 +1,214 @@
+package com.rackspacecloud.blueflood.types;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.*;
+
+public class PointTest {
+
+    @Test
+    public void constructorThrowsNoException() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+
+        // when
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        // then
+        // no exception is thrown
+        assertNotNull(point);
+    }
+
+    @Test
+    public void constructorSetsTimestamp() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+
+        // when
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        // then
+        assertEquals(timestamp, point.getTimestamp());
+    }
+
+    @Test
+    public void constructorSetsData() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+
+        // when
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        // then
+        assertSame(item, point.getData());
+    }
+
+    @Test
+    public void pointIsNotEqualToNull() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        // when
+        boolean isEqual = point.equals(null);
+
+        // then
+        assertFalse(isEqual);
+    }
+
+    @Test
+    public void pointIsNotEqualToObjectOfOtherClass() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        // when
+        boolean isEqual = point.equals(new Object());
+
+        // then
+        assertFalse(isEqual);
+    }
+
+    @Test
+    public void pointIsNotEqualToOtherPointWithDifferentType() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        float item2 = 42;
+        Points.Point<Float> point2 = new Points.Point<Float>(timestamp, item2);
+
+        // when
+        boolean isEqual = point.equals(point2);
+
+        // then
+        assertFalse(isEqual);
+    }
+
+    @Test
+    public void pointIsNotEqualIfTimestampsDiffer() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        long timestamp2 = 1235L;
+        Points.Point<SimpleNumber> point2 = new Points.Point<SimpleNumber>(timestamp2, item);
+
+        // when
+        boolean isEqual = point.equals(point2);
+
+        // then
+        assertFalse(isEqual);
+    }
+
+    @Test
+    public void pointIsNotEqualIfDataPointsAreNotEqual() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        SimpleNumber item2 = new SimpleNumber(43);
+        Points.Point<SimpleNumber> point2 = new Points.Point<SimpleNumber>(timestamp, item2);
+
+        // when
+        boolean isEqual = point.equals(point2);
+
+        // then
+        assertFalse(isEqual);
+    }
+
+    @Test
+    public void pointIsEqualIfDataPointsAreEqualEvenIfNotSameObject() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        SimpleNumber item2 = new SimpleNumber(42);
+        Points.Point<SimpleNumber> point2 = new Points.Point<SimpleNumber>(timestamp, item2);
+
+        // when
+        boolean isEqual = point.equals(point2);
+
+        // then
+        assertTrue(isEqual);
+    }
+
+    @Test
+    public void pointIsEqualIfDataIsSameObject() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        Points.Point<SimpleNumber> point2 = new Points.Point<SimpleNumber>(timestamp, item);
+
+        // when
+        boolean isEqual = point.equals(point2);
+
+        // then
+        assertTrue(isEqual);
+    }
+
+    /**
+     * This is not an exhaustive test. There could be instances where two
+     * Point<T> objects have different hash codes for equivalent data, e.g. if
+     * the {@code hashCode()} method of T is faulty in some way.
+     */
+    @Test
+    public void hashCodeIsEqualForEquivalentData() {
+
+        // This is not an exhaustive test
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        SimpleNumber item2 = new SimpleNumber(42);
+        Points.Point<SimpleNumber> point2 = new Points.Point<SimpleNumber>(timestamp, item2);
+
+        // expect
+        assertEquals(point.hashCode(), point2.hashCode());
+    }
+
+    /**
+     * This is not an exhaustive test. There could be instances where two
+     * Point<T> objects have identical hash codes for different data, e.g. if
+     * the {@code hashCode()} method of T is faulty in some way.
+     */
+    @Test
+    public void hashCodeIsDifferentForDifferentData() {
+
+        // given
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        SimpleNumber item2 = new SimpleNumber(43);
+        Points.Point<SimpleNumber> point2 = new Points.Point<SimpleNumber>(timestamp, item2);
+
+        // expect
+        assertThat(point.hashCode(), not(equalTo(point2.hashCode())));
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/PointsTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/PointsTest.java
@@ -1,0 +1,67 @@
+package com.rackspacecloud.blueflood.types;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PointsTest {
+
+    @Test
+    public void newObjectIsEmpty() {
+
+        // when
+        Points<SimpleNumber> points = new Points<SimpleNumber>();
+
+        // then
+        assertTrue(points.isEmpty());
+        assertEquals(0, points.getPoints().size());
+    }
+
+    @Test
+    public void addIncreasesCount() {
+
+        // given
+        Points<SimpleNumber> points = new Points<SimpleNumber>();
+
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+
+        // when
+        points.add(point);
+
+        // then
+        assertFalse(points.isEmpty());
+        assertEquals(1, points.getPoints().size());
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void getDataClassOnEmptyObjectThrowsException() {
+
+        // given
+        Points<SimpleNumber> points = new Points<SimpleNumber>();
+
+        // when
+        Class actual = points.getDataClass();
+
+        // then the exception is thrown
+    }
+
+    @Test
+    public void getDataClassGetsClass() {
+
+        // given
+        Points<SimpleNumber> points = new Points<SimpleNumber>();
+
+        SimpleNumber item = new SimpleNumber(42);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+        points.add(point);
+
+        // when
+        Class actual = points.getDataClass();
+
+        // then
+        assertSame(SimpleNumber.class, actual);
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/PointsTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/PointsTest.java
@@ -64,4 +64,52 @@ public class PointsTest {
         // then
         assertSame(SimpleNumber.class, actual);
     }
+
+    // adding point with duplicate timestamp replaces previous, e.g. doesn't increase count
+    @Test
+    public void addWithDuplicateTimestampDoesNotIncreaseCount() {
+
+        // given
+        Points<SimpleNumber> points = new Points<SimpleNumber>();
+
+        SimpleNumber item = new SimpleNumber(42);
+        SimpleNumber item2 = new SimpleNumber(43);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+        Points.Point<SimpleNumber> point2 = new Points.Point<SimpleNumber>(timestamp, item2);
+        points.add(point);
+
+        // precondition
+        assertEquals(1, points.getPoints().size());
+
+        // when
+        points.add(point2);
+
+        // then
+        assertFalse(points.isEmpty());
+        assertEquals(1, points.getPoints().size());
+    }
+
+    @Test
+    public void addWithDuplicateTimestampReplacesPrevious() {
+
+        // given
+        Points<SimpleNumber> points = new Points<SimpleNumber>();
+
+        SimpleNumber item = new SimpleNumber(42);
+        SimpleNumber item2 = new SimpleNumber(43);
+        long timestamp = 1234L;
+        Points.Point<SimpleNumber> point = new Points.Point<SimpleNumber>(timestamp, item);
+        Points.Point<SimpleNumber> point2 = new Points.Point<SimpleNumber>(timestamp, item2);
+        points.add(point);
+
+        // precondition
+        assertSame(item, points.getPoints().get(timestamp).getData());
+
+        // when
+        points.add(point2);
+
+        // then
+        assertSame(item2, points.getPoints().get(timestamp).getData());
+    }
 }


### PR DESCRIPTION
This PR adds tests for the `Points<T>` and `Points.Point<T>` classes. It brings class-specific unit test coverage to 100% for both.