### PR TITLE
LocatorIO interaface with Datastax and Astyanax implementation

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/LocatorIOIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/LocatorIOIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.rackspacecloud.blueflood.io;
+
+import com.netflix.astyanax.Keyspace;
+import com.netflix.astyanax.MutationBatch;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxIO;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxLocatorIO;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxReader;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxWriter;
+import com.rackspacecloud.blueflood.io.datastax.DatastaxLocatorIO;
+import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.utils.Util;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class LocatorIOIntegrationTest {
+
+    private final DatastaxLocatorIO datastaxLocatorIO = new DatastaxLocatorIO();
+    private final AstyanaxLocatorIO astyanaxLocatorIO = new AstyanaxLocatorIO();
+
+    private final String tenantId = "100000";
+    private final String metricName = "locatorio.itest.metric";
+    private List<Locator> testLocators;
+
+    @Before
+    public void setup() {
+        // create test locators
+        testLocators = createTestLocators(4, 2);
+    }
+
+    private List<Locator> createTestLocators(int numTenants, int numMetricNames) {
+        // create a number of test locators of numTenants x numMetricNames combination
+        List<Locator> locators = new ArrayList<Locator>();
+        for (int i = 1; i <= numTenants; i++) {
+            for (int j = 1; j <= numMetricNames; j++) {
+                locators.add(Locator.createLocatorFromPathComponents(tenantId + i, metricName + j));
+            }
+        }
+        return locators;
+    }
+
+    @Test
+    public void writeDatastaxReadAstyanax() throws Exception {
+
+        // insert locators using datastax
+        datastaxLocatorIO.insertLocator(testLocators.get(0));
+        datastaxLocatorIO.insertLocator(testLocators.get(1));
+
+        // retrieve locators using new astyanax class
+        long shard1 = (long) Util.getShard(testLocators.get(0).toString());
+        Collection<Locator> locatorsResult1 = astyanaxLocatorIO.getLocators(shard1);
+        assertEquals("Unexpected number of locators result for shard1", 1, locatorsResult1.size());
+        assertEquals("test locator(0) not equal", testLocators.get(0).toString(), locatorsResult1.toArray()[0].toString());
+
+        long shard2 = (long) Util.getShard(testLocators.get(1).toString());
+        Collection<Locator> locatorsResult2 = astyanaxLocatorIO.getLocators(shard2);
+        assertEquals("Unexpected number of locators result for shard2", 1, locatorsResult2.size());
+        assertEquals("test locator(1) not equal", testLocators.get(1).toString(), locatorsResult2.toArray()[0].toString());
+
+        // assert invalid shard should return empty collection using datastax
+        assertEquals("locators should be empty", astyanaxLocatorIO.getLocators(-1), Collections.emptySet());
+    }
+
+    @Test
+    public void writeAstyanaxReadDatastax() throws Exception {
+
+        // insert locators using new astyanax class
+        astyanaxLocatorIO.insertLocator(testLocators.get(2));
+        astyanaxLocatorIO.insertLocator(testLocators.get(3));
+
+        // retrieve locators using datastax
+        long shard1 = (long) Util.getShard(testLocators.get(2).toString());
+        Collection<Locator> locatorsResult1 = datastaxLocatorIO.getLocators(shard1);
+        assertEquals("Unexpected number of locators result for shard1", 1, locatorsResult1.size());
+        assertEquals("test locator(2) not equal", testLocators.get(2).toString(), locatorsResult1.toArray()[0].toString());
+
+        long shard2 = (long) Util.getShard(testLocators.get(3).toString());
+        Collection<Locator> locatorsResult2 = datastaxLocatorIO.getLocators(shard2);
+        assertEquals("Unexpected number of locators result for shard2", 1, locatorsResult2.size());
+        assertEquals("test locator(3) not equal", testLocators.get(3).toString(), locatorsResult2.toArray()[0].toString());
+
+        // assert invalid shard should return empty collection using datastax
+        assertEquals("locators should be empty", datastaxLocatorIO.getLocators(-1), Collections.emptySet());
+    }
+
+}

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/MetricsIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/MetricsIntegrationTest.java
@@ -19,13 +19,10 @@ package com.rackspacecloud.blueflood.service;
 import com.google.common.collect.Lists;
 import com.netflix.astyanax.MutationBatch;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
-import com.rackspacecloud.blueflood.io.IOContainer;
-import com.rackspacecloud.blueflood.io.ShardStateIO;
+import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.io.astyanax.AstyanaxReader;
 import com.rackspacecloud.blueflood.io.astyanax.AstyanaxWriter;
-import com.rackspacecloud.blueflood.io.CassandraModel;
 import com.rackspacecloud.blueflood.io.CassandraModel.MetricColumnFamily;
-import com.rackspacecloud.blueflood.io.IntegrationTestBase;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.*;
@@ -84,11 +81,11 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
     @Test
     public void testLocatorsWritten() throws Exception {
         Collection<Locator> locators = writeLocatorsOnly(48);
-        AstyanaxReader r = AstyanaxReader.getInstance();
+        LocatorIO locatorIO = IOContainer.fromConfig().getLocatorIO();
 
         Set<String> actualLocators = new HashSet<String>();
         for (Locator locator : locators) {
-            for (Locator databaseLocator : r.getLocatorsToRollup(Util.computeShard(locator.toString()))) {
+            for (Locator databaseLocator : locatorIO.getLocators(Util.computeShard(locator.toString()))) {
                 actualLocators.add(databaseLocator.toString());
             }
         }

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/RollupThreadpoolIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/RollupThreadpoolIntegrationTest.java
@@ -18,10 +18,9 @@ package com.rackspacecloud.blueflood.service;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.rackspacecloud.blueflood.io.astyanax.AstyanaxReader;
+import com.rackspacecloud.blueflood.io.IOContainer;
 import com.rackspacecloud.blueflood.io.astyanax.AstyanaxWriter;
 import com.rackspacecloud.blueflood.io.IntegrationTestBase;
-import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.utils.Metrics;
 import com.rackspacecloud.blueflood.utils.Util;
 import org.junit.After;
@@ -70,10 +69,7 @@ public class RollupThreadpoolIntegrationTest extends IntegrationTestBase {
 
         // lets see how many locators this generated. We want it to be a lot.
 
-        int locatorsForTestShard = 0;
-        for (Locator locator : AstyanaxReader.getInstance().getLocatorsToRollup(shardToTest)) {
-            locatorsForTestShard++;
-        }
+        int locatorsForTestShard = IOContainer.fromConfig().getLocatorIO().getLocators(shardToTest).size();
 
         // Make sure number of locators for test shard is greater than number of rollup threads.
         // This is required so that rollups would be rejected for some locators.

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/TenantTtlProvider.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/TenantTtlProvider.java
@@ -21,6 +21,9 @@ import com.rackspacecloud.blueflood.types.RollupType;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 
 public interface TenantTtlProvider {
+
+    public static final int LOCATOR_TTL = 604800;   // ttl for locators in seconds, 604800s = 1 week
+
     public TimeValue getTTL(String tenantId, Granularity gran, RollupType rollupType) throws Exception;
 
     public void setTTL(String tenantId, Granularity gran, RollupType rollupType, TimeValue ttlValue) throws Exception;
@@ -28,4 +31,5 @@ public interface TenantTtlProvider {
     public TimeValue getTTLForStrings(String tenantId) throws Exception;
 
     public TimeValue getConfigTTLForIngestion() throws Exception;
+
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IOContainer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IOContainer.java
@@ -17,8 +17,10 @@ package com.rackspacecloud.blueflood.io;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxLocatorIO;
 import com.rackspacecloud.blueflood.io.astyanax.AstyanaxMetadataIO;
 import com.rackspacecloud.blueflood.io.astyanax.AstyanaxShardStateIO;
+import com.rackspacecloud.blueflood.io.datastax.DatastaxLocatorIO;
 import com.rackspacecloud.blueflood.io.datastax.DatastaxMetadataIO;
 import com.rackspacecloud.blueflood.io.datastax.DatastaxShardStateIO;
 import com.rackspacecloud.blueflood.service.Configuration;
@@ -39,6 +41,8 @@ public class IOContainer {
 
     private ShardStateIO shardStateIO;
     private MetadataIO metadataIO;
+    private LocatorIO locatorIO;
+
     // more IO classes to follow
 
     /**
@@ -72,11 +76,13 @@ public class IOContainer {
 
             metadataIO = new DatastaxMetadataIO();
             shardStateIO = new DatastaxShardStateIO();
+            locatorIO = new DatastaxLocatorIO();
 
         } else {
 
             metadataIO = new AstyanaxMetadataIO();
             shardStateIO = new AstyanaxShardStateIO();
+            locatorIO = new AstyanaxLocatorIO();
 
         }
     }
@@ -93,6 +99,13 @@ public class IOContainer {
      */
     public MetadataIO getMetadataIO() {
         return metadataIO;
+    }
+
+    /**
+     * @return a class for reading/writing Locators
+     */
+    public LocatorIO getLocatorIO() {
+        return locatorIO;
     }
 
     /**

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/LocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/LocatorIO.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016 Rackspace.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rackspacecloud.blueflood.io;
+
+import com.rackspacecloud.blueflood.types.Locator;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public interface LocatorIO {
+
+    /**
+     * Insert a locator for a shard, calculate by hashing of the locator string value
+     * @param locator
+     * @throws IOException
+     */
+    public void insertLocator(Locator locator) throws IOException;
+
+    /**
+     * @param shard
+     * @return a collection of the locators objects corresponding to the given shard
+     * @throws IOException
+     */
+    public Collection<Locator> getLocators(long shard) throws IOException;
+
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxLocatorIO.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016 Rackspace.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rackspacecloud.blueflood.io.astyanax;
+
+import com.codahale.metrics.Timer;
+import com.netflix.astyanax.MutationBatch;
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.netflix.astyanax.connectionpool.exceptions.NotFoundException;
+import com.netflix.astyanax.query.RowQuery;
+import com.rackspacecloud.blueflood.io.CassandraModel;
+import com.rackspacecloud.blueflood.io.Instrumentation;
+import com.rackspacecloud.blueflood.io.LocatorIO;
+import com.rackspacecloud.blueflood.types.Locator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * This class uses the Astyanax driver to read/write locators from
+ * Cassandra metrics_locator Column Family.
+ */
+public class AstyanaxLocatorIO implements LocatorIO {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AstyanaxLocatorIO.class);
+
+    /**
+     * Insert a locator with key = shard long value calculated using Util.getShard()
+     * @param locator
+     * @throws IOException
+     */
+    @Override
+    public void insertLocator(Locator locator) throws IOException {
+        try {
+            MutationBatch mutationBatch = AstyanaxIO.getKeyspace().prepareMutationBatch();
+            AstyanaxWriter.getInstance().insertLocator(locator, mutationBatch);
+            mutationBatch.execute();
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Returns the locators for a shard, i.e. those that should be rolled up, for a given shard.
+     * 'Should' means:
+     *  1) A locator is capable of rollup (it is not a string/boolean metric).
+     *  2) A locator has had new data in the past LOCATOR_TTL seconds.
+     *
+     * @param shard Number of the shard you want the locators for. 0-127 inclusive.
+     * @return Collection of locators
+     * @throws IOException
+     */
+    @Override
+    public Collection<Locator> getLocators(long shard) throws IOException {
+        Timer.Context ctx = Instrumentation.getReadTimerContext(CassandraModel.CF_METRICS_LOCATOR_NAME);
+        try {
+            RowQuery<Long, Locator> query = AstyanaxIO.getKeyspace()
+                    .prepareQuery(CassandraModel.CF_METRICS_LOCATOR)
+                    .getKey(shard);
+            return query.execute().getResult().getColumnNames();
+        } catch (NotFoundException e) {
+            Instrumentation.markNotFound(CassandraModel.CF_METRICS_LOCATOR_NAME);
+            return Collections.emptySet();
+        } catch (ConnectionException ex) {
+            Instrumentation.markReadError(ex);
+            LOG.error("Connection exception during getLocators(" + Long.toString(shard) + " )", ex);
+            throw new IOException("Error reading locators", ex);
+        } finally {
+            ctx.stop();
+        }
+    }
+
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxWriter.java
@@ -36,7 +36,6 @@ import com.rackspacecloud.blueflood.io.CassandraModel;
 import com.rackspacecloud.blueflood.io.Instrumentation;
 import com.rackspacecloud.blueflood.io.serializers.Serializers;
 import com.rackspacecloud.blueflood.io.serializers.astyanax.StringMetadataSerializer;
-import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.*;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.Metrics;
@@ -54,9 +53,6 @@ public class AstyanaxWriter extends AstyanaxIO {
     private static final Keyspace keyspace = getKeyspace();
 
     private static final TimeValue STRING_TTL = new TimeValue(730, TimeUnit.DAYS); // 2 years
-    private static final int LOCATOR_TTL = 604800;  // in seconds (7 days)
-
-    private static final String INSERT_ROLLUP_BATCH = "Rollup Batch Insert".intern();
     private boolean areStringMetricsDropped = Configuration.getInstance().getBooleanProperty(CoreConfig.STRING_METRICS_DROPPED);
     private List<String> tenantIdsKept = Configuration.getInstance().getListProperty(CoreConfig.TENANTIDS_TO_KEEP);
     private Set<String> keptTenantIdsSet = new HashSet<String>(tenantIdsKept);
@@ -67,7 +63,7 @@ public class AstyanaxWriter extends AstyanaxIO {
 
     // todo: should be some other impl.
     private static TenantTtlProvider TTL_PROVIDER = SafetyTtlProvider.getInstance();
-    
+
 
     // this collection is used to reduce the number of locators that get written.  Simply, if a locator has been
     // seen within the last 10 minutes, don't bother.
@@ -158,9 +154,9 @@ public class AstyanaxWriter extends AstyanaxIO {
     }
 
     // numeric only!
-    private final void insertLocator(Locator locator, MutationBatch mutationBatch) {
+    public final void insertLocator(Locator locator, MutationBatch mutationBatch) {
         mutationBatch.withRow(CassandraModel.CF_METRICS_LOCATOR, (long) Util.getShard(locator.toString()))
-                .putEmptyColumn(locator, LOCATOR_TTL);
+                .putEmptyColumn(locator, TenantTtlProvider.LOCATOR_TTL);
     }
 
     private final void insertEnumValuesWithHashcodes(Locator locator, BluefloodEnumRollup rollup, MutationBatch mutationBatch) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxLocatorIO.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2016 Rackspace.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rackspacecloud.blueflood.io.datastax;
+
+import com.codahale.metrics.Timer;
+import com.datastax.driver.core.*;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.querybuilder.Select;
+import com.rackspacecloud.blueflood.cache.TenantTtlProvider;
+import com.rackspacecloud.blueflood.io.CassandraModel;
+import com.rackspacecloud.blueflood.io.Instrumentation;
+import com.rackspacecloud.blueflood.io.LocatorIO;
+import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.utils.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.ttl;
+
+/**
+ * This class uses the Datastax driver to read/write locators from
+ * Cassandra metrics_locator Column Family.
+ */
+public class DatastaxLocatorIO implements LocatorIO {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DatastaxLocatorIO.class);
+
+    private static final String KEY = "key";
+    private static final String COLUMN1 = "column1";
+    private static final String VALUE = "value";
+
+    private PreparedStatement getValue;
+    private PreparedStatement putValue;
+
+    public DatastaxLocatorIO() {
+        createPreparedStatements();
+    }
+
+    /**
+     * Create all prepared statements use in this class for metrics_locator
+     */
+    private void createPreparedStatements()  {
+
+        // create a generic select statement for retrieving from metrics_locator
+        Select.Where select = QueryBuilder
+                .select()
+                .all()
+                .from( CassandraModel.CF_METRICS_LOCATOR_NAME )
+                .where( eq ( KEY, bindMarker() ));
+        getValue = DatastaxIO.getSession().prepare( select );
+
+        // create a generic insert statement for inserting into metrics_locator
+        Insert insert = QueryBuilder.insertInto( CassandraModel.CF_METRICS_LOCATOR_NAME)
+                .using(ttl(TenantTtlProvider.LOCATOR_TTL))
+                .value(KEY, bindMarker())
+                .value(COLUMN1, bindMarker())
+                .value(VALUE, bindMarker());
+        putValue = DatastaxIO.getSession()
+                .prepare(insert)
+                .setConsistencyLevel( ConsistencyLevel.ONE);  // TODO: remove later; required by the cassandra-maven-plugin 2.0.0-1
+                                                              // (see https://issues.apache.org/jira/browse/CASSANDRA-6238)
+
+    }
+
+    /**
+     * Insert a locator with key = shard long value calculated using Util.getShard()
+     * @param locator
+     * @throws IOException
+     */
+    @Override
+    public void insertLocator(Locator locator) throws IOException {
+        Session session = DatastaxIO.getSession();
+
+        // get shard this locator would belong to
+        long shard = (long) Util.getShard(locator.toString());
+
+        // bound values and execute
+        BoundStatement bs = putValue.bind(shard, locator.toString(), "");
+        session.execute(bs);
+    }
+
+    /**
+     * Returns the locators for a shard, i.e. those that should be rolled up, for a given shard.
+     * 'Should' means:
+     *  1) A locator is capable of rollup (it is not a string/boolean metric).
+     *  2) A locator has had new data in the past LOCATOR_TTL seconds.
+     *
+     * @param shard Number of the shard you want the locators for. 0-127 inclusive.
+     * @return Collection of locators
+     * @throws IOException
+     */
+    @Override
+    public Collection<Locator> getLocators(long shard) throws IOException {
+
+        Timer.Context ctx = Instrumentation.getReadTimerContext(CassandraModel.CF_METRICS_LOCATOR_NAME);
+        Session session = DatastaxIO.getSession();
+
+        Collection<Locator> locators = new ArrayList<Locator>();
+
+        try {
+            // bind value
+            BoundStatement bs = getValue.bind(shard);
+            List<Row> results = session.execute(bs).all();
+            for ( Row row : results ) {
+                if ( LOG.isTraceEnabled() ) {
+                    LOG.trace( "Read metrics_locators with shard " + shard + ": " +
+                            row.getString( KEY ) +
+                            row.getString( COLUMN1 ));
+                }
+                locators.add(Locator.createLocatorFromDbKey(row.getString(COLUMN1)));
+            }
+
+            // return results
+            if (locators.size() == 0) {
+                Instrumentation.markNotFound(CassandraModel.CF_METRICS_LOCATOR_NAME);
+                return Collections.emptySet();
+            }
+            else {
+                return locators;
+            }
+        } finally {
+            ctx.stop();
+        }
+    }
+
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/IOContainerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/IOContainerTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
         "com.rackspacecloud.blueflood.utils.Metrics",
         "com.codahale.metrics.*"})
 @PrepareForTest({Configuration.class})
-@SuppressStaticInitializationFor( "com.rackspacecloud.blueflood.io.datastax.DatastaxIO")
+@SuppressStaticInitializationFor( "com.rackspacecloud.blueflood.io.datastax.DatastaxIO" )
 @RunWith(PowerMockRunner.class)
 public class IOContainerTest {
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnableDrainExecutionContextTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnableDrainExecutionContextTest.java
@@ -1,6 +1,5 @@
 package com.rackspacecloud.blueflood.service;
 
-import com.rackspacecloud.blueflood.io.astyanax.AstyanaxReader;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.rollup.SlotKey;
 import com.rackspacecloud.blueflood.types.Locator;
@@ -25,7 +24,6 @@ public class LocatorFetchRunnableDrainExecutionContextTest {
     ExecutorService rollupReadExecutor;
     ThreadPoolExecutor rollupWriteExecutor;
     ExecutorService enumValidatorExecutor;
-    AstyanaxReader astyanaxReader;
 
     LocatorFetchRunnable lfr;
 
@@ -44,12 +42,10 @@ public class LocatorFetchRunnableDrainExecutionContextTest {
         this.rollupReadExecutor = mock(ExecutorService.class);
         this.rollupWriteExecutor = mock(ThreadPoolExecutor.class);
         this.enumValidatorExecutor = mock(ExecutorService.class);
-        this.astyanaxReader = mock(AstyanaxReader.class);
 
         this.lfr = mock(LocatorFetchRunnable.class);
         this.lfr.initialize(scheduleCtx, destSlotKey,
-                rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor,
-                astyanaxReader);
+                rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor);
         doCallRealMethod().when(lfr).drainExecutionContext(
                 anyLong(), anyInt(), Matchers.<RollupExecutionContext>any(),
                 Matchers.<RollupBatchWriter>any());
@@ -103,14 +99,12 @@ public class LocatorFetchRunnableDrainExecutionContextTest {
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
         verifyZeroInteractions(enumValidatorExecutor);
-        verifyZeroInteractions(astyanaxReader);
         verify(lfr).initialize(
                 Matchers.<ScheduleContext>any(),
                 Matchers.<SlotKey>any(),
                 Matchers.<ExecutorService>any(),
                 Matchers.<ThreadPoolExecutor>any(),
-                Matchers.<ExecutorService>any(),
-                Matchers.<AstyanaxReader>any());
+                Matchers.<ExecutorService>any());
         verify(lfr).drainExecutionContext(anyLong(), anyInt(),
                 Matchers.<RollupExecutionContext>any(),
                 Matchers.<RollupBatchWriter>any());
@@ -141,14 +135,12 @@ public class LocatorFetchRunnableDrainExecutionContextTest {
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
         verifyZeroInteractions(enumValidatorExecutor);
-        verifyZeroInteractions(astyanaxReader);
         verify(lfr).initialize(
                 Matchers.<ScheduleContext>any(),
                 Matchers.<SlotKey>any(),
                 Matchers.<ExecutorService>any(),
                 Matchers.<ThreadPoolExecutor>any(),
-                Matchers.<ExecutorService>any(),
-                Matchers.<AstyanaxReader>any());
+                Matchers.<ExecutorService>any());
         verify(lfr).drainExecutionContext(anyLong(), anyInt(),
                 Matchers.<RollupExecutionContext>any(),
                 Matchers.<RollupBatchWriter>any());
@@ -180,14 +172,12 @@ public class LocatorFetchRunnableDrainExecutionContextTest {
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
         verifyZeroInteractions(enumValidatorExecutor);
-        verifyZeroInteractions(astyanaxReader);
         verify(lfr).initialize(
                 Matchers.<ScheduleContext>any(),
                 Matchers.<SlotKey>any(),
                 Matchers.<ExecutorService>any(),
                 Matchers.<ThreadPoolExecutor>any(),
-                Matchers.<ExecutorService>any(),
-                Matchers.<AstyanaxReader>any());
+                Matchers.<ExecutorService>any());
         verify(lfr).drainExecutionContext(anyLong(), anyInt(),
                 Matchers.<RollupExecutionContext>any(),
                 Matchers.<RollupBatchWriter>any());
@@ -221,14 +211,12 @@ public class LocatorFetchRunnableDrainExecutionContextTest {
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
         verifyZeroInteractions(enumValidatorExecutor);
-        verifyZeroInteractions(astyanaxReader);
         verify(lfr).initialize(
                 Matchers.<ScheduleContext>any(),
                 Matchers.<SlotKey>any(),
                 Matchers.<ExecutorService>any(),
                 Matchers.<ThreadPoolExecutor>any(),
-                Matchers.<ExecutorService>any(),
-                Matchers.<AstyanaxReader>any());
+                Matchers.<ExecutorService>any());
         verify(lfr).drainExecutionContext(anyLong(), anyInt(),
                 Matchers.<RollupExecutionContext>any(),
                 Matchers.<RollupBatchWriter>any());
@@ -259,14 +247,12 @@ public class LocatorFetchRunnableDrainExecutionContextTest {
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
         verifyZeroInteractions(enumValidatorExecutor);
-        verifyZeroInteractions(astyanaxReader);
         verify(lfr).initialize(
                 Matchers.<ScheduleContext>any(),
                 Matchers.<SlotKey>any(),
                 Matchers.<ExecutorService>any(),
                 Matchers.<ThreadPoolExecutor>any(),
-                Matchers.<ExecutorService>any(),
-                Matchers.<AstyanaxReader>any());
+                Matchers.<ExecutorService>any());
         verify(lfr).drainExecutionContext(anyLong(), anyInt(),
                 Matchers.<RollupExecutionContext>any(),
                 Matchers.<RollupBatchWriter>any());

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnableRunTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnableRunTest.java
@@ -1,6 +1,5 @@
 package com.rackspacecloud.blueflood.service;
 
-import com.rackspacecloud.blueflood.io.astyanax.AstyanaxReader;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.rollup.SlotKey;
 import com.rackspacecloud.blueflood.types.Locator;
@@ -24,7 +23,6 @@ public class LocatorFetchRunnableRunTest {
     ExecutorService rollupReadExecutor;
     ThreadPoolExecutor rollupWriteExecutor;
     ExecutorService enumValidatorExecutor;
-    AstyanaxReader astyanaxReader;
 
     LocatorFetchRunnable lfr;
 
@@ -40,7 +38,6 @@ public class LocatorFetchRunnableRunTest {
         this.rollupReadExecutor = mock(ExecutorService.class);
         this.rollupWriteExecutor = mock(ThreadPoolExecutor.class);
         this.enumValidatorExecutor = mock(ExecutorService.class);
-        this.astyanaxReader = mock(AstyanaxReader.class);
 
         this.lfr = mock(LocatorFetchRunnable.class);
         doCallRealMethod().when(lfr).getGranularity();
@@ -51,8 +48,7 @@ public class LocatorFetchRunnableRunTest {
                 Matchers.<SlotKey>any(),
                 Matchers.<ExecutorService>any(),
                 Matchers.<ThreadPoolExecutor>any(),
-                Matchers.<ExecutorService>any(),
-                Matchers.<AstyanaxReader>any());
+                Matchers.<ExecutorService>any());
         doCallRealMethod().when(lfr).run();
 
         executionContext = mock(RollupExecutionContext.class);
@@ -85,8 +81,7 @@ public class LocatorFetchRunnableRunTest {
         // given
         SlotKey destSlotKey = SlotKey.of(Granularity.FULL, 0, 0);
         this.lfr.initialize(scheduleCtx, destSlotKey,
-                rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor,
-                astyanaxReader);
+                rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor);
 
         // when
         lfr.run();
@@ -99,14 +94,12 @@ public class LocatorFetchRunnableRunTest {
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
         verifyZeroInteractions(enumValidatorExecutor);
-        verifyZeroInteractions(astyanaxReader);
         verify(lfr).initialize(
                 Matchers.<ScheduleContext>any(),
                 Matchers.<SlotKey>any(),
                 Matchers.<ExecutorService>any(),
                 Matchers.<ThreadPoolExecutor>any(),
-                Matchers.<ExecutorService>any(),
-                Matchers.<AstyanaxReader>any());
+                Matchers.<ExecutorService>any());
         verify(lfr).run();
         verify(lfr, times(3)).getGranularity();
         verify(lfr, times(1)).getParentSlot();
@@ -119,8 +112,7 @@ public class LocatorFetchRunnableRunTest {
         // given
         SlotKey destSlotKey = SlotKey.of(Granularity.MIN_5, 0, 0);
         lfr.initialize(scheduleCtx, destSlotKey,
-                rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor,
-                astyanaxReader);
+                rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor);
         doReturn(generateLocators(0)).when(lfr).getLocators(
                 Matchers.<RollupExecutionContext>any());
 
@@ -135,14 +127,12 @@ public class LocatorFetchRunnableRunTest {
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
         verifyZeroInteractions(enumValidatorExecutor);
-        verifyZeroInteractions(astyanaxReader);
         verify(lfr).initialize(
                 Matchers.<ScheduleContext>any(),
                 Matchers.<SlotKey>any(),
                 Matchers.<ExecutorService>any(),
                 Matchers.<ThreadPoolExecutor>any(),
-                Matchers.<ExecutorService>any(),
-                Matchers.<AstyanaxReader>any());
+                Matchers.<ExecutorService>any());
         verify(lfr).run();
         verify(lfr, times(2)).getGranularity();
         verify(lfr, times(1)).getParentSlot();
@@ -167,8 +157,7 @@ public class LocatorFetchRunnableRunTest {
         // given
         SlotKey destSlotKey = SlotKey.of(Granularity.MIN_5, 0, 0);
         lfr.initialize(scheduleCtx, destSlotKey,
-                rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor,
-                astyanaxReader);
+                rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor);
         doReturn(generateLocators(1)).when(lfr).getLocators(
                 Matchers.<RollupExecutionContext>any());
 
@@ -183,14 +172,12 @@ public class LocatorFetchRunnableRunTest {
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
         verifyZeroInteractions(enumValidatorExecutor);
-        verifyZeroInteractions(astyanaxReader);
         verify(lfr).initialize(
                 Matchers.<ScheduleContext>any(),
                 Matchers.<SlotKey>any(),
                 Matchers.<ExecutorService>any(),
                 Matchers.<ThreadPoolExecutor>any(),
-                Matchers.<ExecutorService>any(),
-                Matchers.<AstyanaxReader>any());
+                Matchers.<ExecutorService>any());
         verify(lfr).run();
         verify(lfr, times(2)).getGranularity();
         verify(lfr, times(1)).getParentSlot();
@@ -215,8 +202,7 @@ public class LocatorFetchRunnableRunTest {
         // given
         SlotKey destSlotKey = SlotKey.of(Granularity.MIN_5, 0, 0);
         lfr.initialize(scheduleCtx, destSlotKey,
-                rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor,
-                astyanaxReader);
+                rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor);
         doReturn(generateLocators(3)).when(lfr).getLocators(
                 Matchers.<RollupExecutionContext>any());
 
@@ -231,14 +217,12 @@ public class LocatorFetchRunnableRunTest {
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
         verifyZeroInteractions(enumValidatorExecutor);
-        verifyZeroInteractions(astyanaxReader);
         verify(lfr).initialize(
                 Matchers.<ScheduleContext>any(),
                 Matchers.<SlotKey>any(),
                 Matchers.<ExecutorService>any(),
                 Matchers.<ThreadPoolExecutor>any(),
-                Matchers.<ExecutorService>any(),
-                Matchers.<AstyanaxReader>any());
+                Matchers.<ExecutorService>any());
         verify(lfr).run();
         verify(lfr, times(2)).getGranularity();
         verify(lfr, times(1)).getParentSlot();


### PR DESCRIPTION
# What
Create new classes to reimplement the AstyanaxWriter.insertLocator() and AstyanaxReader.getLocatorsToRollup() methods with both an Asytanax implementation and Datastax implementation.

#  Why
Preparation for switching blueflood to use Datastax instead of Astyanax driver for communicating with cassandra.

#  How
Create LocatorIO interface with Datastax and Astyanax implementation,
  wire new LocatorIO classes in IOContainer,
  replace wherever AstyanaxReader.getLocatorsToRollup is called
