### PR TITLE
Fix intermittent errors with ROR tests

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/outputs/RollupHandlerIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/outputs/RollupHandlerIntegrationTest.java
@@ -64,6 +64,11 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
     private long startRollupMS = startMS + (1000 * 60 * 60 * (hours/2 - 5));
     private long endRollupMS = startMS + (1000 * 60 * 60 * (hours/2));
 
+    // max possible value for random generator of metric values
+    private final int MAX_METRIC_VALUE = 100;
+    // epsilon for assert of differences between mean of full points and mean of coarser granularity (rolled) points
+    private final double MEAN_EPSILON = 0.0025 * MAX_METRIC_VALUE;
+
     @Before
     public void initData() throws Exception {
 
@@ -106,7 +111,7 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
             for ( int i = 0; i < 60 * hours; i++ ) {
                 final long curMillis = startMS + i * 60000;
                 List<Metric> metrics = new ArrayList<Metric>();
-                metrics.add( getRandomIntMetricMaxValue( locator, curMillis, 100 ) );
+                metrics.add( getRandomIntMetricMaxValue( locator, curMillis, MAX_METRIC_VALUE ) );
                 writer.insertFull( metrics );
             }
         }
@@ -129,10 +134,10 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
         }
 
         // test value
-        double fullMean = fullPointsMean( metric, locator, startMS, endRollupMS );
+        double fullMean = fullPointsMean( metric, locator, Granularity.MIN_5.snapMillis(startMS), endRollupMS );
         double rollMean = meanOfPointCollectionRoll( points.values() );
 
-        Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
+        Assert.assertEquals( fullMean, rollMean, MEAN_EPSILON );
     }
 
     @Test
@@ -152,10 +157,10 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
         }
 
         // test value
-        double fullMean = fullPointsMean( metric, locator, startRollupMS, endMS );
+        double fullMean = fullPointsMean( metric, locator, Granularity.MIN_5.snapMillis(startRollupMS), endMS );
         double rollMean = meanOfPointCollectionRoll( points.values() );
 
-        Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
+        Assert.assertEquals( fullMean, rollMean, MEAN_EPSILON );
     }
 
     @Test
@@ -178,10 +183,10 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
         }
 
         // test value
-        double fullMean = fullPointsMean( metric, locator, start, endMS );
+        double fullMean = fullPointsMean( metric, locator, Granularity.MIN_5.snapMillis(start), endMS );
         double rollMean = meanOfPointCollectionRoll( points.values() );
 
-        Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
+        Assert.assertEquals( fullMean, rollMean, MEAN_EPSILON );
     }
 
     @Test
@@ -203,10 +208,10 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
             }
 
             // test value
-            double fullMean = fullPointsMean( metric, locator, startMS, endRollupMS );
+            double fullMean = fullPointsMean( metric, locator, Granularity.MIN_5.snapMillis(startMS), endRollupMS );
             double rollMean = meanOfPointCollectionRoll( points.values() );
 
-            Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
+            Assert.assertEquals( fullMean, rollMean, MEAN_EPSILON );
         }
     }
 
@@ -229,10 +234,10 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
             }
 
             // test value
-            double fullMean = fullPointsMean( metric, locator, startMS, endRollupMS );
+            double fullMean = fullPointsMean( metric, locator, Granularity.MIN_5.snapMillis(startRollupMS), endMS );
             double rollMean = meanOfPointCollectionRoll( points.values() );
 
-            Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
+            Assert.assertEquals( fullMean, rollMean, MEAN_EPSILON );
         }
     }
 
@@ -258,10 +263,10 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
             }
 
             // test value
-            double fullMean = fullPointsMean( metric, locator, start, endMS );
+            double fullMean = fullPointsMean( metric, locator, Granularity.MIN_5.snapMillis(start), endMS );
             double rollMean = meanOfPointCollectionRoll( points.values() );
 
-            Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
+            Assert.assertEquals( fullMean, rollMean, MEAN_EPSILON );
         }
     }
 
@@ -276,13 +281,13 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
     }
 
     private double meanOfPointCollectionRoll( Collection<Points.Point<BasicRollup>> fullPoints ) {
-        long sum = 0;
+        double sum = 0;
         for( Points.Point<BasicRollup> p : fullPoints ) {
 
             sum += p.getData().getAverage().toLong();
         }
 
-        return sum / fullPoints.size();
+        return sum / (double) fullPoints.size();
     }
 
     private double fullPointsMean( List<String> metric, Locator locator, long start, long end ) {
@@ -291,10 +296,5 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
                 .get( locator ).getData().getPoints().values();
         return meanOfPointCollectionFull( fullPoints );
     }
-
-    private double getEpsilon( double fullMean, double rollMean ) {
-        return Math.abs( Math.max(fullMean, rollMean) * .05 );
-    }
-
 
 }

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/outputs/RollupHandlerIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/outputs/RollupHandlerIntegrationTest.java
@@ -128,13 +128,11 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
             Assert.assertEquals( repairedRanges.next().getStart(), timestamp.longValue() );
         }
 
-        /* TODO:  Fix with CMD-1001
         // test value
         double fullMean = fullPointsMean( metric, locator, startMS, endRollupMS );
         double rollMean = meanOfPointCollectionRoll( points.values() );
 
         Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
-        */
     }
 
     @Test
@@ -153,13 +151,11 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
             Assert.assertEquals( repairedRanges.next().getStart(), timestamp.longValue() );
         }
 
-        /* TODO:  Fix with CMD-1001
         // test value
         double fullMean = fullPointsMean( metric, locator, startRollupMS, endMS );
         double rollMean = meanOfPointCollectionRoll( points.values() );
 
         Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
-        */
     }
 
     @Test
@@ -181,13 +177,11 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
             Assert.assertEquals(repairedRanges.next().getStart(), timestamp.longValue() );
         }
 
-        /* TODO:  Fix with CMD-1001
         // test value
         double fullMean = fullPointsMean( metric, locator, start, endMS );
         double rollMean = meanOfPointCollectionRoll( points.values() );
 
         Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
-        */
     }
 
     @Test
@@ -208,13 +202,11 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
                 Assert.assertEquals( repairedRanges.next().getStart(), timestamp.longValue() );
             }
 
-            /* TODO:  Fix with CMD-1001
             // test value
             double fullMean = fullPointsMean( metric, locator, startMS, endRollupMS );
             double rollMean = meanOfPointCollectionRoll( points.values() );
 
             Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
-            */
         }
     }
 
@@ -236,13 +228,11 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
                 Assert.assertEquals( repairedRanges.next().getStart(), timestamp.longValue() );
             }
 
-            /* TODO:  Fix with CMD-1001
             // test value
             double fullMean = fullPointsMean( metric, locator, startMS, endRollupMS );
             double rollMean = meanOfPointCollectionRoll( points.values() );
 
             Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
-            */
         }
     }
 
@@ -267,13 +257,11 @@ public class RollupHandlerIntegrationTest extends IntegrationTestBase {
                 Assert.assertEquals( repairedRanges.next().getStart(), timestamp.longValue() );
             }
 
-            /* TODO:  Fix with CMD-1001
             // test value
             double fullMean = fullPointsMean( metric, locator, start, endMS );
             double rollMean = meanOfPointCollectionRoll( points.values() );
 
             Assert.assertEquals( rollMean, fullMean, getEpsilon( fullMean, rollMean ) );
-            */
         }
     }
 


### PR DESCRIPTION
- WHAT

Uncomment and fix intermittent assert errors in RollupHandlerIntegrationTest.

- HOW
 * Fix bug with calculate full mean using long value sum and division, which were dropping of whole decimal places during calculation.

 * Fix bug in testMplotRollupsOnReadGenerationRight() using the wrong start value (should be ``startRollupMS`` instead of ``startMs``)

 * Modify all FULL datapoints query for mean calculation to assert with to use MIN_5. snapMillis to match the RollupHandler range calculation during rollup.  Data loss still present when mean is calculated during rollup.
