### PR TITLE
modify multi ingestion handler to return 207 multi-status

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetric.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetric.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.rackspacecloud.blueflood.inputs.formats;
+
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+
+import java.util.List;
+
+// Jackson compatible class. Jackson uses reflection to call these methods and so they have to match JSON keys.
+public class JSONMetric {
+
+    final long BEFORE_CURRENT_COLLECTIONTIME_MS = Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
+    final long AFTER_CURRENT_COLLECTIONTIME_MS = Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
+
+    private String metricName;
+    private Object metricValue;
+    private long collectionTime;
+    private int ttlInSeconds;
+    private String unit;
+
+    public String getMetricName() {
+        return metricName;
+    }
+
+    public void setMetricName(String metricName) {
+        this.metricName = metricName;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    public Object getMetricValue() {
+        return metricValue;
+    }
+
+    public void setMetricValue(Object metricValue) {
+        this.metricValue = metricValue;
+    }
+
+    public long getCollectionTime() {
+        return collectionTime;
+    }
+
+    public void setCollectionTime(long collectionTime) {
+        this.collectionTime = collectionTime;
+    }
+
+    public int getTtlInSeconds() {
+        return this.ttlInSeconds;
+    }
+
+    public void setTtlInSeconds(int ttlInSeconds) {
+        this.ttlInSeconds = ttlInSeconds;
+    }
+
+    public List<String> getValidationErrors() {
+        List<String> errors = new java.util.ArrayList<String>();
+
+        long currentTime = System.currentTimeMillis();
+        if ( collectionTime < currentTime - BEFORE_CURRENT_COLLECTIONTIME_MS ) {
+            // collectionTime is too far in the past
+            errors.add( "'" + metricName + "': 'collectionTime' '" + collectionTime + "' is more than '" + BEFORE_CURRENT_COLLECTIONTIME_MS + "' milliseconds into the past." );
+        } else if ( collectionTime > currentTime + AFTER_CURRENT_COLLECTIONTIME_MS ) {
+            // collectionTime is too far in the future
+            errors.add( "'" + metricName + "': 'collectionTime' '" + collectionTime + "' is more than '" + AFTER_CURRENT_COLLECTIONTIME_MS + "' milliseconds into the future." );
+        }
+
+        return errors;
+    }
+
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricScoped.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricScoped.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.rackspacecloud.blueflood.inputs.formats;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.List;
+
+public class JSONMetricScoped extends JSONMetric {
+    private String tenantId;
+
+    public String getTenantId() { return tenantId; }
+
+    public void setTenantId(String tenantId) { this.tenantId = tenantId; }
+
+    @Override
+    public List<String> getValidationErrors() {
+
+        List<String> errors = super.getValidationErrors();
+
+        // validate tenantid
+        if (StringUtils.isBlank(tenantId)) {
+            errors.add ( "'" + getMetricName() + "': No tenantId is provided for the metric." );
+        }
+
+        return errors;
+    }
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
@@ -22,8 +22,6 @@ import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Metric;
 import com.rackspacecloud.blueflood.utils.TimeValue;
-import org.apache.commons.lang.StringUtils;
-import org.codehaus.jackson.annotate.JsonIgnore;
 import org.joda.time.DateTime;
 
 import java.util.ArrayList;
@@ -33,68 +31,79 @@ import java.util.concurrent.TimeUnit;
 public class JSONMetricsContainer {
     private final String tenantId;
     private final List<JSONMetric> jsonMetrics;
-    private List<Metric> delayedMetrics;
 
     private static final long TRACKER_DELAYED_METRICS_MILLIS = Configuration.getInstance().getLongProperty(CoreConfig.TRACKER_DELAYED_METRICS_MILLIS);
-
     private static final long MAX_AGE_ALLOWED = Configuration.getInstance().getLongProperty(CoreConfig.ROLLUP_DELAY_MILLIS);
     private static final long SHORT_DELAY = Configuration.getInstance().getLongProperty(CoreConfig.SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS);
 
     private static final long pastDiff = Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
     private static final long futureDiff = Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
 
+    private final List<Metric> metrics = new ArrayList<Metric>();
+    private final List<Metric> delayedMetrics = new ArrayList<Metric>();
+    private final List<String> errors = new ArrayList<String>();
+
     public JSONMetricsContainer(String tenantId, List<JSONMetric> metrics) {
         this.tenantId = tenantId;
         this.jsonMetrics = metrics;
+        processJson();
     }
 
     public List<String> getValidationErrors() {
-
-        List<String> errors = new ArrayList<String>();
-
-        // Validate that any ScopedJSONMetric is actually scoped to a tenant.
-        for (JSONMetric jsonMetric : this.jsonMetrics) {
-            errors.addAll( jsonMetric.getValidationErrors() );
-        }
-
         return errors;
     }
 
-    public List<Metric> toMetrics() {
+    public List<Metric> getValidMetrics() {
+        return metrics;
+    }
+
+    private List<Metric> processJson() {
+
         if (jsonMetrics == null || jsonMetrics.isEmpty()) {
             return null;
         }
 
-        final List<Metric> metrics = new ArrayList<Metric>();
-        delayedMetrics = new ArrayList<Metric>();
         for (JSONMetric jsonMetric : jsonMetrics) {
+
+            // validate metric and retrieve error message if failed
+            List<String> metricValidationErrors = jsonMetric.getValidationErrors();
+            if ( !metricValidationErrors.isEmpty() ) {
+                // has metric has validation errors, do not convert metric and add to errors list and go to next metric
+                errors.addAll(metricValidationErrors);
+                continue;
+            }
+
+            if (jsonMetric.getMetricValue() == null) {
+                // skip null value
+                continue;
+            }
+
+            // no error, create metric from json values, but skip null metricValue
             Locator locator;
-            if (jsonMetric instanceof ScopedJSONMetric) {
-                ScopedJSONMetric scopedMetric = (ScopedJSONMetric)jsonMetric;
+            if (jsonMetric instanceof JSONMetricScoped) {
+                JSONMetricScoped scopedMetric = (JSONMetricScoped)jsonMetric;
                 locator = Locator.createLocatorFromPathComponents(scopedMetric.getTenantId(), jsonMetric.getMetricName());
             } else {
                 locator = Locator.createLocatorFromPathComponents(tenantId, jsonMetric.getMetricName());
             }
 
-            if (jsonMetric.getMetricValue() != null) {
-                final Metric metric = new Metric(locator, jsonMetric.getMetricValue(), jsonMetric.getCollectionTime(),
-                        new TimeValue(jsonMetric.getTtlInSeconds(), TimeUnit.SECONDS), jsonMetric.getUnit());
-                long delay = new DateTime().getMillis() - metric.getCollectionTime();
+            final Metric metric = new Metric(locator, jsonMetric.getMetricValue(), jsonMetric.getCollectionTime(),
+                    new TimeValue(jsonMetric.getTtlInSeconds(), TimeUnit.SECONDS), jsonMetric.getUnit());
+            long delay = new DateTime().getMillis() - metric.getCollectionTime();
 
-                if (delay > TRACKER_DELAYED_METRICS_MILLIS) {
-                    delayedMetrics.add(metric);
-                }
-
-                if (delay > MAX_AGE_ALLOWED) {
-                    if (delay <= SHORT_DELAY) {
-                        Instrumentation.markMetricsWithShortDelayReceived();
-                    } else {
-                        Instrumentation.markMetricsWithLongDelayReceived();
-                    }
-                }
-
-                metrics.add(metric);
+            if (delay > TRACKER_DELAYED_METRICS_MILLIS) {
+                delayedMetrics.add(metric);
             }
+
+            if (delay > MAX_AGE_ALLOWED) {
+                if (delay <= SHORT_DELAY) {
+                    Instrumentation.markMetricsWithShortDelayReceived();
+                } else {
+                    Instrumentation.markMetricsWithLongDelayReceived();
+                }
+            }
+
+            metrics.add(metric);
         }
 
         return metrics;
@@ -108,90 +117,4 @@ public class JSONMetricsContainer {
         return delayedMetrics;
     }
 
-    // Jackson compatible class. Jackson uses reflection to call these methods and so they have to match JSON keys.
-    public static class JSONMetric {
-        private String metricName;
-        private Object metricValue;
-        private long collectionTime;
-        private int ttlInSeconds;
-        private String unit;
-
-        public String getMetricName() {
-            return metricName;
-        }
-
-        public void setMetricName(String metricName) {
-            this.metricName = metricName;
-        }
-
-        public String getUnit() {
-            return unit;
-        }
-
-        public void setUnit(String unit) {
-            this.unit = unit;
-        }
-
-        public Object getMetricValue() {
-            return metricValue;
-        }
-
-        public void setMetricValue(Object metricValue) {
-            this.metricValue = metricValue;
-        }
-
-        public long getCollectionTime() {
-            return collectionTime;
-        }
-
-        public void setCollectionTime(long collectionTime) {
-            this.collectionTime = collectionTime;
-        }
-
-        public int getTtlInSeconds() {
-            return this.ttlInSeconds;
-        }
-
-        public void setTtlInSeconds(int ttlInSeconds) {
-            this.ttlInSeconds = ttlInSeconds;
-        }
-
-        @JsonIgnore
-        public List<String> getValidationErrors() {
-
-            long current = System.currentTimeMillis();
-
-            List<String> errors = new ArrayList<String>();
-
-            // collectionTime is an optional parameter
-            if ( collectionTime > current + futureDiff )
-                errors.add( "'" + metricName + "': 'collectionTime' '" + collectionTime + "' is more than '" + futureDiff + "' milliseconds into the future." );
-
-            if ( collectionTime < current - pastDiff )
-                errors.add( "'" + metricName + "': 'collectionTime' '" + collectionTime + "' is more than '" + pastDiff + "' milliseconds into the past." );
-
-            return errors;
-        }
-    }
-
-    public static class ScopedJSONMetric extends JSONMetric {
-        private String tenantId;
-
-        public String getTenantId() { return tenantId; }
-
-        public void setTenantId(String tenantId) { this.tenantId = tenantId; }
-
-        @Override
-        @JsonIgnore
-        public List<String> getValidationErrors() {
-
-            List<String> errors = super.getValidationErrors();
-
-            if( StringUtils.isBlank( tenantId ) ) {
-                errors.add( "'" + getMetricName() + "': No tenantId is provided for the metric." );
-            }
-
-            return errors;
-        }
-    }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
@@ -157,8 +157,7 @@ public class HttpIntegrationTestBase {
         // urlPath is path for url ingestion after the hostname
         // payloadFilepath is location of the payload for the POST content entity
 
-        String json = getJsonFromFile( new InputStreamReader( getClass().getClassLoader().getResourceAsStream( payloadFilePath ) ),
-                postfix );
+        String json = getJsonFromFile( payloadFilePath, postfix );
         return httpPost( tenantId, urlPath, json );
     }
 
@@ -167,20 +166,16 @@ public class HttpIntegrationTestBase {
         // urlPath is path for url ingestion after the hostname
         // payloadFilepath is location of the payload for the POST content entity
 
-        String json = getJsonFromFile( new InputStreamReader( getClass().getClassLoader().getResourceAsStream( payloadFilePath ) ),
-                timestamp, postfix );
+        String json = getJsonFromFile( payloadFilePath, timestamp, postfix );
         return httpPost( tenantId, urlPath, json );
     }
 
 
     public HttpResponse postEvent( String tenantId, String requestBody ) throws Exception {
 
-
         HttpPost post = getHttpPost( tenantId, postEventsPath, requestBody );
-
         post.setHeader( Event.FieldLabels.tenantId.name(), tenantId);
-        HttpResponse response = client.execute(post);
-        return response;
+        return client.execute(post);
     }
 
     public HttpResponse httpPost( String tenantId, String urlPath, String json ) throws URISyntaxException, IOException {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandler.java
@@ -16,8 +16,7 @@
 
 package com.rackspacecloud.blueflood.inputs.handlers;
 
-
-import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainer;
+import com.rackspacecloud.blueflood.inputs.formats.*;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
@@ -33,11 +32,11 @@ public class HttpMultitenantMetricsIngestionHandler extends HttpMetricsIngestion
 
     @Override
     protected JSONMetricsContainer createContainer(String body, String tenantId) throws JsonParseException, JsonMappingException, IOException {
-        List<JSONMetricsContainer.JSONMetric> jsonMetrics =
+        List<JSONMetric> jsonMetrics =
                 mapper.readValue(
                         body,
                         typeFactory.constructCollectionType(List.class,
-                                JSONMetricsContainer.ScopedJSONMetric.class)
+                                JSONMetricScoped.class)
                 );
         return new JSONMetricsContainer(tenantId, jsonMetrics);
     }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/PreaggregateConversions.java
@@ -19,7 +19,7 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 import com.codahale.metrics.Meter;
 
 import com.google.gson.internal.LazilyParsedNumber;
-import com.rackspacecloud.blueflood.inputs.handlers.wrappers.AggregatedPayload;
+import com.rackspacecloud.blueflood.inputs.formats.AggregatedPayload;
 import com.rackspacecloud.blueflood.service.ExcessEnumReader;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.Metrics;

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainerTest.java
@@ -42,7 +42,7 @@ public class JSONMetricsContainerTest {
          // Construct the JSONMetricsContainter from JSON metric objects
         JSONMetricsContainer jsonMetricsContainer = getContainer( "ac1", generateJSONMetricsData() );
 
-        List<Metric> metricsCollection = jsonMetricsContainer.toMetrics();
+        List<Metric> metricsCollection = jsonMetricsContainer.getValidMetrics();
 
         assertTrue( jsonMetricsContainer.getValidationErrors().isEmpty() );
         assertTrue( metricsCollection.size() == 2 );
@@ -65,7 +65,7 @@ public class JSONMetricsContainerTest {
 
         JSONMetricsContainer container = getContainer( "786659", jsonBody );
 
-        List<Metric> metrics = container.toMetrics();
+        List<Metric> metrics = container.getValidMetrics();
         assertTrue( container.getValidationErrors().isEmpty() );
     }
 
@@ -77,7 +77,7 @@ public class JSONMetricsContainerTest {
         JSONMetricsContainer container = getContainer("786659", jsonBody );
 
         // has a side-effect required by areDelayedMetricsPresent()
-        List<Metric> metrics = container.toMetrics();
+        List<Metric> metrics = container.getValidMetrics();
 
         assertTrue( container.getValidationErrors().isEmpty() );
         assertTrue( container.areDelayedMetricsPresent() );
@@ -90,7 +90,7 @@ public class JSONMetricsContainerTest {
         JSONMetricsContainer container = getContainer( "786659", jsonBody );
 
         // has a side-effect required by areDelayedMetricsPresent()
-        List<Metric> metrics = container.toMetrics();
+        List<Metric> metrics = container.getValidMetrics();
 
         assertTrue( container.getValidationErrors().isEmpty() );
         assertFalse( container.areDelayedMetricsPresent() );
@@ -153,21 +153,19 @@ public class JSONMetricsContainerTest {
 
     private JSONMetricsContainer getScopedContainer( String name, String jsonBody ) throws java.io.IOException {
 
-        List<JSONMetricsContainer.JSONMetric> jsonMetrics =
+        List<JSONMetric> jsonMetrics =
                 mapper.readValue(
                         jsonBody,
-                        typeFactory.constructCollectionType(List.class,
-                                JSONMetricsContainer.ScopedJSONMetric.class)
+                        typeFactory.constructCollectionType(List.class, JSONMetricScoped.class)
                 );
         return new JSONMetricsContainer( name, jsonMetrics);
     }
     private JSONMetricsContainer getContainer( String name, String jsonBody ) throws java.io.IOException {
 
-        List<JSONMetricsContainer.JSONMetric> jsonMetrics =
+        List<JSONMetric> jsonMetrics =
                 mapper.readValue(
                         jsonBody,
-                        typeFactory.constructCollectionType(List.class,
-                                JSONMetricsContainer.JSONMetric.class)
+                        typeFactory.constructCollectionType(List.class, JSONMetric.class)
                 );
         return new JSONMetricsContainer( name, jsonMetrics);
     }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionTest.java
@@ -18,7 +18,7 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.google.gson.internal.LazilyParsedNumber;
 import com.netflix.astyanax.serializers.AbstractSerializer;
-import com.rackspacecloud.blueflood.inputs.handlers.wrappers.AggregatedPayload;
+import com.rackspacecloud.blueflood.inputs.formats.AggregatedPayload;
 import com.rackspacecloud.blueflood.io.serializers.Serializers;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
@@ -46,7 +46,7 @@ public class HttpAggregatedIngestionTest {
     @Before
     public void buildPayload() throws IOException {
 
-        String json = getJsonFromFile( new InputStreamReader( getClass().getClassLoader().getResourceAsStream( "sample_payload.json" ) ), postfix );
+        String json = getJsonFromFile("sample_payload.json", postfix);
         payload = HttpAggregatedIngestionHandler.createPayload(json);
     }
     
@@ -106,14 +106,11 @@ public class HttpAggregatedIngestionTest {
         long timestamp = System.currentTimeMillis() + TIME_DIFF_MS
                 + Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
 
-        String json = getJsonFromFile( new InputStreamReader( getClass().getClassLoader().getResourceAsStream( "sample_payload.json" ) ),
-                timestamp, postfix );
+        String json = getJsonFromFile("sample_payload.json", timestamp, postfix );
         payload = HttpAggregatedIngestionHandler.createPayload(json );
 
         List<String> errors = payload.getValidationErrors();
-
-        assertEquals( 1, errors.size() );
-        assertTrue( Pattern.matches( FUTURE_COLLECTION_TIME_REGEX, errors.get( 0 ) ) );
+        assertTrue( "'" + errors.get(0) + "' does not match pattern " + FUTURE_COLLECTION_TIME_REGEX, Pattern.matches( FUTURE_COLLECTION_TIME_REGEX, errors.get(0) ) );
     }
 
     @Test
@@ -122,14 +119,11 @@ public class HttpAggregatedIngestionTest {
         long timestamp = System.currentTimeMillis() - TIME_DIFF_MS
                 - Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
 
-        String json = getJsonFromFile( new InputStreamReader( getClass().getClassLoader().getResourceAsStream( "sample_payload.json" ) ),
-                timestamp, postfix );
+        String json = getJsonFromFile( "sample_payload.json", timestamp, postfix );
         payload = HttpAggregatedIngestionHandler.createPayload(json );
 
         List<String> errors = payload.getValidationErrors();
-
-        assertEquals( 1, errors.size() );
-        assertTrue( Pattern.matches( PAST_COLLECTION_TIME_REGEX, errors.get( 0 ) ) );
+        assertTrue( "'" + errors.get(0) + "' does not match pattern " + PAST_COLLECTION_TIME_REGEX, Pattern.matches( PAST_COLLECTION_TIME_REGEX, errors.get(0) ) );
     }
 
     // ok. while we're out it, let's test serialization. Just for fun. The reasoning is that these metrics

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionTest.java
@@ -17,7 +17,7 @@
 package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.netflix.astyanax.serializers.AbstractSerializer;
-import com.rackspacecloud.blueflood.inputs.handlers.wrappers.AggregatedPayload;
+import com.rackspacecloud.blueflood.inputs.formats.AggregatedPayload;
 import com.rackspacecloud.blueflood.io.serializers.Serializers;
 import com.rackspacecloud.blueflood.types.PreaggregatedMetric;
 import junit.framework.Assert;
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -41,9 +40,7 @@ public class HttpAggregatedMultiIngestionTest {
 
     @Before
     public void buildBundle() throws IOException {
-
-        String json = getJsonFromFile( new InputStreamReader( getClass().getClassLoader().getResourceAsStream( "sample_multi_aggregated_payload.json" ) ),
-                postfix );
+        String json = getJsonFromFile("sample_multi_aggregated_payload.json", postfix);
         bundleList = HttpAggregatedMultiIngestionHandler.createBundleList(json);
     }
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/wrappers/TestGsonParsing.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/wrappers/TestGsonParsing.java
@@ -2,9 +2,9 @@ package com.rackspacecloud.blueflood.inputs.handlers.wrappers;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.rackspacecloud.blueflood.inputs.formats.AggregatedPayload;
 import com.rackspacecloud.blueflood.types.BluefloodTimer;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpAggregatedIngestionHandler;
-import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,8 +25,7 @@ public class TestGsonParsing {
 
     @Before
     public void readJsonFile() throws IOException, InterruptedException {
-
-        json = getJsonFromFile( new InputStreamReader( getClass().getClassLoader().getResourceAsStream( "sample_payload.json" ) ), postfix );
+        json = getJsonFromFile("sample_payload.json", postfix);
     }
     
     @Test

--- a/blueflood-http/src/test/resources/sample_multi_aggregated_payload_with_different_time.json
+++ b/blueflood-http/src/test/resources/sample_multi_aggregated_payload_with_different_time.json
@@ -1,0 +1,110 @@
+[
+    {
+        "tenantId":"5405532",
+        "timestamp":"%TIMESTAMP_1%",
+        "gauges":[
+            {
+                "name":"G200ms%POSTFIX%",
+                "value":145
+            }
+        ],
+        "counters":[
+            {
+                "name":"internal.bad_lines_seen%POSTFIX%",
+                "value":0,
+                "rate":0
+            }
+        ],
+        "timers":[
+            {
+                "name":"T1s%POSTFIX%","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+                "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
+                "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
+            }
+        ],
+        "sets":[
+            {
+                "name":"S500ms%POSTFIX%",
+                "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
+            }
+        ],
+        "enums": [
+            {
+                "name": "call_xyz_api%POSTFIX%",
+                "value": "OK"
+            }
+        ]
+    },
+    {
+        "tenantId":"5405577",
+        "timestamp":"%TIMESTAMP_2%",
+        "gauges":[
+            {
+                "name":"G200ms%POSTFIX%",
+                "value":145
+            }
+        ],
+        "counters":[
+            {
+                "name":"internal.bad_lines_seen%POSTFIX%",
+                "value":0,
+                "rate":0
+            }
+        ],
+        "timers":[
+            {
+                "name":"T1s%POSTFIX%","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+                "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
+                "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
+            }
+        ],
+        "sets":[
+            {
+                "name":"%POSTFIX%S500ms",
+                "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
+            }
+        ],
+        "enums": [
+            {
+                "name": "call_xyz_api%POSTFIX%",
+                "value": "OK"
+            }
+        ]
+    },
+    {
+        "tenantId":"1234567",
+        "timestamp":"%TIMESTAMP_3%",
+        "gauges":[
+            {
+                "name":"G200ms%POSTFIX%",
+                "value":145
+            }
+        ],
+        "counters":[
+            {
+                "name":"internal.bad_lines_seen%POSTFIX%",
+                "value":0,
+                "rate":0
+            }
+        ],
+        "timers":[
+            {
+                "name":"T1s%POSTFIX%","count":15,"rate":1,"min":43,"max":497,"sum":3865,"avg":257.6666666666667,"median":234,"std":149.02020742913433,
+                "percentiles":{"50":{"avg":134.5,"max":234,"sum":1076},"75":{"avg":188.63636363636363,"max":369,"sum":2075},"98":{"avg":257.6666666666667,"max":497,"sum":3865},"99":{"avg":257.6666666666667,"max":497,"sum":3865},"999":{"avg":321,"max":321,"sum":321}},
+                "histogram":{"bin_100":4,"bin_250":4,"bin_500":7,"bin_inf":0}
+            }
+        ],
+        "sets":[
+            {
+                "name":"S500ms%POSTFIX%",
+                "values":["cow","dog","cat","loris","narwhal","platypus","chicken","nutria","pangolin","horse"]
+            }
+        ],
+        "enums": [
+            {
+                "name": "call_xyz_api%POSTFIX%",
+                "value": "OK"
+            }
+        ]
+    }
+]

--- a/blueflood-http/src/test/resources/sample_multi_payload_with_different_time.json
+++ b/blueflood-http/src/test/resources/sample_multi_payload_with_different_time.json
@@ -1,0 +1,44 @@
+[
+    {
+        "tenantId": "%TENANT_ID_1%",
+        "collectionTime": "%TIMESTAMP_1%",
+        "ttlInSeconds": 172800,
+        "metricValue": 1,
+        "metricName": "multi.valid_metric_one%POSTFIX%"
+    },
+    {
+        "tenantId": "%TENANT_ID_2%",
+        "collectionTime": "%TIMESTAMP_1%",
+        "ttlInSeconds": 172800,
+        "metricValue": 2,
+        "metricName": "multi.valid_metric_two%POSTFIX%"
+    },
+    {
+        "tenantId": "%TENANT_ID_1%",
+        "collectionTime": "%TIMESTAMP_2%",
+        "ttlInSeconds": 172800,
+        "metricValue": 1,
+        "metricName": "multi.invalid_metric_one%POSTFIX%"
+    },
+    {
+        "tenantId": "%TENANT_ID_2%",
+        "collectionTime": "%TIMESTAMP_2%",
+        "ttlInSeconds": 172800,
+        "metricValue": 2,
+        "metricName": "multi.invalid_metric_two%POSTFIX%"
+    },
+    {
+        "tenantId": "%TENANT_ID_3%",
+        "collectionTime": "%TIMESTAMP_3%",
+        "ttlInSeconds": 172800,
+        "metricValue": 3,
+        "metricName": "multi.valid_metric_three%POSTFIX%"
+    },
+    {
+        "tenantId": "%TENANT_ID_3%",
+        "collectionTime": "%TIMESTAMP_3%",
+        "ttlInSeconds": 172800,
+        "metricValue": 3,
+        "metricName": "multi.invalid_metric_three%POSTFIX%"
+    }
+]


### PR DESCRIPTION
- WHAT
When handling mutliple metrics ingestion, return 207 (MULTI_STATUS) when partial errors are encountered; i.e. when some of the metrics failed validation.  Valid metrics should still be posted.  For now the response should be empty if 207 is returned.

Still return 200 for 100% valid payload and 400 for 100% invalid payload (along with validation error messages).

- HOW
Modify HttpMetricsIngestionHandler and JSONMetricsContainer to test for partial validation failures and return 207 after persisting the valid metrics.

- TEST
To test manually, modify the timestamp in the following post examples and POST to a blueflood ingest node.  Use http://www.epochconverter.com/ to obtain timestamp in seconds (and then multiple it by 1000 to convert it to ms for use in the payload).

```
# single metric
curl -i -X POST 'http://localhost:19000/v2.0/836986/ingest' -d \
  '[
      {
        "collectionTime": 1461873511000,
        "ttlInSeconds": 172800,
        "metricValue": 1,
        "metricName": "p3.metric.one"
      }
    ]'

# multi metrics
curl -i -X POST 'http://localhost:19000/v2.0/836986/ingest/multi' -d \
  '[
      {
        "tenantId": 836986,
        "collectionTime": 1461873511000,
        "ttlInSeconds": 172800,
        "metricValue": 2,
        "metricName": "p3.metric.two"
      },
      {
        "tenantId": 836986,
        "collectionTime": 1461873511000,
        "ttlInSeconds": 172800,
        "metricValue": 3,
        "metricName": "p3.metric.three"
      },
      {
        "tenantId": 836986,
        "collectionTime": 1461873511000,
        "ttlInSeconds": 172800,
        "metricValue": 4,
        "metricName": "p3.metric.four"
      }
    ]'

# aggregated single
curl -i -X POST 'http://localhost:19000/v2.0/836986/ingest/aggregated' -d \
  '{
    "tenantId":"836986",
    "timestamp":1462312693000,
    "flushInterval": 15000,
    "counters":[
        {
            "name":"internal.bad_lines_seen",
            "value":0,
            "rate":0
        },{
            "name":"internal.packets_received",
            "value":317,
            "rate":21.133333333333333
        },{
            "name":"new.C5s",
            "value":16,
            "rate":1
        }
    ],
    "gauges":[
        {
            "name":"836986.G200ms",
            "value":145
        },{
            "name":"836986.G1s",
            "value":397
        },{
            "name":"836986.G10s",
            "value":56
        },{
            "name":"internal.timestamp_lag",
            "value":0
        }
    ]
  }'

# aggregated multi
curl -i -X POST 'http://localhost:19000/v2.0/836986/ingest/aggregated/multi' -d \
  '[
  {
    "tenantId":"836986",
    "timestamp":14623126930,
    "flushInterval": 15000,
    "counters":[
        {
            "name":"ap1.counter.one",
            "value":1,
            "rate":0
        },{
            "name":"ap1.counter.two",
            "value":2,
            "rate":21.133333333333333
        },{
            "name":"ap1.counter.three",
            "value":3,
            "rate":1
        }
    ],
    "gauges":[
        {
            "name":"ap1.gauge.one",
            "value":100
        },{
            "name":"ap1.gauge.two",
            "value":200
        },{
            "name":"ap1.gauge.three",
            "value":300
        }
    ]
  },
  {
    "tenantId":"836986",
    "timestamp":1462312693000,
    "flushInterval": 15000,
    "counters":[
        {
            "name":"ap2.counter.one",
            "value":1,
            "rate":0
        },{
            "name":"ap2.counter.two",
            "value":2,
            "rate":21.133333333333333
        },{
            "name":"ap2.counter.three",
            "value":3,
            "rate":1
        }
    ],
    "gauges":[
        {
            "name":"ap2.gauge.one",
            "value":100
        },{
            "name":"ap2.gauge.two",
            "value":200
        },{
            "name":"ap2.gauge.three",
            "value":300
        }
    ]
  },
  {
    "tenantId":"836986",
    "timestamp":146231269300000,
    "flushInterval": 15000,
    "counters":[
        {
            "name":"ap3.counter.one",
            "value":1,
            "rate":0
        },{
            "name":"ap3.counter.two",
            "value":2,
            "rate":21.133333333333333
        },{
            "name":"ap3.counter.three",
            "value":3,
            "rate":1
        }
    ],
    "gauges":[
        {
            "name":"ap3.gauge.one",
            "value":100
        },{
            "name":"ap3.gauge.two",
            "value":200
        },{
            "name":"ap3.gauge.three",
            "value":300
        }
    ]
  }
  ]'
```
