### PR TITLE
Test RollupType

### DIFF
--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
@@ -1,6 +1,12 @@
 package com.rackspacecloud.blueflood.types;
 
+import com.bigml.histogram.Bin;
+import com.bigml.histogram.SimpleTarget;
+import com.rackspacecloud.blueflood.utils.TimeValue;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -69,5 +75,92 @@ public class RollupTypeTest {
     @Test
     public void fromStringNotARollupYieldsNotARollup() {
         assertEquals(RollupType.NOT_A_ROLLUP, RollupType.fromString("NOT_A_ROLLUP"));
+    }
+
+    @Test
+    public void fromRollupBluefloodSetRollupYieldsSet() {
+        Rollup rollup = new BluefloodSetRollup();
+        assertEquals(RollupType.SET, RollupType.fromRollup(rollup));
+    }
+
+    @Test
+    public void fromRollupBluefloodTimerRollupYieldsTimer() {
+        Rollup rollup = new BluefloodTimerRollup();
+        assertEquals(RollupType.TIMER, RollupType.fromRollup(rollup));
+    }
+
+    @Test
+    public void fromRollupBluefloodCounterRollupYieldsCounter() {
+        Rollup rollup = new BluefloodCounterRollup();
+        assertEquals(RollupType.COUNTER, RollupType.fromRollup(rollup));
+    }
+
+    @Test
+    public void fromRollupBluefloodGaugeRollupYieldsGauge() {
+        Rollup rollup = new BluefloodGaugeRollup();
+        assertEquals(RollupType.GAUGE, RollupType.fromRollup(rollup));
+    }
+
+    class MetricImplementsRollup extends Metric implements Rollup {
+        public MetricImplementsRollup(Locator locator, Object metricValue, long collectionTime, TimeValue ttl, String unit) {
+            super(locator, metricValue, collectionTime, ttl, unit);
+        }
+        @Override
+        public Boolean hasData() {
+            return null;
+        }
+    }
+
+    @Test
+    public void fromRollupMetricYieldsBasic() {
+        // TODO: This appears to be very wrong. The fromRollup method takes a
+        // Rollup argument, but one of the things it checks against is Metric,
+        // which does not implement the Rollup interface.
+
+        Rollup rollup = new MetricImplementsRollup(null, 123L, 0, new TimeValue(456L, TimeUnit.SECONDS), null);
+        assertEquals(RollupType.BF_BASIC, RollupType.fromRollup(rollup));
+    }
+
+    @Test
+    public void fromRollupHistogramRollupYieldsHistograms() {
+        ArrayList<Bin<SimpleTarget>> bins = new ArrayList<Bin<SimpleTarget>>();
+        Rollup rollup = new HistogramRollup(bins);
+        assertEquals(RollupType.BF_HISTOGRAMS, RollupType.fromRollup(rollup));
+    }
+
+    @Test
+    public void fromRollupSimpleNumberYieldsNotARollup() {
+        Rollup rollup = new SimpleNumber(123L);
+        assertEquals(RollupType.NOT_A_ROLLUP, RollupType.fromRollup(rollup));
+    }
+
+    @Test
+    public void fromRollupBluefloodEnumRollupYieldsEnum() {
+        Rollup rollup = new BluefloodEnumRollup();
+        assertEquals(RollupType.ENUM, RollupType.fromRollup(rollup));
+    }
+
+    class DummyRollup implements Rollup {
+
+        @Override
+        public Boolean hasData() {
+            return null;
+        }
+
+        @Override
+        public RollupType getRollupType() {
+            return null;
+        }
+    }
+
+    @Test(expected = Error.class)
+    public void fromRollupCustomSubclassCausesError() {
+        Rollup rollup = new DummyRollup();
+
+        // when
+        RollupType.fromRollup(rollup);
+
+        // then
+        // the error is thrown
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
@@ -1,4 +1,28 @@
 package com.rackspacecloud.blueflood.types;
 
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
 public class RollupTypeTest {
+
+    @Test
+    public void testFromString() {
+        assertEquals(RollupType.BF_BASIC, RollupType.fromString(null));
+        assertEquals(RollupType.BF_BASIC, RollupType.fromString(""));
+        assertEquals(RollupType.BF_BASIC, RollupType.fromString("abcdef"));
+
+        assertEquals(RollupType.BF_BASIC, RollupType.fromString("BF_BASIC"));
+        assertEquals(RollupType.BF_BASIC, RollupType.fromString("bf_basic"));
+        assertEquals(RollupType.BF_BASIC, RollupType.fromString("bF_bAsIc"));
+
+        assertEquals(RollupType.COUNTER, RollupType.fromString("COUNTER"));
+        assertEquals(RollupType.TIMER, RollupType.fromString("TIMER"));
+        assertEquals(RollupType.SET, RollupType.fromString("SET"));
+        assertEquals(RollupType.GAUGE, RollupType.fromString("GAUGE"));
+        assertEquals(RollupType.ENUM, RollupType.fromString("ENUM"));
+        assertEquals(RollupType.BF_HISTOGRAMS, RollupType.fromString("BF_HISTOGRAMS"));
+
+        assertEquals(RollupType.NOT_A_ROLLUP, RollupType.fromString("NOT_A_ROLLUP"));
+    }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
@@ -163,4 +163,60 @@ public class RollupTypeTest {
         // then
         // the error is thrown
     }
+
+    @Test
+    public void fromRollupTypeClassSimpleNumberYieldsBasic() {
+        assertEquals(RollupType.BF_BASIC, RollupType.fromRollupTypeClass(SimpleNumber.class));
+    }
+
+    @Test
+    public void fromRollupTypeClassBasicRollupYieldsBasic() {
+        assertEquals(RollupType.BF_BASIC, RollupType.fromRollupTypeClass(BasicRollup.class));
+    }
+
+    @Test
+    public void fromRollupTypeClassBluefloodCounterRollupYieldsCounter() {
+        assertEquals(RollupType.COUNTER, RollupType.fromRollupTypeClass(BluefloodCounterRollup.class));
+    }
+
+    @Test
+    public void fromRollupTypeClassBluefloodSetRollupYieldsSet() {
+        assertEquals(RollupType.SET, RollupType.fromRollupTypeClass(BluefloodSetRollup.class));
+    }
+
+    @Test
+    public void fromRollupTypeClassBluefloodTimerRollupYieldsSet() {
+        assertEquals(RollupType.TIMER, RollupType.fromRollupTypeClass(BluefloodTimerRollup.class));
+    }
+
+    @Test
+    public void fromRollupTypeClassBluefloodGaugeRollupYieldsSet() {
+        assertEquals(RollupType.GAUGE, RollupType.fromRollupTypeClass(BluefloodGaugeRollup.class));
+    }
+
+    @Test
+    public void fromRollupTypeClassBluefloodEnumRollupYieldsSet() {
+        assertEquals(RollupType.ENUM, RollupType.fromRollupTypeClass(BluefloodEnumRollup.class));
+    }
+
+    @Test
+    public void fromRollupTypeClassHistogramRollupYieldsSet() {
+        assertEquals(RollupType.BF_HISTOGRAMS, RollupType.fromRollupTypeClass(HistogramRollup.class));
+    }
+
+    @Test(expected = Error.class)
+    public void fromRollupTypeClassCustomSubclassThrowsError() {
+        // when
+        RollupType.fromRollupTypeClass(DummyRollup.class);
+        // then
+        // the error is thrown
+    }
+
+    @Test(expected = Error.class)
+    public void fromRollupTypeClassMetricThrowsError() {
+        // when
+        RollupType.fromRollupTypeClass(MetricImplementsRollup.class);
+        // then
+        // the error is thrown
+    }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
@@ -2,6 +2,7 @@ package com.rackspacecloud.blueflood.types;
 
 import com.bigml.histogram.Bin;
 import com.bigml.histogram.SimpleTarget;
+import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import org.junit.Test;
 
@@ -216,6 +217,59 @@ public class RollupTypeTest {
     public void fromRollupTypeClassMetricThrowsError() {
         // when
         RollupType.fromRollupTypeClass(MetricImplementsRollup.class);
+        // then
+        // the error is thrown
+    }
+
+    @Test
+    public void classOfCounterYieldsBluefloodCounterRollup() {
+        assertEquals(BluefloodCounterRollup.class, RollupType.classOf(RollupType.COUNTER, null));
+    }
+
+    @Test
+    public void classOfTimerYieldsBluefloodTimerRollup() {
+        assertEquals(BluefloodTimerRollup.class, RollupType.classOf(RollupType.TIMER, null));
+    }
+
+    @Test
+    public void classOfSetYieldsBluefloodSetRollup() {
+        assertEquals(BluefloodSetRollup.class, RollupType.classOf(RollupType.SET, null));
+    }
+
+    @Test
+    public void classOfGaugeYieldsBluefloodGaugeRollup() {
+        assertEquals(BluefloodGaugeRollup.class, RollupType.classOf(RollupType.GAUGE, null));
+    }
+
+    @Test
+    public void classOfHistogramsYieldsHistogramRollup() {
+        assertEquals(HistogramRollup.class, RollupType.classOf(RollupType.BF_HISTOGRAMS, null));
+    }
+
+    @Test
+    public void classOfEnumYieldsBluefloodEnumRollup() {
+        assertEquals(BluefloodEnumRollup.class, RollupType.classOf(RollupType.ENUM, null));
+    }
+
+    @Test
+    public void classOfBasicWithFullGranularityYieldsSimpleNumber() {
+        assertEquals(SimpleNumber.class, RollupType.classOf(RollupType.BF_BASIC, Granularity.FULL));
+    }
+
+    @Test
+    public void classOfBasicWithOtherGranularityYieldsBasicRollup() {
+        assertEquals(BasicRollup.class, RollupType.classOf(RollupType.BF_BASIC, null));
+        assertEquals(BasicRollup.class, RollupType.classOf(RollupType.BF_BASIC, Granularity.MIN_5));
+        assertEquals(BasicRollup.class, RollupType.classOf(RollupType.BF_BASIC, Granularity.MIN_20));
+        assertEquals(BasicRollup.class, RollupType.classOf(RollupType.BF_BASIC, Granularity.MIN_60));
+        assertEquals(BasicRollup.class, RollupType.classOf(RollupType.BF_BASIC, Granularity.MIN_240));
+        assertEquals(BasicRollup.class, RollupType.classOf(RollupType.BF_BASIC, Granularity.MIN_1440));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void classOfNotARollupThrowsException() {
+        // when
+        RollupType.classOf(RollupType.NOT_A_ROLLUP, null);
         // then
         // the error is thrown
     }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
@@ -7,22 +7,67 @@ import static org.junit.Assert.assertEquals;
 public class RollupTypeTest {
 
     @Test
-    public void testFromString() {
+    public void fromStringNullYieldsBasic() {
         assertEquals(RollupType.BF_BASIC, RollupType.fromString(null));
+    }
+
+    @Test
+    public void fromStringEmptyStringYieldsBasic() {
         assertEquals(RollupType.BF_BASIC, RollupType.fromString(""));
+    }
+
+    @Test
+    public void fromStringInvalidYieldsBasic() {
         assertEquals(RollupType.BF_BASIC, RollupType.fromString("abcdef"));
+    }
 
+    @Test
+    public void fromStringBasicYieldsBasic() {
         assertEquals(RollupType.BF_BASIC, RollupType.fromString("BF_BASIC"));
+    }
+
+    @Test
+    public void fromStringBasicLowercaseYieldsBasic() {
         assertEquals(RollupType.BF_BASIC, RollupType.fromString("bf_basic"));
+    }
+
+    @Test
+    public void fromStringBasicMixedCaseYieldsBasic() {
         assertEquals(RollupType.BF_BASIC, RollupType.fromString("bF_bAsIc"));
+    }
 
+    @Test
+    public void fromStringCounterYieldsCounter() {
         assertEquals(RollupType.COUNTER, RollupType.fromString("COUNTER"));
-        assertEquals(RollupType.TIMER, RollupType.fromString("TIMER"));
-        assertEquals(RollupType.SET, RollupType.fromString("SET"));
-        assertEquals(RollupType.GAUGE, RollupType.fromString("GAUGE"));
-        assertEquals(RollupType.ENUM, RollupType.fromString("ENUM"));
-        assertEquals(RollupType.BF_HISTOGRAMS, RollupType.fromString("BF_HISTOGRAMS"));
+    }
 
+    @Test
+    public void fromStringTimeYieldsTimer() {
+        assertEquals(RollupType.TIMER, RollupType.fromString("TIMER"));
+    }
+
+    @Test
+    public void fromStringSetYieldsSet() {
+        assertEquals(RollupType.SET, RollupType.fromString("SET"));
+    }
+
+    @Test
+    public void fromStringGaugeYieldsGauge() {
+        assertEquals(RollupType.GAUGE, RollupType.fromString("GAUGE"));
+    }
+
+    @Test
+    public void fromStringEnumYieldsEnum() {
+        assertEquals(RollupType.ENUM, RollupType.fromString("ENUM"));
+    }
+
+    @Test
+    public void fromStringHistgramsYieldsHistgrams() {
+        assertEquals(RollupType.BF_HISTOGRAMS, RollupType.fromString("BF_HISTOGRAMS"));
+    }
+
+    @Test
+    public void fromStringNotARollupYieldsNotARollup() {
         assertEquals(RollupType.NOT_A_ROLLUP, RollupType.fromString("NOT_A_ROLLUP"));
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/RollupTypeTest.java
@@ -1,0 +1,4 @@
+package com.rackspacecloud.blueflood.types;
+
+public class RollupTypeTest {
+}


### PR DESCRIPTION
This PR adds tests for the `RollupType` class. It brings the class-specific unit test coverage from zero up to 100% of lines, and from zero to 97% of branches.