### PR TITLE
Revert datastax wiring

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/processors/DiscoveryWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/processors/DiscoveryWriter.java
@@ -19,13 +19,12 @@ package com.rackspacecloud.blueflood.inputs.processors;
 import com.codahale.metrics.Meter;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.rackspacecloud.blueflood.concurrent.FunctionWithThreadPool;
-import com.rackspacecloud.blueflood.io.IOContainer;
+
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxWriter;
 import com.rackspacecloud.blueflood.io.DiscoveryIO;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.IMetric;
-import com.rackspacecloud.blueflood.types.Locator;
-import com.rackspacecloud.blueflood.types.RollupType;
 import com.rackspacecloud.blueflood.utils.Metrics;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -90,24 +89,13 @@ public class DiscoveryWriter extends FunctionWithThreadPool<List<List<IMetric>>,
             }
 
             for (IMetric m : list) {
-                if (!isLocatorCurrent(m)) {
+                if (!AstyanaxWriter.isLocatorCurrent(m.getLocator())) {
                     willIndex.add(m);
                 }
             }
         }
         return willIndex;
     }
-
-    private static boolean isLocatorCurrent(IMetric m) {
-        Locator locator = m.getLocator();
-        RollupType rollupType = m.getRollupType();
-        if ( rollupType == null || rollupType == RollupType.BF_BASIC ) {
-            return IOContainer.fromConfig().getBasicMetricsRW().isLocatorCurrent(locator);
-        } else {
-            return IOContainer.fromConfig().getPreAggregatedMetricsRW().isLocatorCurrent(locator);
-        }
-    }
-    
     
     public ListenableFuture<Boolean> processMetrics(final List<List<IMetric>> input) {
         // process en masse.

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AbstractMetricsRW.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class AbstractMetricsRW implements MetricsRW {
 
+    protected final MetadataCache metadataCache = MetadataCache.getInstance();
     protected static final String DATA_TYPE_CACHE_KEY = MetricMetadata.TYPE.toString().toLowerCase();
 
     protected static TenantTtlProvider TTL_PROVIDER = SafetyTtlProvider.getInstance();
@@ -60,9 +61,7 @@ public abstract class AbstractMetricsRW implements MetricsRW {
      * @param loc
      * @return
      */
-    // I don't like making this public, but currently DiscoveryWriter
-    // calls this
-    public synchronized boolean isLocatorCurrent(Locator loc) {
+    protected synchronized boolean isLocatorCurrent(Locator loc) {
         return insertedLocators.getIfPresent(loc.toString()) != null;
     }
 
@@ -93,11 +92,12 @@ public abstract class AbstractMetricsRW implements MetricsRW {
      * its corresponding {@link com.rackspacecloud.blueflood.types.DataType}
      *
      * @param locator
+     * @param dataTypeCacheKey
      * @return
      * @throws CacheException
      */
-    protected DataType getDataType(Locator locator) throws CacheException {
-        String meta = MetadataCache.getInstance().get(locator, DATA_TYPE_CACHE_KEY);
+    protected DataType getDataType(Locator locator, String dataTypeCacheKey) throws CacheException {
+        String meta = metadataCache.get(locator, dataTypeCacheKey);
         if (meta != null) {
             return new DataType(meta);
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IMetricsWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IMetricsWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Rackspace
+ * Copyright 2014 Rackspace
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -14,12 +14,15 @@
  *    limitations under the License.
  */
 
-package com.rackspacecloud.blueflood.service;
+package com.rackspacecloud.blueflood.io;
 
-import com.rackspacecloud.blueflood.io.IMetricsWriter;
+import com.rackspacecloud.blueflood.types.IMetric;
+import com.rackspacecloud.blueflood.types.Metric;
 
-public interface IngestionService {
-    public void startService(ScheduleContext context, IMetricsWriter writer);
-    public void shutdownService();
+import java.io.IOException;
+import java.util.Collection;
+
+public interface IMetricsWriter {
+    void insertFullMetrics(Collection<? extends IMetric> metrics) throws Exception;
+    void insertPreaggreatedMetrics(Collection<IMetric> metrics) throws Exception;
 }
-

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxMetricsWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxMetricsWriter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 Rackspace
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.io.astyanax;
+
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.rackspacecloud.blueflood.io.CassandraModel;
+import com.rackspacecloud.blueflood.io.IMetricsWriter;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxWriter;
+import com.rackspacecloud.blueflood.types.IMetric;
+import com.rackspacecloud.blueflood.types.Metric;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class AstyanaxMetricsWriter implements IMetricsWriter {
+    @Override
+    public void insertFullMetrics(Collection<? extends IMetric> metrics) throws IOException {
+        try {
+            AstyanaxWriter.getInstance().insertFull(metrics);
+        } catch (ConnectionException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void insertPreaggreatedMetrics(Collection<IMetric> metrics) throws IOException {
+        try {
+            AstyanaxWriter.getInstance().insertMetrics(metrics, CassandraModel.CF_METRICS_PREAGGREGATED_FULL);
+        } catch (ConnectionException e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
@@ -135,7 +135,7 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
             for (Locator locator : locators) {
                 try {
 
-                    String rType = MetadataCache.getInstance().get(locator, MetricMetadata.ROLLUP_TYPE.name().toLowerCase());
+                    String rType = metadataCache.get( locator, MetricMetadata.ROLLUP_TYPE.name().toLowerCase() );
 
                     DAbstractMetricIO io = getIO( rType, granularity );
 
@@ -243,7 +243,7 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
                 Points points = convertToPoints( tsRollupMap );
 
                 // get the dataType for this locator
-                DataType dataType = getDataType( locator );
+                DataType dataType = getDataType( locator, MetricMetadata.TYPE.name().toLowerCase() );
 
                 RollupType rollupType = getRollupType( tsRollupMap );
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
@@ -130,18 +130,26 @@ public class DBasicMetricsRW extends DAbstractMetricsRW {
         List<Locator> booleans = new ArrayList<Locator>();
         List<Locator> numerics = new ArrayList<Locator>();
 
+        MetadataCache metadataCache = MetadataCache.getInstance();
+
         for ( Locator locator : locators ) {
 
-            DataType metricType;
+            Object type;
             try {
-                metricType = getDataType(locator);
+
+                type = metadataCache.get( locator, DATA_TYPE_CACHE_KEY );
+
             } catch ( CacheException e ) {
                 LOG.error(String.format("Error looking up locator %s in cache", locator), e);
                 unknowns.add( locator );
                 continue;
             }
 
-            if ( !DataType.isKnownMetricType( metricType ) ) {
+
+            DataType metricType = new DataType( (String) type );
+
+            if ( type == null || !DataType.isKnownMetricType( metricType ) ) {
+
                 unknowns.add( locator );
                 continue;
             } else if ( metricType.equals( DataType.STRING ) ) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/RollupHandler.java
@@ -24,7 +24,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.rackspacecloud.blueflood.concurrent.ThreadPoolBuilder;
-import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxReader;
+import com.rackspacecloud.blueflood.io.DiscoveryIO;
+import com.rackspacecloud.blueflood.io.SearchResult;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.Configuration;
@@ -163,9 +165,7 @@ public class RollupHandler {
                  }
              });
         }
-
-        MetricsRWDelegator delegator = new MetricsRWDelegator();
-        final Map<Locator,MetricData> metricDataMap = delegator.getDatapointsForRange(
+        final Map<Locator,MetricData> metricDataMap = AstyanaxReader.getInstance().getDatapointsForRange(
                 locators,
                 new Range(g.snapMillis(from), to),
                 g);
@@ -390,8 +390,7 @@ public class RollupHandler {
         for ( Range r : ranges ) {
             try {
                 Timer.Context cRead = timerCassandraReadRollupOnRead.time();
-                MetricsRWDelegator delegator = new MetricsRWDelegator();
-                MetricData data = delegator.getDatapointsForRange(locator, r, Granularity.FULL);
+                MetricData data = AstyanaxReader.getInstance().getDatapointsForRange( locator, r, Granularity.FULL );
                 cRead.stop();
 
                 Points dataToRoll = data.getData();

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/BluefloodServiceStarter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/BluefloodServiceStarter.java
@@ -21,6 +21,7 @@ import com.rackspacecloud.blueflood.io.AbstractMetricsRW;
 import com.rackspacecloud.blueflood.io.IOContainer;
 import com.rackspacecloud.blueflood.io.ShardStateIO;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
+import com.rackspacecloud.blueflood.io.IMetricsWriter;
 import com.rackspacecloud.blueflood.utils.Metrics;
 import com.rackspacecloud.blueflood.utils.RestartGauge;
 import com.rackspacecloud.blueflood.utils.Util;
@@ -99,12 +100,16 @@ public class BluefloodServiceStarter {
             for (String module : modules) {
                 log.info("Loading ingestion service module " + module);
                 try {
+                    ClassLoader loader = IMetricsWriter.class.getClassLoader();
+                    Class writerImpl = loader.loadClass(config.getStringProperty(CoreConfig.IMETRICS_WRITER));
+                    IMetricsWriter writer = (IMetricsWriter) writerImpl.newInstance();
+
                     Class serviceClass = classLoader.loadClass(module);
                     IngestionService service = (IngestionService) serviceClass.newInstance();
-                    log.info("Starting ingestion service module " + module);
+                    log.info("Starting ingestion service module " + module + " with writer: " + writerImpl.getSimpleName());
                     ingestionServices.add(service);
-                    service.startService(context);
-                    log.info("Successfully started ingestion service module " + module);
+                    service.startService(context, writer);
+                    log.info("Successfully started ingestion service module " + module + " with writer: " + writerImpl.getSimpleName());
                     services_started++;
                 } catch (InstantiationException e) {
                     log.error("Unable to create instance of ingestion service class for: " + module, e);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -139,6 +139,8 @@ public enum CoreConfig implements ConfigDefaults {
     // valid options are: GEOMETRIC, LINEAR, and LESSTHANEQUAL
     GET_BY_POINTS_GRANULARITY_SELECTION("GEOMETRIC"),
 
+    IMETRICS_WRITER("com.rackspacecloud.blueflood.io.astyanax.AstyanaxMetricsWriter"),
+
     METADATA_CACHE_PERSISTENCE_ENABLED("false"),
     METADATA_CACHE_PERSISTENCE_PATH("/dev/null"),
     METADATA_CACHE_PERSISTENCE_PERIOD_MINS("10"),

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/EnumValidator.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/EnumValidator.java
@@ -17,7 +17,11 @@
 package com.rackspacecloud.blueflood.service;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.io.EnumReaderIO;
+import com.rackspacecloud.blueflood.io.IOContainer;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxReader;
+import com.rackspacecloud.blueflood.io.DiscoveryIO;
+import com.rackspacecloud.blueflood.io.SearchResult;
 import com.rackspacecloud.blueflood.types.BluefloodEnumRollup;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.Locator;
@@ -42,6 +46,7 @@ public class EnumValidator implements Runnable {
     private static final int ENUM_UNIQUE_VALUES_THRESHOLD = config.getIntegerProperty(CoreConfig.ENUM_UNIQUE_VALUES_THRESHOLD);
     private Set<Locator> locators;
 
+    private AstyanaxReader reader = null;
     private DiscoveryIO discoveryIO = null;
     private EnumReaderIO enumIO = null;
 
@@ -68,7 +73,7 @@ public class EnumValidator implements Runnable {
     public void run() {
         if (locators == null) return;
 
-        Map<Locator, List<String>> locatorEnums = enumIO.getEnumStringMappings(new ArrayList(locators));
+        Map<Locator, List<String>> locatorEnums = getReader().getEnumStringMappings(new ArrayList(locators));
         for (final Locator locator : locatorEnums.keySet()) {
             // validate enum values count and write to index or bad metric
             validateThresholdAndWrite(locator, locatorEnums.get(locator));
@@ -132,6 +137,17 @@ public class EnumValidator implements Runnable {
             rollup = rollup.withEnumValue(val);
         }
         return rollup;
+    }
+
+    public AstyanaxReader getReader() {
+        if (this.reader == null) {
+            this.reader = AstyanaxReader.getInstance();
+        }
+        return this.reader;
+    }
+
+    public void setReader(AstyanaxReader reader) {
+        this.reader = reader;
     }
 
     public DiscoveryIO getDiscoveryIO() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ExcessEnumReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ExcessEnumReader.java
@@ -17,17 +17,14 @@
 package com.rackspacecloud.blueflood.service;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import com.codahale.metrics.Meter;
 
 import com.rackspacecloud.blueflood.io.IOContainer;
-import com.rackspacecloud.blueflood.io.astyanax.AExcessEnumIO;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.utils.Metrics;
 
-import io.netty.util.internal.ConcurrentSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,8 +54,7 @@ public class ExcessEnumReader implements Runnable {
         while (true)
         {
             try {
-                Set<Locator> excess = IOContainer.fromConfig().getExcessEnumIO().getExcessEnumMetrics();
-                excessEnumMetrics = excess;
+                excessEnumMetrics = IOContainer.fromConfig().getExcessEnumIO().getExcessEnumMetrics();
                 readMeter.mark();
                 Thread.sleep(sleepMillis);
             } catch (Exception e) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -21,7 +21,8 @@ import com.codahale.metrics.Timer;
 import com.google.common.collect.Sets;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.exceptions.GranularityException;
-import com.rackspacecloud.blueflood.io.AbstractMetricsRW;
+import com.rackspacecloud.blueflood.io.IOContainer;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxReader;
 import com.rackspacecloud.blueflood.io.CassandraModel;
 import com.rackspacecloud.blueflood.io.CassandraModel.MetricColumnFamily;
 import com.rackspacecloud.blueflood.rollup.Granularity;
@@ -36,6 +37,7 @@ import com.rackspacecloud.blueflood.eventemitter.RollupEvent;
 
 import java.util.*;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /** rolls up data into one data point, inserts that data point. */
@@ -127,16 +129,20 @@ public class RollupRunnable implements Runnable {
                 }
             }
 
-            // first, get the points.
-            AbstractMetricsRW metricsRW;
             try {
-                metricsRW = RollupUtils.getMetricsRWForRollupType(rollupType);
-
-                input = metricsRW.getDataToRollup(
-                        singleRollupReadContext.getLocator(),
-                        rollupType,
-                        singleRollupReadContext.getRange(),
-                        srcCF.getName());
+                // first, get the points.
+                // TODO: replace the Astyanax call with:
+                // MetricsRW metricsRW;
+                // if ( rollupType == RollupType.BF_BASIC ) {
+                //    metricsRW = IOContainer.fromConfig().getBasicIO();
+                // } else if ( rollupType == RollupType.BF_HISTORGRAM ) {
+                //    metricsRW = histogram column family differences
+                // } else {
+                //    metricsRW = IOContainer.fromConfig().getPreaggregatedIO();
+                // }
+                // metricsRW.getDataToRollup(locator, rollupType, range, columnFamily)
+                input = AstyanaxReader.getInstance().getDataToRoll(rollupClass,
+                        singleRollupReadContext.getLocator(), singleRollupReadContext.getRange(), srcCF);
 
                 if (input.isEmpty()) {
                     LOG.debug(String.format("No points rollup for locator %s", singleRollupReadContext.getLocator()));

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/BatchWriterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/BatchWriterTest.java
@@ -20,8 +20,7 @@ import com.codahale.metrics.Counter;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.rackspacecloud.blueflood.concurrent.ThreadPoolBuilder;
 import com.rackspacecloud.blueflood.inputs.processors.BatchWriter;
-import com.rackspacecloud.blueflood.io.AbstractMetricsRW;
-import com.rackspacecloud.blueflood.io.MetricsRWDelegator;
+import com.rackspacecloud.blueflood.io.IMetricsWriter;
 import com.rackspacecloud.blueflood.service.IngestionContext;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.Metric;
@@ -67,22 +66,17 @@ public class BatchWriterTest {
 
     @Test
     public void testWriter() throws Exception {
+        IMetricsWriter writer = mock(IMetricsWriter.class);
         Counter bufferedMetrics = mock(Counter.class);
         IngestionContext context = mock(IngestionContext.class);
-        AbstractMetricsRW basicRW = mock(AbstractMetricsRW.class);
-        AbstractMetricsRW preAggrRW = mock(AbstractMetricsRW.class);
-        MetricsRWDelegator metricsRWDelegator = new MetricsRWDelegator(basicRW, preAggrRW);
         List<List<IMetric>> testdata = createTestData(Metric.class);
         List<List<IMetric>> pTestdata = createTestData(PreaggregatedMetric.class);
         List<List<IMetric>> allTestdata = new ArrayList<List<IMetric>>();
         allTestdata.addAll(testdata);
         allTestdata.addAll(pTestdata);
         BatchWriter batchWriter = new BatchWriter(
-                        new ThreadPoolBuilder().build(),
-                        timeout, bufferedMetrics,
-                        context,
-                        metricsRWDelegator
-                        );
+            new ThreadPoolBuilder().build(), writer, timeout, bufferedMetrics,
+                context);
         
         ListenableFuture<List<Boolean>> futures = batchWriter.apply(allTestdata);
         List<Boolean> persisteds = futures.get(timeout.getValue(), timeout.getUnit());
@@ -98,12 +92,12 @@ public class BatchWriterTest {
 
         //Confirm that each regular batch was inserted
         for (List<IMetric> l : testdata) {
-            verify(basicRW).insertMetrics((List<IMetric>)(List<?>)l);
+            verify(writer).insertFullMetrics((List<Metric>)(List<?>)l);
         }
 
         //Confirm that each preagg batch was inserted
         for (List<IMetric> l : pTestdata) {
-            verify(preAggrRW).insertMetrics(l);
+            verify(writer).insertPreaggreatedMetrics(l);
         }
 
         //Confirm scheduleContext was updated

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/DummyIngestionService.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/DummyIngestionService.java
@@ -1,5 +1,7 @@
 package com.rackspacecloud.blueflood.service;
 
+import com.rackspacecloud.blueflood.io.IMetricsWriter;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,14 +27,19 @@ public class DummyIngestionService implements IngestionService {
     public ScheduleContext getContext() {
         return context;
     }
+    IMetricsWriter writer;
+    public IMetricsWriter getWriter() {
+        return writer;
+    }
 
     @Override
-    public void startService(ScheduleContext context) {
+    public void startService(ScheduleContext context, IMetricsWriter writer) {
         if (startServiceCalled) {
             throw new UnsupportedOperationException("startService was called more than once");
         }
         startServiceCalled = true;
         this.context = context;
+        this.writer = writer;
     }
 
     boolean shutdownServiceCalled = false;

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/EnumValidatorTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/EnumValidatorTest.java
@@ -18,7 +18,6 @@ package com.rackspacecloud.blueflood.service;
 
 import com.rackspacecloud.blueflood.concurrent.ThreadPoolBuilder;
 import com.rackspacecloud.blueflood.io.*;
-import com.rackspacecloud.blueflood.io.astyanax.AEnumIO;
 import com.rackspacecloud.blueflood.io.astyanax.AstyanaxIO;
 import com.rackspacecloud.blueflood.io.astyanax.AstyanaxReader;
 import com.rackspacecloud.blueflood.types.IMetric;
@@ -50,7 +49,7 @@ import static org.mockito.Mockito.*;
 } )
 public class EnumValidatorTest {
 
-    private EnumReaderIO readerMock;
+    private AstyanaxReader readerMock;
     private DiscoveryIO discoveryIOMock;
     private ExcessEnumIO excessEnumIO;
 
@@ -63,12 +62,12 @@ public class EnumValidatorTest {
     public void setup() {
 
         // static mock
-        readerMock = mock(AEnumIO.class);
+        readerMock = mock(AstyanaxReader.class);
         discoveryIOMock = mock(DiscoveryIO.class);
         excessEnumIO = mock(ExcessEnumIO.class);
 
-        //PowerMockito.mockStatic(AstyanaxReader.class);
-        //when(AstyanaxReader.getInstance()).thenReturn(readerMock);
+        PowerMockito.mockStatic(AstyanaxReader.class);
+        when(AstyanaxReader.getInstance()).thenReturn(readerMock);
         PowerMockito.mockStatic(IOContainer.class);
         IOContainer ioContainer = mock(IOContainer.class);
         when(IOContainer.fromConfig()).thenReturn(ioContainer);
@@ -89,7 +88,8 @@ public class EnumValidatorTest {
     }
 
     private EnumValidator setupEnumValidatorWithMock(Set<Locator> locators) {
-        EnumValidator enumValidator = new EnumValidator(locators, readerMock);
+        EnumValidator enumValidator = new EnumValidator(locators);
+        enumValidator.setReader(readerMock);
         enumValidator.setDiscoveryIO(discoveryIOMock);
         return enumValidator;
     }
@@ -208,7 +208,7 @@ public class EnumValidatorTest {
         EnumValidator validator = new EnumValidator(null);
 
         // expect
-        assertSame(IOContainer.fromConfig().getEnumReaderIO(), validator.getEnumIO());
+        assertSame(AstyanaxReader.getInstance(), validator.getReader());
     }
 
     @Test
@@ -225,10 +225,16 @@ public class EnumValidatorTest {
     public void setReaderSetsReader() {
 
         // given
-        EnumValidator validator = new EnumValidator(null, readerMock);
+        EnumValidator validator = new EnumValidator(null);
 
-        // expect
-        assertSame(readerMock, validator.getEnumIO());
+        // precondition
+        assertSame(AstyanaxReader.getInstance(), validator.getReader());
+
+        // when
+        validator.setReader(readerMock);
+
+        // then
+        assertSame(readerMock, validator.getReader());
     }
 
     @Test

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
@@ -20,6 +20,7 @@ import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpEventsIngestionHandler;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpMetricsIngestionServer;
 import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxMetricsWriter;
 import com.rackspacecloud.blueflood.service.*;
 import com.rackspacecloud.blueflood.types.Event;
 import com.rackspacecloud.blueflood.utils.ModuleLoader;
@@ -101,11 +102,11 @@ public class HttpIntegrationTestBase {
         ((EnumElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.ENUMS_DISCOVERY_MODULES)).setClient(esSetup.client());
 
         // setup ingestion server
-        HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context);
+        HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context, new AstyanaxMetricsWriter());
         server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
         httpIngestionService = new HttpIngestionService();
         httpIngestionService.setMetricsIngestionServer(server);
-        httpIngestionService.startService(context);
+        httpIngestionService.startService(context, new AstyanaxMetricsWriter());
 
         // setup query server
         httpQueryService = new HttpQueryService();

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndTest.java
@@ -17,6 +17,7 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxMetricsWriter;
 import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
 import com.rackspacecloud.blueflood.io.EventsIO;
 import com.rackspacecloud.blueflood.outputs.handlers.HttpMetricDataQueryServer;
@@ -74,12 +75,12 @@ public class HttpAnnotationsEndToEndTest {
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
                 .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
         eventsSearchIO = new EventElasticSearchIO(esSetup.client());
-        HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context);
+        HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context, new AstyanaxMetricsWriter());
         server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
 
         httpIngestionService = new HttpIngestionService();
         httpIngestionService.setMetricsIngestionServer(server);
-        httpIngestionService.startService(context);
+        httpIngestionService.startService(context, new AstyanaxMetricsWriter());
 
         httpQueryService = new HttpQueryService();
         HttpMetricDataQueryServer queryServer = new HttpMetricDataQueryServer();

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
@@ -20,6 +20,7 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
 import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxMetricsWriter;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.HttpConfig;
@@ -71,7 +72,7 @@ public class HttpMetricsIngestionServerShutdownIntegrationTest {
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
                 .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
         eventsSearchIO = new EventElasticSearchIO(esSetup.client());
-        server = new HttpMetricsIngestionServer(context);
+        server = new HttpMetricsIngestionServer(context, new AstyanaxMetricsWriter());
         server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
 
         server.startServer();

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEnumRollupIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEnumRollupIntegrationTest.java
@@ -19,6 +19,7 @@ package com.rackspacecloud.blueflood.outputs.handlers;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
 import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.io.astyanax.AstyanaxWriter;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.*;
 import com.rackspacecloud.blueflood.types.*;
@@ -51,7 +52,7 @@ public class HttpEnumRollupIntegrationTest extends HttpIntegrationTestBase {
     @Before
     public void generateEnumData() throws Exception {
 
-        MetricsRW metricsRW = IOContainer.fromConfig().getPreAggregatedMetricsRW();
+        AstyanaxWriter writer = AstyanaxWriter.getInstance();
 
         dt = new DateTime();
         System.out.println(String.format("Starting generation of metrics %s %s %s %s", dt.getHourOfDay(), dt.getMinuteOfHour(), dt.getSecondOfMinute(), dt.getMillisOfSecond()));
@@ -68,7 +69,7 @@ public class HttpEnumRollupIntegrationTest extends HttpIntegrationTestBase {
 
             MetadataCache.getInstance().put(enumMetric.getLocator(), MetricMetadata.TYPE.name().toLowerCase(), null);
             MetadataCache.getInstance().put(enumMetric.getLocator(), MetricMetadata.ROLLUP_TYPE.name().toLowerCase(), RollupType.ENUM.toString());
-            metricsRW.insertMetrics(metrics);
+            writer.insertMetrics(metrics, CassandraModel.CF_METRICS_PREAGGREGATED_FULL);
         }
 
         dt= new DateTime();

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gson.*;
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.rackspacecloud.blueflood.http.DefaultHandler;
 import com.rackspacecloud.blueflood.http.HttpRequestHandler;
 import com.rackspacecloud.blueflood.inputs.formats.AggregatedPayload;
@@ -129,6 +130,9 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
             log.debug(String.format("BAD JSON: %s", body));
             log.error(ex.getMessage(), ex);
             DefaultHandler.sendResponse(ctx, request, ex.getMessage(), HttpResponseStatus.BAD_REQUEST);
+        } catch (ConnectionException ex) {
+            log.error(ex.getMessage(), ex);
+            DefaultHandler.sendResponse(ctx, request, "Internal error saving data", HttpResponseStatus.INTERNAL_SERVER_ERROR);
         } catch (TimeoutException ex) {
             DefaultHandler.sendResponse(ctx, request, "Timed out persisting metrics", HttpResponseStatus.ACCEPTED);
         } catch (Exception ex) {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpIngestionService.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpIngestionService.java
@@ -18,6 +18,7 @@ package com.rackspacecloud.blueflood.service;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpMetricsIngestionServer;
+import com.rackspacecloud.blueflood.io.IMetricsWriter;
 
 /**
  * HTTP Ingestion Service.
@@ -25,9 +26,11 @@ import com.rackspacecloud.blueflood.inputs.handlers.HttpMetricsIngestionServer;
 public class HttpIngestionService implements IngestionService {
     private HttpMetricsIngestionServer server;
     private ScheduleContext context;
+    private IMetricsWriter writer;
 
-    public void startService(ScheduleContext context) {
+    public void startService(ScheduleContext context, IMetricsWriter writer) {
         this.context = context;
+        this.writer = writer;
 
         getHttpMetricsIngestionServer().startServer();
     }
@@ -39,7 +42,7 @@ public class HttpIngestionService implements IngestionService {
 
     private HttpMetricsIngestionServer getHttpMetricsIngestionServer() {
         if (this.server == null) {
-            this.server = new HttpMetricsIngestionServer(this.context);
+            this.server = new HttpMetricsIngestionServer(this.context, this.writer);
         }
 
         return this.server;


### PR DESCRIPTION
Based on performance testing last week, we are seeing negative performance impact with the latest datastax wiring. This PR reverts the services code and some test code back to the way it used to be. 

I am currently running this code in perf01 and am seeing good results so far.

