### PR TITLE
Added configuration for storing units

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AbstractMetricsRW.java
@@ -104,23 +104,6 @@ public abstract class AbstractMetricsRW implements MetricsRW {
         return DataType.NUMERIC;
     }
 
-    // TODO: can this move to MetadataCache?
-    protected String getUnitString(Locator locator) {
-        String unitString = Util.UNKNOWN;
-        // Only grab units from cassandra, if we have to
-        if (!Util.shouldUseESForUnits()) {
-            try {
-                unitString = metadataCache.get(locator, MetricMetadata.UNIT.name().toLowerCase(), String.class);
-            } catch (CacheException ex) {
-                LOG.warn("Cache exception reading unitString from MetadataCache: ", ex);
-            }
-            if (unitString == null) {
-                unitString = Util.UNKNOWN;
-            }
-        }
-        return unitString;
-    }
-
     /**
      * Gets the TTL for a particular locator, rollupType and granularity.
      *

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/EnumMetricData.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/EnumMetricData.java
@@ -136,7 +136,7 @@ public class EnumMetricData {
             for (Locator locator : locators) {
                 populateEnumValueToCountMap(enumHashRollup.row(locator), enumHashValues.row(locator));
                 Points points = convertToPoints(enumHashRollup.row(locator));
-                MetricData metricData = new MetricData(points, getUnitString(locator), MetricData.Type.ENUM);
+                MetricData metricData = new MetricData(points, metadataCache.getUnitString(locator), MetricData.Type.ENUM);
                 resultMap.put(locator, metricData);
             }
         } catch (InterruptedException e) {
@@ -178,23 +178,6 @@ public class EnumMetricData {
             enumRollupPoints.add(new Points.Point<BluefloodEnumRollup>(enumRollup.getKey(), enumRollup.getValue()));
         }
         return enumRollupPoints;
-    }
-
-    // TODO: can this move to MetadataCache
-    private String getUnitString(Locator locator) {
-        String unitString = Util.UNKNOWN;
-        // Only grab units from cassandra, if we have to
-        if (!Util.shouldUseESForUnits()) {
-            try {
-                unitString = metadataCache.get(locator, MetricMetadata.UNIT.name().toLowerCase(), String.class);
-            } catch (CacheException ex) {
-                LOG.warn("Cache exception reading unitString from MetadataCache: ", ex);
-            }
-            if (unitString == null) {
-                unitString = Util.UNKNOWN;
-            }
-        }
-        return unitString;
     }
 
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
@@ -245,7 +245,7 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
 
                 // create MetricData
                 MetricData.Type outputType = MetricData.Type.from( rollupType, dataType );
-                MetricData metricData = new MetricData( points, getUnitString( locator ), outputType );
+                MetricData metricData = new MetricData( points, metadataCache.getUnitString( locator ), outputType );
                 locatorMetricDataMap.put( locator, metricData );
 
             } catch (CacheException ex) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
@@ -256,7 +256,8 @@ public class DBasicMetricsRW extends DAbstractMetricsRW {
 
                 try {
 
-                    metrics.put( future.getKey(), rawIO.createMetricDataStringBoolean( future.getValue(), isBoolean, getUnitString( future.getKey() ) ) );
+                    metrics.put( future.getKey(), rawIO.createMetricDataStringBoolean( future.getValue(),
+                            isBoolean, metadataCache.getUnitString( future.getKey() ) ) );
                 }
                 catch (Exception e ) {
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -154,6 +154,7 @@ public enum CoreConfig implements ConfigDefaults {
     TENANTIDS_TO_KEEP(""),
     TRACKER_DELAYED_METRICS_MILLIS("300000"),
 
+    SHOULD_STORE_UNITS("true"),
     USE_ES_FOR_UNITS("false"),
     // Should at least be equal to the number of the netty worker threads, if http module is getting loaded
     ES_UNIT_THREADS("50"),

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -45,6 +45,7 @@ public class RollupRunnable implements Runnable {
 
     private static final Timer writeTimer = Metrics.timer(RollupRunnable.class, "Write Rollup");
     protected final SingleRollupReadContext singleRollupReadContext;
+    protected static final MetadataCache metadataCache = MetadataCache.getInstance();
     protected static final MetadataCache rollupTypeCache = MetadataCache.createLoadingCacheInstance(
             new TimeValue(48, TimeUnit.HOURS), // todo: need a good default expiration here.
             Configuration.getInstance().getIntegerProperty(CoreConfig.MAX_ROLLUP_READ_THREADS));
@@ -160,7 +161,7 @@ public class RollupRunnable implements Runnable {
             //Emit a rollup event to eventemitter
             RollupEventEmitter.getInstance().emit(RollupEventEmitter.ROLLUP_EVENT_NAME,
                     new RollupEvent(singleRollupReadContext.getLocator(), rollup,
-                            AstyanaxReader.getUnitString(singleRollupReadContext.getLocator()),
+                            metadataCache.getUnitString(singleRollupReadContext.getLocator()),
                             singleRollupReadContext.getRollupGranularity().name(),
                             singleRollupReadContext.getRange().getStart()));
         } catch (Exception e) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Util.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Util.java
@@ -86,7 +86,8 @@ public class Util {
     public static String UNKNOWN = "unknown".intern();
 
     public static boolean shouldUseESForUnits() {
-        return Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) &&
+        return Configuration.getInstance().getBooleanProperty(CoreConfig.SHOULD_STORE_UNITS) &&
+                Configuration.getInstance().getBooleanProperty(CoreConfig.USE_ES_FOR_UNITS) &&
                 Configuration.getInstance().getListProperty(CoreConfig.DISCOVERY_MODULES).contains(ElasticIOPath);
     }
 }


### PR DESCRIPTION
We're not using Blueflood to store units (we do that in our frontend at Square) so being able to disable that is a big performance boost for us. Moved `getUnitString` to `MetadataCache` to help facilitate the change.