### PR TITLE
Test BluefloodCounterRollup

### DIFF
--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Random;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
@@ -282,7 +281,7 @@ public class BluefloodCounterRollupTest {
         assertNotNull(count);
         assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
         assertEquals(3L, count.longValue());
-        assertEquals(Double.POSITIVE_INFINITY, rollup.getRate(), 0.00001d); //(3)/0=inf
+        assertEquals(Double.POSITIVE_INFINITY, rollup.getRate(), 0.00001d); //(3)/(1-1)=inf
         assertEquals(1, rollup.getSampleCount());
     }
 
@@ -299,7 +298,7 @@ public class BluefloodCounterRollupTest {
         assertNotNull(count);
         assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
         assertEquals(7L, count.longValue());
-        assertEquals(7.0d, rollup.getRate(), 0.00001d); // (3+4)/1=7
+        assertEquals(7.0d, rollup.getRate(), 0.00001d); // (3+4)/(2-1)=7
         assertEquals(2, rollup.getSampleCount());
     }
 
@@ -371,7 +370,7 @@ public class BluefloodCounterRollupTest {
         assertNotNull(count);
         assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
         assertEquals(12L, count.longValue());
-        assertEquals(6.0d, rollup.getRate(), 0.00001d); // (3+4+5)/2=6
+        assertEquals(6.0d, rollup.getRate(), 0.00001d); // (3+4+5)/(3-1)=6
         assertEquals(3, rollup.getSampleCount());
     }
 
@@ -391,7 +390,7 @@ public class BluefloodCounterRollupTest {
         assertNotNull(count);
         assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
         assertEquals(18L, count.longValue());
-        assertEquals(6.0d, rollup.getRate(), 0.00001d); // (3+4+5+6)/3=6
+        assertEquals(6.0d, rollup.getRate(), 0.00001d); // (3+4+5+6)/(4-1)=6
         assertEquals(4, rollup.getSampleCount());
     }
 
@@ -449,7 +448,7 @@ public class BluefloodCounterRollupTest {
         Points<SimpleNumber> input = new Points<SimpleNumber>();
         input.add(new Points.Point<SimpleNumber>(1234L, new SimpleNumber(Double.MIN_NORMAL)));
         input.add(new Points.Point<SimpleNumber>(1235L, new SimpleNumber(Double.MIN_NORMAL)));
-        double expectedCount = Double.MIN_NORMAL * 2; // Long.MIN_VALUE + 2;
+        double expectedCount = Double.MIN_NORMAL * 2;
         // when
         BluefloodCounterRollup rollup = BluefloodCounterRollup.buildRollupFromRawSamples(input);
         // then
@@ -552,7 +551,7 @@ public class BluefloodCounterRollupTest {
         assertNotNull(count);
         assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
         assertEquals(3L, count.longValue()); // 1+2
-        assertEquals(3.0d, rollup.getRate(), 0.00001d); // (1+2+3+4)/2=5
+        assertEquals(3.0d, rollup.getRate(), 0.00001d); // (1+2+3+4)/(3-1)=5
         assertEquals(2, rollup.getSampleCount());
     }
 
@@ -582,7 +581,7 @@ public class BluefloodCounterRollupTest {
         assertNotNull(count);
         assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
         assertEquals(10L, count.longValue()); // 1+2+3+4
-        assertEquals(5.0d, rollup.getRate(), 0.00001d); // (1+2+3+4)/(1+1)=5
+        assertEquals(5.0d, rollup.getRate(), 0.00001d); // (1+2+3+4)/((2-1)+(2-1))=5
         assertEquals(4, rollup.getSampleCount());
     }
 
@@ -611,7 +610,7 @@ public class BluefloodCounterRollupTest {
         assertNotNull(count);
         assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
         assertEquals(6L, count.longValue()); // 1+2+3
-        assertEquals(6.0d, rollup.getRate(), 0.00001d); // (1+2+3)/(1+0)=6
+        assertEquals(6.0d, rollup.getRate(), 0.00001d); // (1+2+3)/((2-1)+(1-1))=6
         assertEquals(3, rollup.getSampleCount());
     }
 
@@ -636,7 +635,7 @@ public class BluefloodCounterRollupTest {
         assertNotNull(count);
         assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
         assertEquals(6L, count.longValue()); // 1+2+3
-        assertEquals(3.0d, rollup.getRate(), 0.00001d); // (1+2+3)/(2)=3
+        assertEquals(3.0d, rollup.getRate(), 0.00001d); // (1+2+3)/(3-1)=3
         assertEquals(3, rollup.getSampleCount());
     }
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -6,10 +6,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class BluefloodCounterRollupTest {
     private static final Random random = new Random(72262L);
@@ -163,5 +160,15 @@ public class BluefloodCounterRollupTest {
         BluefloodCounterRollup a = new BluefloodCounterRollup().withCount(1).withSampleCount(1);
         //when
         assertTrue(a.equals(b));
+    }
+
+    @Test
+    public void constructorSetsInitialValues() {
+        // when
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup();
+        // then
+        assertNull(rollup.getCount());
+        assertEquals(0.0d, rollup.getRate(), 0.000001d);
+        assertEquals(0, rollup.getSampleCount());
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -1,98 +1,14 @@
 package com.rackspacecloud.blueflood.types;
 
-import com.rackspacecloud.blueflood.io.Constants;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 public class BluefloodCounterRollupTest {
-    private static final Random random = new Random(72262L);
-    
-    @Test
-    public void testRateCalculations() throws IOException {
-        long[] sample0 = {10L,10L,10L,10L,10L,10L,10L,10L,10L,10L}; // 300 secs
-        long[] sample1 = {20L,20L,20L,20L,20L,20L,20L,20L,20L,20L,20L,20L,20L,20L,20L}; // 450 secs
-        final BluefloodCounterRollup cr0 = BluefloodCounterRollupTest.buildCounterRollupFromLongs(sample0);
-        final BluefloodCounterRollup cr1 = BluefloodCounterRollupTest.buildCounterRollupFromLongs(sample1);
-        
-        assertEquals(100d / 300d, cr0.getRate(), 0.00001d);
-        assertEquals(300d / 450d, cr1.getRate(), 0.00001d);
-        
-        // great, now combine them.
-        BluefloodCounterRollup cr2 = BluefloodCounterRollup.buildRollupFromCounterRollups(asPoints(BluefloodCounterRollup.class, 0, 300, cr0, cr1));
-        
-        assertEquals(400d / 750d, cr2.getRate(), 0.00001d);
-    }
-    
-    @Test
-    public void testCounterRollupIdempotence() throws IOException {
-        final BluefloodCounterRollup cr0 = BluefloodCounterRollupTest.buildCounterRollupFromLongs(makeRandomNumbers(1000));
-        BluefloodCounterRollup cumulative = BluefloodCounterRollup.buildRollupFromCounterRollups(asPoints(BluefloodCounterRollup.class, 0, 10, cr0));
-        assertEquals(cr0, cumulative);
-    }
-    
-    @Test
-    public void testCounterRollupGeneration() throws IOException {
-        final long[] src0 = makeRandomNumbers(1000);
-        final long[] src1 = makeRandomNumbers(500);
-        final BluefloodCounterRollup cr0 = BluefloodCounterRollupTest.buildCounterRollupFromLongs(src0);
-        final BluefloodCounterRollup cr1 = BluefloodCounterRollupTest.buildCounterRollupFromLongs(src1);
-        
-        long expectedSum = sum(src0) + sum(src1);
-        
-        BluefloodCounterRollup cumulative = BluefloodCounterRollup.buildRollupFromCounterRollups(asPoints(BluefloodCounterRollup.class, 0, 1000, cr0, cr1));
-        
-        assertEquals(expectedSum, cumulative.getCount());
-    }
-
-    @Test
-    public void testNullCounterRollupVersusZero() throws IOException {
-        final long[] data = new long[]{0L, 0L, 0L};
-        final long[] no_data = new long[]{};
-        final BluefloodCounterRollup crData = BluefloodCounterRollupTest.buildCounterRollupFromLongs(data);
-        final BluefloodCounterRollup crNoData = BluefloodCounterRollupTest.buildCounterRollupFromLongs(no_data);
-        assertNotSame(crData, crNoData);
-    }
-
-    private static <T> Points<T> asPoints(Class<T> type, long initialTime, long timeDelta, T... values) {
-        Points<T> points = new Points<T>();
-        long time = initialTime;
-        for (T v : values) {
-            points.add(new Points.Point<T>(time, v));
-            time += timeDelta;
-        }
-        return points;
-    }
-    
-    private static long[] makeRandomNumbers(int count) {
-        long[] numbers = new long[count];
-        for (int i = 0; i < count; i++)
-            numbers[i] = random.nextLong() % 1000000L;
-        return numbers;
-    }
-    
-    private static long sum(long[] numbers) {
-        long sum = 0;
-        for (long num : numbers)
-            sum += num;
-        return sum;
-    }
-    
-    // assume the samples are 30s apart.
-    private static BluefloodCounterRollup buildCounterRollupFromLongs(long... numbers) throws IOException {
-        long count = 0;
-        for (long number : numbers) {
-            count += number;
-        }
-        long sum = sum(numbers);
-        double rate = (double)sum / (double)(Constants.DEFAULT_SAMPLE_INTERVAL * numbers.length);
-        return new BluefloodCounterRollup().withCount(count).withRate(rate).withSampleCount(numbers.length);
-    }
 
     @Test
     public void equalsOtherNullReturnsFalse() {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -8,6 +8,8 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class BluefloodCounterRollupTest {
     private static final Random random = new Random(72262L);
@@ -91,5 +93,75 @@ public class BluefloodCounterRollupTest {
         long sum = sum(numbers);
         double rate = (double)sum / (double)(Constants.DEFAULT_SAMPLE_INTERVAL * numbers.length);
         return new BluefloodCounterRollup().withCount(count).withRate(rate).withSampleCount(numbers.length);
+    }
+
+    @Test
+    public void equalsOtherNullReturnsFalse() {
+        //given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup();
+        //when
+        assertFalse(rollup.equals(null));
+    }
+
+    @Test
+    public void equalsOtherNotRollupReturnsFalse() {
+        //given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup();
+        //when
+        assertFalse(rollup.equals(""));
+    }
+
+    @Test
+    public void equalsDifferentCountReturnsFalse() {
+        //given
+        BluefloodCounterRollup a = new BluefloodCounterRollup().withCount(1);
+        BluefloodCounterRollup b = new BluefloodCounterRollup().withCount(2);
+        //when
+        assertFalse(a.equals(b));
+    }
+
+    @Test
+    public void equalsSameCountReturnsFalse() {
+        //given
+        BluefloodCounterRollup a = new BluefloodCounterRollup().withCount(1);
+        BluefloodCounterRollup b = new BluefloodCounterRollup().withCount(1);
+        //when
+        assertTrue(a.equals(b));
+    }
+
+    @Test
+    public void equalsDifferentRateReturnsFalse() {
+        //given
+        BluefloodCounterRollup a = new BluefloodCounterRollup().withCount(1).withRate(1.0d);
+        BluefloodCounterRollup b = new BluefloodCounterRollup().withCount(1).withRate(2.0d);
+        //when
+        assertFalse(a.equals(b));
+    }
+
+    @Test
+    public void equalsSameRateReturnsFalse() {
+        //given
+        BluefloodCounterRollup a = new BluefloodCounterRollup().withCount(1).withRate(1.0d);
+        BluefloodCounterRollup b = new BluefloodCounterRollup().withCount(1).withRate(1.0d);
+        //when
+        assertTrue(a.equals(b));
+    }
+
+    @Test
+    public void equalsDifferentSampleCountReturnsFalse() {
+        //given
+        BluefloodCounterRollup a = new BluefloodCounterRollup().withCount(1).withSampleCount(1);
+        BluefloodCounterRollup b = new BluefloodCounterRollup().withCount(1).withSampleCount(2);
+        //when
+        assertFalse(a.equals(b));
+    }
+
+    @Test
+    public void equalsSameSampleCountReturnsFalse() {
+        //given
+        BluefloodCounterRollup b = new BluefloodCounterRollup().withCount(1).withSampleCount(1);
+        BluefloodCounterRollup a = new BluefloodCounterRollup().withCount(1).withSampleCount(1);
+        //when
+        assertTrue(a.equals(b));
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -639,4 +639,50 @@ public class BluefloodCounterRollupTest {
         assertEquals(3.0d, rollup.getRate(), 0.00001d); // (1+2+3)/(2)=3
         assertEquals(3, rollup.getSampleCount());
     }
+
+    @Test
+    public void counterRollupBuiderWithNoInputYieldsRateEqualToOffByOneAverage() throws IOException {
+
+        // given
+        Points<SimpleNumber> inputA = new Points<SimpleNumber>();
+        BluefloodCounterRollup rollupA = BluefloodCounterRollup.buildRollupFromRawSamples(inputA);
+
+        Points<BluefloodCounterRollup> combined = new Points<BluefloodCounterRollup>();
+        combined.add(new Points.Point<BluefloodCounterRollup>(1234L, rollupA));
+
+        // when
+        BluefloodCounterRollup rollup = BluefloodCounterRollup.buildRollupFromCounterRollups(combined);
+
+        // then
+        Number count = rollup.getCount();
+        assertNotNull(count);
+        assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
+        assertEquals(0L, count.longValue());
+        assertEquals(0.0d, rollup.getRate(), 0.00001d); // (0)/(inf)=0
+        assertEquals(0, rollup.getSampleCount());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void counterRollupBuiderWithNullRollupInputThrowsException() throws IOException {
+
+        // given
+        Points<BluefloodCounterRollup> combined = new Points<BluefloodCounterRollup>();
+        combined.add(new Points.Point<BluefloodCounterRollup>(1234L, null));
+
+        // when
+        BluefloodCounterRollup rollup = BluefloodCounterRollup.buildRollupFromCounterRollups(combined);
+
+        // then
+        // the exception is thrown
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void counterRollupBuiderWithNullCombinedInputThrowsException() throws IOException {
+
+        // when
+        BluefloodCounterRollup rollup = BluefloodCounterRollup.buildRollupFromCounterRollups(null);
+
+        // then
+        // the exception is thrown
+    }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -1,11 +1,14 @@
 package com.rackspacecloud.blueflood.types;
 
 import com.rackspacecloud.blueflood.io.Constants;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Random;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 public class BluefloodCounterRollupTest {
@@ -170,5 +173,85 @@ public class BluefloodCounterRollupTest {
         assertNull(rollup.getCount());
         assertEquals(0.0d, rollup.getRate(), 0.000001d);
         assertEquals(0, rollup.getSampleCount());
+    }
+
+    @Test
+    public void withCountIntegerSetsCount() {
+        // given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup();
+        // precondition
+        assertNull(rollup.getCount());
+        // when
+        rollup.withCount(123);
+        // then
+        Number value = rollup.getCount();
+        assertThat(value, is(CoreMatchers.<Number>instanceOf(Long.class)));
+        assertEquals(123L, value.longValue());
+    }
+
+    @Test
+    public void withCountLongSetsCount() {
+        // given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup();
+        // precondition
+        assertNull(rollup.getCount());
+        // when
+        rollup.withCount(123L);
+        // then
+        Number value = rollup.getCount();
+        assertThat(value, is(CoreMatchers.<Number>instanceOf(Long.class)));
+        assertEquals(123L, value.longValue());
+    }
+
+    @Test
+    public void withCountFloatSetsCount() {
+        // given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup();
+        // precondition
+        assertNull(rollup.getCount());
+        // when
+        rollup.withCount(123.45f);
+        // then
+        Number value = rollup.getCount();
+        assertThat(value, is(CoreMatchers.<Number>instanceOf(Double.class)));
+        assertEquals(123.45d, value.doubleValue(), 0.00001d);
+    }
+
+    @Test
+    public void withCountDoubleSetsCount() {
+        // given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup();
+        // precondition
+        assertNull(rollup.getCount());
+        // when
+        rollup.withCount(123.45d);
+        // then
+        Number value = rollup.getCount();
+        assertThat(value, is(CoreMatchers.<Number>instanceOf(Double.class)));
+        assertEquals(123.45d, value.doubleValue(), 0.00001d);
+    }
+
+    @Test
+    public void withRateSetsRate() {
+        // given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup();
+        // precondition
+        assertEquals(0.0d, rollup.getRate(), 0.00001d);
+        // when
+        rollup.withRate(123.45d);
+        // then
+        assertEquals(123.45d, rollup.getRate(), 0.00001d);
+    }
+
+    @Test
+    public void withSampleCountSetsSampleCount() {
+        // given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup();
+        // precondition
+        assertEquals(0, rollup.getSampleCount());
+        // when
+        rollup.withSampleCount(123);
+        // then
+        assertEquals(123, rollup.getSampleCount());
     }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -600,4 +600,129 @@ public class BluefloodCounterRollupTest {
         // then
         // the exception is thrown
     }
+
+    @Test
+    public void counterRollupBuiderWithsSingleExplicitInputYieldsSameValues() throws IOException {
+
+        // given
+        BluefloodCounterRollup rollupA = new BluefloodCounterRollup()
+                .withCount(6)
+                .withRate(3)
+                .withSampleCount(3);
+
+        Points<BluefloodCounterRollup> combined = new Points<BluefloodCounterRollup>();
+        combined.add(new Points.Point<BluefloodCounterRollup>(1234L, rollupA));
+
+        // when
+        BluefloodCounterRollup rollup = BluefloodCounterRollup.buildRollupFromCounterRollups(combined);
+
+        // then
+        Number count = rollup.getCount();
+        assertNotNull(count);
+        assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
+        assertEquals(6L, count.longValue()); // 1+2+3
+        assertEquals(3.0d, rollup.getRate(), 0.00001d); // (1+2+3)/(3-1)=3
+        assertEquals(3, rollup.getSampleCount());
+    }
+
+    @Test
+    public void counterRollupBuiderWithsSingleExplicitZeroCountInputYieldsZeroRate() throws IOException {
+
+        // given
+        BluefloodCounterRollup rollupA = new BluefloodCounterRollup()
+                .withCount(0)
+                .withRate(3)
+                .withSampleCount(3);
+
+        Points<BluefloodCounterRollup> combined = new Points<BluefloodCounterRollup>();
+        combined.add(new Points.Point<BluefloodCounterRollup>(1234L, rollupA));
+
+        // when
+        BluefloodCounterRollup rollup = BluefloodCounterRollup.buildRollupFromCounterRollups(combined);
+
+        // then
+        Number count = rollup.getCount();
+        assertNotNull(count);
+        assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
+        assertEquals(0, count.longValue());
+        assertEquals(0.0d, rollup.getRate(), 0.00001d); // (0)/(3-1)=0
+        assertEquals(3, rollup.getSampleCount());
+    }
+
+    @Test
+    public void counterRollupBuiderWithsSingleExplicitZeroRateInputYieldsSameValues() throws IOException {
+
+        // given
+        BluefloodCounterRollup rollupA = new BluefloodCounterRollup()
+                .withCount(6)
+                .withRate(0)
+                .withSampleCount(3);
+
+        Points<BluefloodCounterRollup> combined = new Points<BluefloodCounterRollup>();
+        combined.add(new Points.Point<BluefloodCounterRollup>(1234L, rollupA));
+
+        // when
+        BluefloodCounterRollup rollup = BluefloodCounterRollup.buildRollupFromCounterRollups(combined);
+
+        // then
+        Number count = rollup.getCount();
+        assertNotNull(count);
+        assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
+        assertEquals(6L, count.longValue()); // 1+2+3
+        assertEquals(0.0d, rollup.getRate(), 0.00001d); // (1+2+3)/(3-1)=3
+        assertEquals(3, rollup.getSampleCount());
+    }
+
+    @Test
+    public void counterRollupBuiderWithsSingleExplicitZeroSampleCountInputYieldsSameValues() throws IOException {
+
+        // given
+        BluefloodCounterRollup rollupA = new BluefloodCounterRollup()
+                .withCount(6)
+                .withRate(3)
+                .withSampleCount(0);
+
+        Points<BluefloodCounterRollup> combined = new Points<BluefloodCounterRollup>();
+        combined.add(new Points.Point<BluefloodCounterRollup>(1234L, rollupA));
+
+        // when
+        BluefloodCounterRollup rollup = BluefloodCounterRollup.buildRollupFromCounterRollups(combined);
+
+        // then
+        Number count = rollup.getCount();
+        assertNotNull(count);
+        assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
+        assertEquals(6L, count.longValue()); // 1+2+3
+        assertEquals(3.0d, rollup.getRate(), 0.00001d); // (1+2+3)/(3-1)=3
+        assertEquals(0, rollup.getSampleCount());
+    }
+
+    @Test
+    public void counterRollupBuiderWithsTwoExplicitInputYieldsSameValues() throws IOException {
+
+        // given
+        BluefloodCounterRollup rollupA = new BluefloodCounterRollup()
+                .withCount(6) // 1+2+3
+                .withRate(3)
+                .withSampleCount(3);
+        BluefloodCounterRollup rollupB = new BluefloodCounterRollup()
+                .withCount(15) // 4+5+6
+                .withRate(7.5d)
+                .withSampleCount(3);
+
+        Points<BluefloodCounterRollup> combined = new Points<BluefloodCounterRollup>();
+        combined.add(new Points.Point<BluefloodCounterRollup>(1234L, rollupA));
+        combined.add(new Points.Point<BluefloodCounterRollup>(1235L, rollupB));
+
+        // when
+        BluefloodCounterRollup rollup = BluefloodCounterRollup.buildRollupFromCounterRollups(combined);
+
+        // then
+        Number count = rollup.getCount();
+        assertNotNull(count);
+        assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
+        assertEquals(21L, count.longValue()); // 1+2+3+4+5+6
+        assertEquals(5.25d, rollup.getRate(), 0.00001d); // (1+2+3+4+5+6)/((3-1)+(3-1))=5.25
+        assertEquals(6, rollup.getSampleCount());
+    }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -725,4 +725,34 @@ public class BluefloodCounterRollupTest {
         assertEquals(5.25d, rollup.getRate(), 0.00001d); // (1+2+3+4+5+6)/((3-1)+(3-1))=5.25
         assertEquals(6, rollup.getSampleCount());
     }
+
+    @Test
+    public void hasDataWithZeroSampleCountReturnsFalse() {
+        // given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup()
+                .withCount(1)
+                .withRate(1)
+                .withSampleCount(0);
+        // expect
+        assertFalse(rollup.hasData());
+    }
+
+    @Test
+    public void hasDataWithNonZeroSampleCountReturnsTrue() {
+        // given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup()
+                .withCount(1)
+                .withRate(1)
+                .withSampleCount(1);
+        // expect
+        assertTrue(rollup.hasData());
+    }
+
+    @Test
+    public void getRollupTypeReturnsCounter() {
+        // given
+        BluefloodCounterRollup rollup = new BluefloodCounterRollup();
+        // expect
+        assertEquals(RollupType.COUNTER, rollup.getRollupType());
+    }
 }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -197,7 +197,8 @@ public class BluefloodCounterRollupTest {
         assertNotNull(count);
         assertThat(count, is(CoreMatchers.<Number>instanceOf(Long.class)));
         assertEquals(3L, count.longValue());
-        assertEquals(Double.POSITIVE_INFINITY, rollup.getRate(), 0.00001d); //(3)/(1-1)=inf
+        assertTrue(Double.isInfinite(rollup.getRate())); //(3)/(1-1)=+inf
+        assertTrue(rollup.getRate() > 0);
         assertEquals(1, rollup.getSampleCount());
     }
 
@@ -352,8 +353,10 @@ public class BluefloodCounterRollupTest {
         Number count = rollup.getCount();
         assertNotNull(count);
         assertThat(count, is(CoreMatchers.<Number>instanceOf(Double.class)));
-        assertEquals(Double.POSITIVE_INFINITY, count.doubleValue(), 0.00001d);
-        assertEquals(Double.POSITIVE_INFINITY, rollup.getRate(), 0.00001d);
+        assertTrue(((Double)count).isInfinite());
+        assertTrue(((Double)count) > 0);
+        assertTrue(Double.isInfinite(rollup.getRate()));
+        assertTrue(rollup.getRate() > 0);
         assertEquals(2, rollup.getSampleCount());
     }
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -1,11 +1,13 @@
 package com.rackspacecloud.blueflood.types;
 
 import com.rackspacecloud.blueflood.io.Constants;
-import junit.framework.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 
 public class BluefloodCounterRollupTest {
     private static final Random random = new Random(72262L);
@@ -17,20 +19,20 @@ public class BluefloodCounterRollupTest {
         final BluefloodCounterRollup cr0 = BluefloodCounterRollupTest.buildCounterRollupFromLongs(sample0);
         final BluefloodCounterRollup cr1 = BluefloodCounterRollupTest.buildCounterRollupFromLongs(sample1);
         
-        Assert.assertEquals(100d/300d, cr0.getRate());
-        Assert.assertEquals(300d/450d, cr1.getRate());
+        assertEquals(100d / 300d, cr0.getRate(), 0.00001d);
+        assertEquals(300d / 450d, cr1.getRate(), 0.00001d);
         
         // great, now combine them.
         BluefloodCounterRollup cr2 = BluefloodCounterRollup.buildRollupFromCounterRollups(asPoints(BluefloodCounterRollup.class, 0, 300, cr0, cr1));
         
-        Assert.assertEquals(400d/750d, cr2.getRate());
+        assertEquals(400d / 750d, cr2.getRate(), 0.00001d);
     }
     
     @Test
     public void testCounterRollupIdempotence() throws IOException {
         final BluefloodCounterRollup cr0 = BluefloodCounterRollupTest.buildCounterRollupFromLongs(makeRandomNumbers(1000));
         BluefloodCounterRollup cumulative = BluefloodCounterRollup.buildRollupFromCounterRollups(asPoints(BluefloodCounterRollup.class, 0, 10, cr0));
-        Assert.assertEquals(cr0, cumulative);
+        assertEquals(cr0, cumulative);
     }
     
     @Test
@@ -44,7 +46,7 @@ public class BluefloodCounterRollupTest {
         
         BluefloodCounterRollup cumulative = BluefloodCounterRollup.buildRollupFromCounterRollups(asPoints(BluefloodCounterRollup.class, 0, 1000, cr0, cr1));
         
-        Assert.assertEquals(expectedSum, cumulative.getCount());
+        assertEquals(expectedSum, cumulative.getCount());
     }
 
     @Test
@@ -53,7 +55,7 @@ public class BluefloodCounterRollupTest {
         final long[] no_data = new long[]{};
         final BluefloodCounterRollup crData = BluefloodCounterRollupTest.buildCounterRollupFromLongs(data);
         final BluefloodCounterRollup crNoData = BluefloodCounterRollupTest.buildCounterRollupFromLongs(no_data);
-        Assert.assertNotSame(crData, crNoData);
+        assertNotSame(crData, crNoData);
     }
 
     private static <T> Points<T> asPoints(Class<T> type, long initialTime, long timeDelta, T... values) {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/BluefloodCounterRollupTest.java
@@ -36,7 +36,7 @@ public class BluefloodCounterRollupTest {
     }
 
     @Test
-    public void equalsSameCountReturnsFalse() {
+    public void equalsSameCountReturnsTrue() {
         //given
         BluefloodCounterRollup a = new BluefloodCounterRollup().withCount(1);
         BluefloodCounterRollup b = new BluefloodCounterRollup().withCount(1);
@@ -54,7 +54,7 @@ public class BluefloodCounterRollupTest {
     }
 
     @Test
-    public void equalsSameRateReturnsFalse() {
+    public void equalsSameRateReturnsTrue() {
         //given
         BluefloodCounterRollup a = new BluefloodCounterRollup().withCount(1).withRate(1.0d);
         BluefloodCounterRollup b = new BluefloodCounterRollup().withCount(1).withRate(1.0d);
@@ -72,7 +72,7 @@ public class BluefloodCounterRollupTest {
     }
 
     @Test
-    public void equalsSameSampleCountReturnsFalse() {
+    public void equalsSameSampleCountReturnsTrue() {
         //given
         BluefloodCounterRollup b = new BluefloodCounterRollup().withCount(1).withSampleCount(1);
         BluefloodCounterRollup a = new BluefloodCounterRollup().withCount(1).withSampleCount(1);


### PR DESCRIPTION
This PR adds tests for the `BluefloodCounterRollup` class. It brings the class-specific unit test coverage from 63% up to 98% of lines, and from 47% to 93% of branches. Also, the old tests were pretty bad, and did not properly test the functionality, so I replaced them.