### PR TITLE
Docker graphite api

### DIFF
--- a/contrib/blueflood-docker/Dockerfile
+++ b/contrib/blueflood-docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 RUN apt-get install -y netcat
 RUN apt-get install -y python python-dev python-pip python-virtualenv && \
     rm -rf /var/lib/apt/lists/*
-RUN pip install cqlsh
+RUN pip install cqlsh==4.1.1
 
 ADD ./configs/ .
 

--- a/contrib/blueflood-docker/docker-compose.yml
+++ b/contrib/blueflood-docker/docker-compose.yml
@@ -30,5 +30,10 @@ elasticsearch:
 
 graphite-api:
   image: goru97/graphite-api
+  ports:
+        - "8888:8888"
   links:
     - blueflood:BLUEFLOOD
+  environment:
+    - TENANT_ID=123 # Give your Tenant Id Here
+    - GRAFANA_URLS=http://127.0.0.1:3000 #Comma seperated list of Grafana servers using graphite api

--- a/contrib/blueflood-docker/docker-compose.yml
+++ b/contrib/blueflood-docker/docker-compose.yml
@@ -31,4 +31,4 @@ elasticsearch:
 graphite-api:
   image: goru97/graphite-api
   links:
-    -blueflood:BLUEFLOOD
+    - blueflood:BLUEFLOOD

--- a/contrib/blueflood-docker/docker-compose.yml
+++ b/contrib/blueflood-docker/docker-compose.yml
@@ -1,5 +1,5 @@
 blueflood:
-  image: goru97/blueflood
+  image: rackerlabs/blueflood
   links:
     - cassandra
     - elasticsearch
@@ -29,7 +29,7 @@ elasticsearch:
 #Graphite-API Integration
 
 graphite-api:
-  image: goru97/graphite-api
+  image: rackerlabs/graphite-api
   ports:
         - "8888:8888"
   links:

--- a/contrib/blueflood-docker/docker-compose.yml
+++ b/contrib/blueflood-docker/docker-compose.yml
@@ -1,5 +1,5 @@
 blueflood:
-  build: .
+  image: goru97/blueflood
   links:
     - cassandra
     - elasticsearch
@@ -10,6 +10,10 @@ blueflood:
 
 cassandra:
   image: cassandra:2.1
+  ports:
+        - "9042:9042"
+        - "9160:9160"
+        - "7199:7199"
 
 cassandran:
   image: cassandra:2.1
@@ -21,3 +25,10 @@ cassandran:
 elasticsearch:
   image: elasticsearch:1.7
   command: elasticsearch -Des.cluster.name="blueflood"
+
+#Graphite-API Integration
+
+graphite-api:
+  image: goru97/graphite-api
+  links:
+    -blueflood:BLUEFLOOD


### PR DESCRIPTION
Adding graphite-api to docker-compose. 
This PR includes fixes done in https://github.com/rackerlabs/blueflood/pull/695