### PR TITLE
Modify json parsing exceptions catching

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
@@ -19,7 +19,6 @@ package com.rackspacecloud.blueflood.inputs.formats;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.*;
-import org.codehaus.jackson.annotate.JsonIgnore;
 
 import java.util.*;
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
@@ -29,16 +29,13 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class JSONMetricsContainer {
-    private final String tenantId;
-    private final List<JSONMetric> jsonMetrics;
 
     private static final long TRACKER_DELAYED_METRICS_MILLIS = Configuration.getInstance().getLongProperty(CoreConfig.TRACKER_DELAYED_METRICS_MILLIS);
     private static final long MAX_AGE_ALLOWED = Configuration.getInstance().getLongProperty(CoreConfig.ROLLUP_DELAY_MILLIS);
     private static final long SHORT_DELAY = Configuration.getInstance().getLongProperty(CoreConfig.SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS);
 
-    private static final long pastDiff = Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
-    private static final long futureDiff = Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
-
+    private final String tenantId;
+    private final List<JSONMetric> jsonMetrics;
     private final List<Metric> metrics = new ArrayList<Metric>();
     private final List<Metric> delayedMetrics = new ArrayList<Metric>();
     private final List<String> errors = new ArrayList<String>();
@@ -55,6 +52,10 @@ public class JSONMetricsContainer {
 
     public List<Metric> getValidMetrics() {
         return metrics;
+    }
+
+    public List<JSONMetric> getJsonMetrics() {
+        return jsonMetrics;
     }
 
     private List<Metric> processJson() {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
@@ -112,16 +112,19 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
                 if (errors.isEmpty()) {
                     // no validation error, response OK
                     DefaultHandler.sendResponse(ctx, request, null, HttpResponseStatus.OK);
+                    return;
                 }
                 else {
                     // has some validation errors, response MULTI_STATUS
                     DefaultHandler.sendResponse(ctx, request, null, HttpResponseStatus.MULTI_STATUS);
+                    return;
                 }
 
             }
             else {
-                // no aggregated metric bundles in body
-                DefaultHandler.sendResponse( ctx, request, null, HttpResponseStatus.BAD_REQUEST );
+                // no aggregated metric bundles in body, response OK
+                DefaultHandler.sendResponse(ctx, request, null, HttpResponseStatus.OK);
+                return;
             }
         } catch (JsonParseException ex) {
             log.debug(String.format("BAD JSON: %s", body));


### PR DESCRIPTION
- WHAT
Modify response body message when empty json payload is received.  This functionality was modified when the 207 response code was introduced in the previous commits, which change the location of json parsing but not where the exception is caught.

- HOW
Since json processing is changed from previous JSONMetricsContainer.toMetrics() call to just process when the class is initialized (i.e. in the constructor), all json parsing and exceptions catching should have moved with it to the property try-catch location.  I did so by merging the two separated blocks into one, and checking if the jsonMetrics list isEmpty, which was previously inferred by the toMetrics() call during json parsing.