### PR TITLE
Delayed metrics part3

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/LocatorIOIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/LocatorIOIntegrationTest.java
@@ -7,11 +7,13 @@ import com.rackspacecloud.blueflood.utils.Util;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class LocatorIOIntegrationTest extends IntegrationTestBase {
 
@@ -38,11 +40,13 @@ public class LocatorIOIntegrationTest extends IntegrationTestBase {
         Collection<Locator> locatorsResult1 = astyanaxLocatorIO.getLocators(shard1);
         assertEquals("Unexpected number of locators result for shard1", 1, locatorsResult1.size());
         assertEquals("test locator(0) not equal", testLocators.get(0).toString(), locatorsResult1.toArray()[0].toString());
+        assertTrue("last update stamp should have value", new ArrayList<Locator>(locatorsResult1).get(0).getLastUpdatedTimestamp() > 0);
 
         long shard2 = (long) Util.getShard(testLocators.get(1).toString());
         Collection<Locator> locatorsResult2 = astyanaxLocatorIO.getLocators(shard2);
         assertEquals("Unexpected number of locators result for shard2", 1, locatorsResult2.size());
         assertEquals("test locator(1) not equal", testLocators.get(1).toString(), locatorsResult2.toArray()[0].toString());
+        assertTrue("last update stamp should have value", new ArrayList<Locator>(locatorsResult2).get(0).getLastUpdatedTimestamp() > 0);
 
         // assert invalid shard should return empty collection using datastax
         assertEquals("locators should be empty", astyanaxLocatorIO.getLocators(-1), Collections.emptySet());
@@ -60,11 +64,13 @@ public class LocatorIOIntegrationTest extends IntegrationTestBase {
         Collection<Locator> locatorsResult1 = datastaxLocatorIO.getLocators(shard1);
         assertEquals("Unexpected number of locators result for shard1", 1, locatorsResult1.size());
         assertEquals("test locator(2) not equal", testLocators.get(2).toString(), locatorsResult1.toArray()[0].toString());
+        assertTrue("last update stamp should have value", new ArrayList<Locator>(locatorsResult1).get(0).getLastUpdatedTimestamp() > 0);
 
         long shard2 = (long) Util.getShard(testLocators.get(3).toString());
         Collection<Locator> locatorsResult2 = datastaxLocatorIO.getLocators(shard2);
         assertEquals("Unexpected number of locators result for shard2", 1, locatorsResult2.size());
         assertEquals("test locator(3) not equal", testLocators.get(3).toString(), locatorsResult2.toArray()[0].toString());
+        assertTrue("last update stamp should have value", new ArrayList<Locator>(locatorsResult2).get(0).getLastUpdatedTimestamp() > 0);
 
         // assert invalid shard should return empty collection using datastax
         assertEquals("locators should be empty", datastaxLocatorIO.getLocators(-1), Collections.emptySet());

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AbstractMetricsRW.java
@@ -62,7 +62,7 @@ public abstract class AbstractMetricsRW implements MetricsRW {
 
     private final Clock clock;
 
-    public AbstractMetricsRW(Clock clock) {
+    protected AbstractMetricsRW(Clock clock) {
         this.clock = clock;
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
@@ -46,6 +46,9 @@ public class Instrumentation implements InstrumentationMBean {
     private static final Meter metricsWithShortDelayReceived;
     private static final Meter metricsWithLongDelayReceived;
     private static final Meter enumMetricWritten;
+    private static final Meter locatorRolled;
+    private static final Meter locatorReRolled;
+
 
     static {
         Class kls = Instrumentation.class;
@@ -60,6 +63,8 @@ public class Instrumentation implements InstrumentationMBean {
         enumMetricWritten = Metrics.meter( kls, "Enum Metrics Written" );
         metricsWithShortDelayReceived = Metrics.meter(kls, "Metrics with short delay received");
         metricsWithLongDelayReceived = Metrics.meter(kls, "Metrics with long delay received");
+        locatorRolled = Metrics.meter(kls, "Locators rolled during initial rollup of a slot");
+        locatorReRolled = Metrics.meter(kls, "Locators rolled during re-roll of a slot");
 
             try {
                 final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
@@ -180,5 +185,13 @@ public class Instrumentation implements InstrumentationMBean {
 
     public static void markMetricsWithLongDelayReceived() {
         metricsWithLongDelayReceived.mark();
+    }
+
+    public static void markLocatorRolled() {
+        locatorRolled.mark();
+    }
+
+    public static void markLocatorReRolled() {
+        locatorReRolled.mark();
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/ABasicMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/ABasicMetricsRW.java
@@ -3,10 +3,13 @@ package com.rackspacecloud.blueflood.io.astyanax;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.rackspacecloud.blueflood.io.AbstractMetricsRW;
 import com.rackspacecloud.blueflood.io.CassandraModel;
+import com.rackspacecloud.blueflood.io.LocatorIO;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.SingleRollupWriteContext;
 import com.rackspacecloud.blueflood.types.*;
+import com.rackspacecloud.blueflood.utils.Clock;
+import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -18,6 +21,14 @@ import java.util.Map;
  * using Astyanax driver
  */
 public class ABasicMetricsRW extends AbstractMetricsRW {
+
+    public ABasicMetricsRW() {
+        this(new DefaultClockImpl());
+    }
+
+    public ABasicMetricsRW(Clock clock) {
+        super(clock);
+    }
 
     @Override
     public void insertMetrics( Collection<IMetric> metrics ) throws IOException {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/APreaggregatedMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/APreaggregatedMetricsRW.java
@@ -25,6 +25,8 @@ import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.SingleRollupWriteContext;
 import com.rackspacecloud.blueflood.types.*;
+import com.rackspacecloud.blueflood.utils.Clock;
+import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -36,6 +38,14 @@ import java.util.Map;
  * using Astyanax driver
  */
 public class APreaggregatedMetricsRW extends AbstractMetricsRW implements PreaggregatedRW{
+
+    public APreaggregatedMetricsRW() {
+        this(new DefaultClockImpl());
+    }
+
+    public APreaggregatedMetricsRW(Clock clock) {
+        super(clock);
+    }
 
     /**
      * Inserts a collection of metrics to the metrics_preaggregated_full column family

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxLocatorIO.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class uses the Astyanax driver to read/write locators from
@@ -79,7 +80,8 @@ public class AstyanaxLocatorIO implements LocatorIO {
 
             ColumnList<Locator> columns = query.execute().getResult();
             for (Column<Locator> column: columns) {
-                locators.add(column.getName().withLastUpdatedTimestamp(column.getTimestamp() / 1000));
+                locators.add(column.getName()
+                        .withLastUpdatedTimestamp(TimeUnit.MILLISECONDS.convert(column.getTimestamp(), TimeUnit.MICROSECONDS)));
             }
 
             if (locators.size() == 0) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxShardStateIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxShardStateIO.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class uses the Astyanax driver to read/write ShardState from
@@ -55,7 +56,7 @@ public class AstyanaxShardStateIO implements ShardStateIO {
             for (Column<SlotState> column : columns) {
                 slotStates.add(column.getName()
                                  .withTimestamp(column.getLongValue())
-                                 .withLastUpdatedTimestamp(column.getTimestamp() / 1000)); //write time is in micro seconds
+                                 .withLastUpdatedTimestamp(TimeUnit.MILLISECONDS.convert(column.getTimestamp(), TimeUnit.MICROSECONDS)));
             }
         } catch (ConnectionException e) {
             Instrumentation.markReadError(e);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
@@ -25,6 +25,7 @@ import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.*;
+import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.*;
 import org.slf4j.Logger;
@@ -48,7 +49,7 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
     private final DTimerIO timerIO = new DTimerIO();
     private final LocatorIO locatorIO;
 
-    private final boolean IS_REROLL_ONLY_DELAYED_METRICS = com.rackspacecloud.blueflood.service.Configuration.getInstance().getBooleanProperty(CoreConfig.REROLL_ONLY_DELAYED_METRICS);
+    private final boolean IS_REROLL_ONLY_DELAYED_METRICS = Configuration.getInstance().getBooleanProperty(CoreConfig.REROLL_ONLY_DELAYED_METRICS);
 
     // a map of RollupType to its IO class that knows
     // how to read/write that particular type of rollup

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
@@ -24,7 +24,9 @@ import com.rackspacecloud.blueflood.exceptions.InvalidDataException;
 import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
+import com.rackspacecloud.blueflood.service.*;
 import com.rackspacecloud.blueflood.types.*;
+import com.rackspacecloud.blueflood.utils.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +46,9 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
     private final DGagueIO gaugeIO = new DGagueIO();
     private final DSetIO setIO = new DSetIO();
     private final DTimerIO timerIO = new DTimerIO();
-    private final LocatorIO locatorIO = IOContainer.fromConfig().getLocatorIO();
+    private final LocatorIO locatorIO;
+
+    private final boolean IS_REROLL_ONLY_DELAYED_METRICS = com.rackspacecloud.blueflood.service.Configuration.getInstance().getBooleanProperty(CoreConfig.REROLL_ONLY_DELAYED_METRICS);
 
     // a map of RollupType to its IO class that knows
     // how to read/write that particular type of rollup
@@ -56,6 +60,15 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
                 put(RollupType.SET, setIO);
                 put(RollupType.TIMER, timerIO);
             }};
+
+    public DPreaggregatedMetricsRW() {
+        this(new DefaultClockImpl());
+    }
+
+    public DPreaggregatedMetricsRW(Clock clock) {
+        super(clock);
+        this.locatorIO = IOContainer.fromConfig().getLocatorIO();
+    }
 
 
     /**
@@ -109,7 +122,11 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
                             granularity, metric.getTtlInSeconds());
                     futureLocatorMap.put(future, locator);
 
-                    if ( !isLocatorCurrent(locator) ) {
+                    // always insert delayed metrics
+                    if (IS_REROLL_ONLY_DELAYED_METRICS && isDelayedMetric(metric)) {
+                        locatorIO.insertLocator(locator);
+                        setLocatorCurrent(locator);
+                    } else if ( !isLocatorCurrent(locator) ) {
                         locatorIO.insertLocator(locator);
                         setLocatorCurrent(locator);
                     }  else {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DShardStateIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DShardStateIO.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
@@ -102,7 +103,7 @@ public class DShardStateIO implements ShardStateIO {
                 }
                 SlotState state = serDes.deserialize(row.getString( COLUMN1 ));
                 state.withTimestamp(row.getLong( VALUE ))
-                     .withLastUpdatedTimestamp(row.getLong( WRITE_TIME ) / 1000); //write time is in micro seconds
+                     .withLastUpdatedTimestamp(TimeUnit.MILLISECONDS.convert(row.getLong(WRITE_TIME), TimeUnit.MICROSECONDS));
                 slotStates.add(state);
             }
             return slotStates;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxLocatorIO.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
@@ -134,7 +135,7 @@ public class DatastaxLocatorIO implements LocatorIO {
                             row.getString( COLUMN1 ));
                 }
                 locators.add(Locator.createLocatorFromDbKey(row.getString(COLUMN1))
-                                    .withLastUpdatedTimestamp(row.getLong( WRITE_TIME ) / 1000));
+                                    .withLastUpdatedTimestamp(TimeUnit.MILLISECONDS.convert(row.getLong(WRITE_TIME), TimeUnit.MICROSECONDS)));
             }
 
             // return results

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxLocatorIO.java
@@ -50,6 +50,7 @@ public class DatastaxLocatorIO implements LocatorIO {
     private static final String KEY = "key";
     private static final String COLUMN1 = "column1";
     private static final String VALUE = "value";
+    public static final String WRITE_TIME = "writetime(value)";
 
     private PreparedStatement getValue;
     private PreparedStatement putValue;
@@ -66,7 +67,10 @@ public class DatastaxLocatorIO implements LocatorIO {
         // create a generic select statement for retrieving from metrics_locator
         Select.Where select = QueryBuilder
                 .select()
-                .all()
+                .column( KEY )
+                .column( COLUMN1 )
+                .column(VALUE)
+                .writeTime(VALUE)
                 .from( CassandraModel.CF_METRICS_LOCATOR_NAME )
                 .where( eq ( KEY, bindMarker() ));
         getValue = DatastaxIO.getSession().prepare( select );
@@ -129,7 +133,8 @@ public class DatastaxLocatorIO implements LocatorIO {
                             row.getString( KEY ) +
                             row.getString( COLUMN1 ));
                 }
-                locators.add(Locator.createLocatorFromDbKey(row.getString(COLUMN1)));
+                locators.add(Locator.createLocatorFromDbKey(row.getString(COLUMN1))
+                                    .withLastUpdatedTimestamp(row.getLong( WRITE_TIME ) / 1000));
             }
 
             // return results

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/serializers/json/IMetricSerializer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/serializers/json/IMetricSerializer.java
@@ -113,7 +113,7 @@ public class IMetricSerializer {
     @JsonIgnoreProperties({ "ttl", "value", "type", "rollupType" })
     abstract class PreaggMetricMixin { }
 
-    @JsonIgnoreProperties({ "stringRep" })
+    @JsonIgnoreProperties({ "stringRep", "lastUpdatedTimestamp" })
     abstract class LocatorMixin { }
 
     @JsonPropertyOrder(alphabetic=true)

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -154,6 +154,8 @@ public enum CoreConfig implements ConfigDefaults {
     TENANTIDS_TO_KEEP(""),
     TRACKER_DELAYED_METRICS_MILLIS("300000"),
 
+    REROLL_ONLY_DELAYED_METRICS("true"),
+
     USE_ES_FOR_UNITS("false"),
     // Should at least be equal to the number of the netty worker threads, if http module is getting loaded
     ES_UNIT_THREADS("50"),

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -121,6 +121,7 @@ class LocatorFetchRunnable implements Runnable {
                 Instrumentation.markLocatorRolled();
             }
         }
+        log.debug("For slotKey {}, number of locator's that were rolled up are {}", parentSlotKey, rollCount);
 
         // now wait until ctx is drained. someone needs to be notified.
         drainExecutionContext(waitStart, rollCount, executionContext, rollupBatchWriter);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -120,7 +120,7 @@ class LocatorFetchRunnable implements Runnable {
                 rollCount = processLocator(rollCount, executionContext, rollupBatchWriter, locator, isSlotBeingRerolled);
             }
         }
-        log.debug("For slotKey {}, number of locator's that were rolled up are {} out of {}", new Object[]{parentSlotKey, rollCount, locators.size()});
+        log.debug("For slotKey {} [isReroll={}], number of locator's that were rolled up are {} out of {}", new Object[]{parentSlotKey, isSlotBeingRerolled, rollCount, locators.size()});
 
         // now wait until ctx is drained. someone needs to be notified.
         drainExecutionContext(waitStart, rollCount, executionContext, rollupBatchWriter);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -19,6 +19,7 @@ package com.rackspacecloud.blueflood.service;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.rackspacecloud.blueflood.io.IOContainer;
+import com.rackspacecloud.blueflood.io.Instrumentation;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.rollup.SlotKey;
 import com.rackspacecloud.blueflood.types.Locator;
@@ -30,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
@@ -50,6 +50,8 @@ class LocatorFetchRunnable implements Runnable {
     private static final Timer rollupLocatorExecuteTimer = Metrics.timer(RollupService.class, "Locate and Schedule Rollups for Slot");
 
     private Range parentRange;
+
+    private final boolean IS_REROLL_ONLY_DELAYED_METRICS = Configuration.getInstance().getBooleanProperty(CoreConfig.REROLL_ONLY_DELAYED_METRICS);
 
     LocatorFetchRunnable(ScheduleContext scheduleCtx,
                          SlotKey destSlotKey,
@@ -102,10 +104,24 @@ class LocatorFetchRunnable implements Runnable {
 
         Set<Locator> locators = getLocators(executionContext);
 
+        boolean isSlotBeingRerolled = scheduleCtx.isReroll(parentSlotKey);
         for (Locator locator : locators) {
-            rollCount = processLocator(rollCount, executionContext, rollupBatchWriter, locator);
+
+            //if slot is being re-rolled, only process locator if locator's lastUpdateTimestamp is after last rollup time
+            if (IS_REROLL_ONLY_DELAYED_METRICS &&
+                    isSlotBeingRerolled) {
+
+                UpdateStamp updateStamp = scheduleCtx.getShardStateManager().getUpdateStamp(parentSlotKey);
+                if (locator.getLastUpdatedTimestamp() > updateStamp.getLastRollupTimestamp()) {
+                    rollCount = processLocator(rollCount, executionContext, rollupBatchWriter, locator, true);
+                }
+
+            } else {
+                rollCount = processLocator(rollCount, executionContext, rollupBatchWriter, locator, isSlotBeingRerolled);
+                Instrumentation.markLocatorRolled();
+            }
         }
-        
+
         // now wait until ctx is drained. someone needs to be notified.
         drainExecutionContext(waitStart, rollCount, executionContext, rollupBatchWriter);
 
@@ -156,7 +172,21 @@ class LocatorFetchRunnable implements Runnable {
         }
     }
 
-    public int processLocator(int rollCount, RollupExecutionContext executionContext, RollupBatchWriter rollupBatchWriter, Locator locator) {
+    public int processLocator(int rollCount, RollupExecutionContext executionContext,
+                              RollupBatchWriter rollupBatchWriter, Locator locator, boolean isSlotBeingRerolled) {
+
+        if (isSlotBeingRerolled) {
+            Instrumentation.markLocatorReRolled();
+        } else {
+            Instrumentation.markLocatorRolled();
+        }
+
+        return processLocator(rollCount, executionContext, rollupBatchWriter, locator);
+    }
+
+    public int processLocator(int rollCount, RollupExecutionContext executionContext,
+                              RollupBatchWriter rollupBatchWriter, Locator locator) {
+
         if (log.isTraceEnabled())
             log.trace("Rolling up (check,metric,dimension) {} for (gran,slot,shard) {}", locator, parentSlotKey);
         try {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -118,7 +118,6 @@ class LocatorFetchRunnable implements Runnable {
 
             } else {
                 rollCount = processLocator(rollCount, executionContext, rollupBatchWriter, locator, isSlotBeingRerolled);
-                Instrumentation.markLocatorRolled();
             }
         }
         log.debug("For slotKey {}, number of locator's that were rolled up are {}", parentSlotKey, rollCount);
@@ -185,7 +184,7 @@ class LocatorFetchRunnable implements Runnable {
         return processLocator(rollCount, executionContext, rollupBatchWriter, locator);
     }
 
-    public int processLocator(int rollCount, RollupExecutionContext executionContext,
+    protected int processLocator(int rollCount, RollupExecutionContext executionContext,
                               RollupBatchWriter rollupBatchWriter, Locator locator) {
 
         if (log.isTraceEnabled())

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -120,7 +120,7 @@ class LocatorFetchRunnable implements Runnable {
                 rollCount = processLocator(rollCount, executionContext, rollupBatchWriter, locator, isSlotBeingRerolled);
             }
         }
-        log.debug("For slotKey {}, number of locator's that were rolled up are {}", parentSlotKey, rollCount);
+        log.debug("For slotKey {}, number of locator's that were rolled up are {} out of {}", new Object[]{parentSlotKey, rollCount, locators.size()});
 
         // now wait until ctx is drained. someone needs to be notified.
         drainExecutionContext(waitStart, rollCount, executionContext, rollupBatchWriter);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ScheduleContext.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ScheduleContext.java
@@ -256,6 +256,11 @@ public class ScheduleContext implements IngestionContext, ScheduleContextMBean {
         }
     }
 
+    boolean isReroll(SlotKey slotKey) {
+        return shardStateManager.getSlotStateManager(slotKey.getShard(), slotKey.getGranularity())
+                .isReroll(slotKey.getSlot(), scheduleTime);
+    }
+
     boolean areChildKeysOrSelfKeyScheduledOrRunning(SlotKey slotKey) {
         // if any ineligible (children and self) keys are running or scheduled to run, we shouldn't work on this.
         Collection<SlotKey> ineligibleKeys = slotKey.getChildrenKeys();

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Locator.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Locator.java
@@ -30,6 +30,8 @@ public class Locator implements Comparable<Locator> {
     private String tenantId = null;
     private String metricName = null;
 
+    private long lastUpdatedTimestamp;
+
     static {
         metricTokenSeparator = (Configuration.getInstance().getBooleanProperty(CoreConfig.USE_LEGACY_METRIC_SEPARATOR) ? "," : ".");
         // ugh.
@@ -45,6 +47,11 @@ public class Locator implements Comparable<Locator> {
 
     private Locator(String fullyQualifiedMetricName) throws IllegalArgumentException {
         setStringRep(fullyQualifiedMetricName);
+    }
+
+    public Locator withLastUpdatedTimestamp(long lastUpdatedTimestamp) {
+        this.lastUpdatedTimestamp = lastUpdatedTimestamp;
+        return this;
     }
 
     protected void setStringRep(String rep) throws IllegalArgumentException {
@@ -78,6 +85,10 @@ public class Locator implements Comparable<Locator> {
 
     public String getMetricName() {
         return this.metricName;
+    }
+
+    public long getLastUpdatedTimestamp() {
+        return lastUpdatedTimestamp;
     }
 
     public boolean equals(Locator other) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Locator.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Locator.java
@@ -30,6 +30,7 @@ public class Locator implements Comparable<Locator> {
     private String tenantId = null;
     private String metricName = null;
 
+    //Last update timestamp in millis.
     private long lastUpdatedTimestamp;
 
     static {

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRWTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRWTest.java
@@ -1,0 +1,113 @@
+package com.rackspacecloud.blueflood.io.datastax;
+
+import com.rackspacecloud.blueflood.io.LocatorIO;
+import com.rackspacecloud.blueflood.io.MetricsRW;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.types.IMetric;
+import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.types.Metric;
+import com.rackspacecloud.blueflood.utils.Clock;
+import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
+import com.rackspacecloud.blueflood.utils.TimeValue;
+import org.joda.time.Instant;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+public class DBasicMetricsRWTest {
+
+    @Test
+    public void testIsDelayedMetric() {
+
+        final Instant currentTime = new DefaultClockImpl().now();
+        final long collectionTime = currentTime.getMillis() - 5;
+        final Metric metric = createTestMetric(collectionTime);
+
+        final Clock mockClock = mock(Clock.class);
+        DBasicMetricsRW dbasicMetricsRW = new DBasicMetricsRW(mockClock);
+
+        when(mockClock.now()).thenReturn(currentTime);
+        assertEquals("Should not be a delayed metric", false, dbasicMetricsRW.isDelayedMetric(metric));
+
+        //setting current time in future
+        final Instant futureTime = new Instant(currentTime.getMillis() +
+                Configuration.getInstance().getLongProperty(CoreConfig.ROLLUP_DELAY_MILLIS) + 1);
+
+        when(mockClock.now()).thenReturn(futureTime);
+        assertEquals("Should be a delayed metric", true, dbasicMetricsRW.isDelayedMetric(metric));
+    }
+
+    @Test
+    public void testInsertMetricsLocatorCache() throws IOException {
+
+        final Instant currentTime = new DefaultClockImpl().now();
+        final long collectionTime = currentTime.getMillis() - 5;
+        final Metric metric = createTestMetric(collectionTime);
+
+        final Clock mockClock = mock(Clock.class);
+        LocatorIO mockLocatorIO = mock(LocatorIO.class);
+        MetricsRW metricsRW = new DBasicMetricsRW(mockClock, mockLocatorIO);
+
+        when(mockClock.now()).thenReturn(currentTime);
+        doNothing().when(mockLocatorIO).insertLocator(any(Locator.class));
+
+        //inserting a locator 3 times
+        for (int i = 0; i < 3 ; i ++) {
+            metricsRW.insertMetrics(new ArrayList<IMetric>() {{
+                add(metric);
+            }});
+        }
+
+        //Should insert locator only once
+        verify(mockLocatorIO, times(1)).insertLocator(any(Locator.class));
+    }
+
+    @Test
+    public void testInsertMetricsForDelayedMetrics() throws IOException {
+
+        final Instant currentTime = new DefaultClockImpl().now();
+        final long collectionTime = currentTime.getMillis() - 5;
+        final Metric metric = createTestMetric(collectionTime);
+
+        final Clock mockClock = mock(Clock.class);
+        LocatorIO mockLocatorIO = mock(LocatorIO.class);
+        MetricsRW metricsRW = new DBasicMetricsRW(mockClock, mockLocatorIO);
+
+        when(mockClock.now()).thenReturn(currentTime);
+        doNothing().when(mockLocatorIO).insertLocator(any(Locator.class));
+
+        metricsRW.insertMetrics(new ArrayList<IMetric>() {{
+            add(metric);
+        }});
+
+        //setting current time in future
+        final Instant futureTime = new Instant(currentTime.getMillis() +
+                Configuration.getInstance().getLongProperty(CoreConfig.ROLLUP_DELAY_MILLIS) + 1);
+
+        when(mockClock.now()).thenReturn(futureTime);
+
+        //inserting a locator 3 times
+        for (int i = 0; i < 3 ; i ++) {
+            metricsRW.insertMetrics(new ArrayList<IMetric>() {{
+                add(metric);
+            }});
+        }
+
+        //Should insert locator only once
+        verify(mockLocatorIO, times(4)).insertLocator(any(Locator.class));
+    }
+
+    private Metric createTestMetric(long collectionTime) {
+        Locator locator = Locator.createLocatorFromPathComponents("99999",
+                DBasicMetricsRWTest.class.getName() + ".numeric.metric." + System.currentTimeMillis());
+        return new Metric( locator, 1, collectionTime, new TimeValue(1, TimeUnit.DAYS), "unit");
+    }
+}

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnableRunTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnableRunTest.java
@@ -120,6 +120,7 @@ public class LocatorFetchRunnableRunTest {
         verifyZeroInteractions(executionContext);
         verifyZeroInteractions(rollupBatchWriter);
         verify(scheduleCtx).getCurrentTimeMillis();
+        verify(scheduleCtx).isReroll(Matchers.<SlotKey>any());
         verifyNoMoreInteractions(scheduleCtx);
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
@@ -140,7 +141,8 @@ public class LocatorFetchRunnableRunTest {
         verify(lfr, never()).processLocator(anyInt(),
                 Matchers.<RollupExecutionContext>any(),
                 Matchers.<RollupBatchWriter>any(),
-                Matchers.<Locator>any());
+                Matchers.<Locator>any(),
+                Matchers.anyBoolean());
 
         verify(lfr).drainExecutionContext(anyLong(), anyInt(),
                 Matchers.<RollupExecutionContext>any(),
@@ -165,6 +167,7 @@ public class LocatorFetchRunnableRunTest {
         verifyZeroInteractions(executionContext);
         verifyZeroInteractions(rollupBatchWriter);
         verify(scheduleCtx).getCurrentTimeMillis();
+        verify(scheduleCtx).isReroll(Matchers.<SlotKey>any());
         verifyNoMoreInteractions(scheduleCtx);
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
@@ -185,7 +188,8 @@ public class LocatorFetchRunnableRunTest {
         verify(lfr, times(1)).processLocator(anyInt(),
                 Matchers.<RollupExecutionContext>any(),
                 Matchers.<RollupBatchWriter>any(),
-                Matchers.<Locator>any());
+                Matchers.<Locator>any(),
+                Matchers.anyBoolean());
 
         verify(lfr).drainExecutionContext(anyLong(), anyInt(),
                 Matchers.<RollupExecutionContext>any(),
@@ -210,6 +214,7 @@ public class LocatorFetchRunnableRunTest {
         verifyZeroInteractions(executionContext);
         verifyZeroInteractions(rollupBatchWriter);
         verify(scheduleCtx).getCurrentTimeMillis();
+        verify(scheduleCtx).isReroll(Matchers.<SlotKey>any());
         verifyNoMoreInteractions(scheduleCtx);
         verifyZeroInteractions(rollupReadExecutor);
         verifyZeroInteractions(rollupWriteExecutor);
@@ -230,7 +235,8 @@ public class LocatorFetchRunnableRunTest {
         verify(lfr, times(3)).processLocator(anyInt(),
                 Matchers.<RollupExecutionContext>any(),
                 Matchers.<RollupBatchWriter>any(),
-                Matchers.<Locator>any());
+                Matchers.<Locator>any(),
+                Matchers.anyBoolean());
 
         verify(lfr).drainExecutionContext(anyLong(), anyInt(),
                 Matchers.<RollupExecutionContext>any(),

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ScheduleContextTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ScheduleContextTest.java
@@ -573,8 +573,11 @@ public class ScheduleContextTest {
         ctx.scheduleEligibleSlots(ROLLUP_DELAY_MILLIS, SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS, LONG_DELAY_METRICS_ROLLUP_WAIT_MILLIS);
 
         expected.add(SlotKey.parse("metrics_5m,0,0"));
-        while (ctx.hasScheduled())
-            scheduled.add(ctx.getNextScheduled());
+        while (ctx.hasScheduled()) {
+            SlotKey scheduledSlot = ctx.getNextScheduled();
+            scheduled.add(scheduledSlot);
+            Assert.assertEquals(false, ctx.isReroll(scheduledSlot));
+        }
         Assert.assertEquals(expected, scheduled);
 
         long lastRollupTime = clock;
@@ -606,8 +609,11 @@ public class ScheduleContextTest {
         ctx.setCurrentTimeMillis(clock);
         ctx.scheduleEligibleSlots(ROLLUP_DELAY_MILLIS, SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS, LONG_DELAY_METRICS_ROLLUP_WAIT_MILLIS);
 
-        while (ctx.hasScheduled())
-            scheduled.add(ctx.getNextScheduled());
+        while (ctx.hasScheduled()) {
+            SlotKey scheduledSlot = ctx.getNextScheduled();
+            scheduled.add(scheduledSlot);
+            Assert.assertEquals(true, ctx.isReroll(scheduledSlot));
+        }
 
         Assert.assertEquals(expected, scheduled);
         ctx.clearFromRunning(SlotKey.parse("metrics_5m,0,0")); //metrics_5m,0 is now rolled up.
@@ -637,8 +643,11 @@ public class ScheduleContextTest {
         ctx.setCurrentTimeMillis(clock);
         ctx.scheduleEligibleSlots(ROLLUP_DELAY_MILLIS, SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS, LONG_DELAY_METRICS_ROLLUP_WAIT_MILLIS);
 
-        while (ctx.hasScheduled())
-            scheduled.add(ctx.getNextScheduled());
+        while (ctx.hasScheduled()) {
+            SlotKey scheduledSlot = ctx.getNextScheduled();
+            scheduled.add(scheduledSlot);
+            Assert.assertEquals(true, ctx.isReroll(scheduledSlot));
+        }
 
         Assert.assertEquals(expected, scheduled);
         ctx.clearFromRunning(SlotKey.parse("metrics_5m,0,0")); //metrics_5m,0 is now rolled up.
@@ -671,8 +680,11 @@ public class ScheduleContextTest {
         ctx.scheduleEligibleSlots(ROLLUP_DELAY_MILLIS, SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS, LONG_DELAY_METRICS_ROLLUP_WAIT_MILLIS);
 
         expected.add(SlotKey.parse("metrics_5m,0,0"));
-        while (ctx.hasScheduled())
-            scheduled.add(ctx.getNextScheduled());
+        while (ctx.hasScheduled()) {
+            SlotKey scheduledSlot = ctx.getNextScheduled();
+            scheduled.add(scheduledSlot);
+            Assert.assertEquals(false, ctx.isReroll(scheduledSlot));
+        }
         Assert.assertEquals(expected, scheduled);
 
         long lastRollupTime = clock;
@@ -704,8 +716,11 @@ public class ScheduleContextTest {
         ctx.setCurrentTimeMillis(clock);
         ctx.scheduleEligibleSlots(ROLLUP_DELAY_MILLIS, SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS, LONG_DELAY_METRICS_ROLLUP_WAIT_MILLIS);
 
-        while (ctx.hasScheduled())
-            scheduled.add(ctx.getNextScheduled());
+        while (ctx.hasScheduled()) {
+            SlotKey scheduledSlot = ctx.getNextScheduled();
+            scheduled.add(scheduledSlot);
+            Assert.assertEquals(true, ctx.isReroll(scheduledSlot));
+        }
 
         Assert.assertEquals(expected, scheduled);
         ctx.clearFromRunning(SlotKey.parse("metrics_5m,0,0")); //metrics_5m,0 is now rolled up.

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ShardStateManagerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/ShardStateManagerTest.java
@@ -611,6 +611,7 @@ public class ShardStateManagerTest {
         slotStateManager.createOrUpdateForSlotAndMillisecond(0, 1234L);
         List<Integer> slots1 = slotStateManager.getSlotsEligibleForRollup(5235L, 0, 2000, 1000);
         assertTrue("No slots should be returned", slots1.isEmpty());
+        assertEquals("Slot 0 should be identified as re-roll", true, slotStateManager.isReroll(0, 5235L));
 
         //when
         List<Integer> slots2 = slotStateManager.getSlotsEligibleForRollup(6235L, 0, 2000, 1000);


### PR DESCRIPTION
Separate rollup of delayed metrics - part 3
* Added new config parameter to decide if we want to re-roll entire slot for delayed metrics or only the delayed ones.
* Changes to astyanax/datastax RW's to update locator with its last update time stamp when reading from metrics_locator table.
* Update metrics_locator with the locator all the time if it is a delayed metric. If not, update only if its not present in the cache like we do today.
* Instead of re-rolling the entire slot when we get delayed metrics, we only re-roll the ones that were delayed.
* Added instrumentation to visualize locators that are being rolled/re-rolled.