### PR TITLE
refactor to ensure datastax PreparedStatements are created only once

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/BasicMetricsRWIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/BasicMetricsRWIntegrationTest.java
@@ -4,6 +4,7 @@ import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.exceptions.CacheException;
 import com.rackspacecloud.blueflood.io.astyanax.ABasicMetricsRW;
 import com.rackspacecloud.blueflood.io.datastax.DBasicMetricsRW;
+import com.rackspacecloud.blueflood.io.datastax.DLocatorIO;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.SingleRollupWriteContext;
 import com.rackspacecloud.blueflood.types.*;
@@ -30,7 +31,8 @@ public class BasicMetricsRWIntegrationTest extends IntegrationTestBase {
     private static final String TENANT3 = "123789";
     private static final TimeValue TTL = new TimeValue(24, TimeUnit.HOURS);
 
-    protected MetricsRW datastaxMetricsRW = new DBasicMetricsRW();
+    protected LocatorIO locatorIO = new DLocatorIO();
+    protected MetricsRW datastaxMetricsRW = new DBasicMetricsRW(locatorIO);
     protected MetricsRW astyanaxMetricsRW = new ABasicMetricsRW();
 
     protected Map<Locator, IMetric> numericMap = new HashMap<Locator, IMetric>();

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
@@ -20,6 +20,7 @@ import com.google.common.cache.Cache;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.io.astyanax.AstyanaxWriter;
 import com.rackspacecloud.blueflood.io.datastax.DCassandraUtilsIO;
+import com.rackspacecloud.blueflood.io.datastax.DLocatorIO;
 import com.rackspacecloud.blueflood.io.datastax.DPreaggregatedMetricsRW;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
@@ -121,17 +122,6 @@ public class IntegrationTestBase {
 
         Cache<String, Boolean> insertedLocators = (Cache<String, Boolean>) Whitebox.getInternalState(AstyanaxWriter.getInstance(), "insertedLocators");
         insertedLocators.invalidateAll();
-
-        return metric;
-    }
-
-    protected IMetric datastaxWriteEnumMetric(String name, String tenantid) throws Exception {
-        final List<IMetric> metrics = new ArrayList<IMetric>();
-        PreaggregatedMetric metric = getEnumMetric(name, tenantid, System.currentTimeMillis());
-        metrics.add(metric);
-
-        DPreaggregatedMetricsRW metricsRW = new DPreaggregatedMetricsRW();
-        metricsRW.insertMetrics(metrics, Granularity.FULL);
 
         return metric;
     }

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/PreaggregatedMetricsRWIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/PreaggregatedMetricsRWIntegrationTest.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.io.astyanax.APreaggregatedMetricsRW;
+import com.rackspacecloud.blueflood.io.datastax.DEnumIO;
+import com.rackspacecloud.blueflood.io.datastax.DLocatorIO;
 import com.rackspacecloud.blueflood.io.datastax.DPreaggregatedMetricsRW;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
@@ -48,7 +50,9 @@ public class PreaggregatedMetricsRWIntegrationTest extends IntegrationTestBase {
     private static final String TENANT3 = "123789";
     private static final TimeValue TTL = new TimeValue(24, TimeUnit.HOURS);
 
-    protected DPreaggregatedMetricsRW datastaxMetricsRW = new DPreaggregatedMetricsRW();
+    protected LocatorIO locatorIO = new DLocatorIO();
+    protected DEnumIO enumIO = new DEnumIO();
+    protected DPreaggregatedMetricsRW datastaxMetricsRW = new DPreaggregatedMetricsRW(enumIO, locatorIO);
     protected APreaggregatedMetricsRW astyanaxMetricsRW = new APreaggregatedMetricsRW();
 
     protected Map<Locator, IMetric>  expectedLocatorMetricMap = new HashMap<Locator, IMetric>();

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRWIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRWIntegrationTest.java
@@ -19,6 +19,7 @@ package com.rackspacecloud.blueflood.io.datastax;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.io.CassandraModel;
 import com.rackspacecloud.blueflood.io.IntegrationTestBase;
+import com.rackspacecloud.blueflood.io.LocatorIO;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.*;
@@ -35,6 +36,8 @@ import java.util.Set;
  */
 public class DBasicMetricsRWIntegrationTest extends IntegrationTestBase {
 
+    protected LocatorIO locatorIO = new DLocatorIO();
+
     @Test
     public void testStringMetricsIfSoConfiguredAreAlwaysDroppedForAllTenants() throws Exception {
 
@@ -49,7 +52,7 @@ public class DBasicMetricsRWIntegrationTest extends IntegrationTestBase {
         final Locator locator = Locator.createLocatorFromPathComponents(acctId, metricName);
         MetadataCache.getInstance().put(locator, MetricMetadata.TYPE.name().toLowerCase(), DataType.STRING.toString());
 
-        DBasicMetricsRW metricsRW = new DBasicMetricsRW(true, new ArrayList<String>());
+        DBasicMetricsRW metricsRW = new DBasicMetricsRW(locatorIO, true, new ArrayList<String>());
 
         Set<Long> expectedTimestamps = new HashSet<Long>();
         // insert something every 30s for 5 mins.
@@ -85,7 +88,7 @@ public class DBasicMetricsRWIntegrationTest extends IntegrationTestBase {
         List<String> keptTenants = new ArrayList<String>();
         keptTenants.add(locator.getTenantId());
 
-        DBasicMetricsRW metricsRW = new DBasicMetricsRW(true, keptTenants);
+        DBasicMetricsRW metricsRW = new DBasicMetricsRW(locatorIO, true, keptTenants);
 
         Set<Long> expectedTimestamps = new HashSet<Long>();
         // insert something every 30s for 5 mins.
@@ -116,7 +119,7 @@ public class DBasicMetricsRWIntegrationTest extends IntegrationTestBase {
         final Locator locator = Locator.createLocatorFromPathComponents(acctId, metricName);
         MetadataCache.getInstance().put(locator, MetricMetadata.TYPE.name().toLowerCase(), DataType.STRING.toString());
 
-        DBasicMetricsRW metricsRW = new DBasicMetricsRW(false, new ArrayList<String>());
+        DBasicMetricsRW metricsRW = new DBasicMetricsRW(locatorIO, false, new ArrayList<String>());
 
         Set<Long> expectedTimestamps = new HashSet<Long>();
         // insert something every 30s for 5 mins.
@@ -147,7 +150,7 @@ public class DBasicMetricsRWIntegrationTest extends IntegrationTestBase {
         final Locator locator = Locator.createLocatorFromPathComponents(acctId, metricName);
         MetadataCache.getInstance().put(locator, MetricMetadata.TYPE.name().toLowerCase(), DataType.STRING.toString());
 
-        DBasicMetricsRW metricsRW = new DBasicMetricsRW(false, new ArrayList<String>());
+        DBasicMetricsRW metricsRW = new DBasicMetricsRW(locatorIO, false, new ArrayList<String>());
 
         String sameValue = getRandomStringMetricValue();
         Set<Long> expectedTimestamps = new HashSet<Long>();
@@ -186,7 +189,7 @@ public class DBasicMetricsRWIntegrationTest extends IntegrationTestBase {
         String firstValue = getRandomStringMetricValue();
         String secondValue = getRandomStringMetricValue();
 
-        DBasicMetricsRW metricsRW = new DBasicMetricsRW(false, new ArrayList<String>());
+        DBasicMetricsRW metricsRW = new DBasicMetricsRW(locatorIO, false, new ArrayList<String>());
 
         Set<Long> expectedTimestamps = new HashSet<Long>();
         // insert something every 30s for 5 mins.
@@ -224,7 +227,7 @@ public class DBasicMetricsRWIntegrationTest extends IntegrationTestBase {
 
         final Locator locator  = Locator.createLocatorFromPathComponents(acctId, metricName);
 
-        DBasicMetricsRW metricsRW = new DBasicMetricsRW(false, new ArrayList<String>());
+        DBasicMetricsRW metricsRW = new DBasicMetricsRW(locatorIO, false, new ArrayList<String>());
 
         int sameValue = getRandomIntMetricValue();
         Set<Long> expectedTimestamps = new HashSet<Long>();
@@ -258,7 +261,7 @@ public class DBasicMetricsRWIntegrationTest extends IntegrationTestBase {
         final Locator locator  = Locator.createLocatorFromPathComponents(acctId, metricName);
         MetadataCache.getInstance().put(locator, MetricMetadata.TYPE.name().toLowerCase(), DataType.BOOLEAN.toString());
 
-        DBasicMetricsRW metricsRW = new DBasicMetricsRW(false, new ArrayList<String>());
+        DBasicMetricsRW metricsRW = new DBasicMetricsRW(locatorIO, false, new ArrayList<String>());
 
         boolean sameValue = true;
         Set<Long> expectedTimestamps = new HashSet<Long>();
@@ -295,7 +298,7 @@ public class DBasicMetricsRWIntegrationTest extends IntegrationTestBase {
         final Locator locator  = Locator.createLocatorFromPathComponents(acctId, metricName);
         MetadataCache.getInstance().put(locator, MetricMetadata.TYPE.name().toLowerCase(), DataType.BOOLEAN.toString());
 
-        DBasicMetricsRW metricsRW = new DBasicMetricsRW(false, new ArrayList<String>());
+        DBasicMetricsRW metricsRW = new DBasicMetricsRW(locatorIO, false, new ArrayList<String>());
 
         Set<Long> expectedTimestamps = new HashSet<Long>();
         // insert something every 30s for 5 mins.

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AbstractMetricsRW.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class AbstractMetricsRW implements MetricsRW {
 
-    protected final MetadataCache metadataCache = MetadataCache.getInstance();
     protected static final String DATA_TYPE_CACHE_KEY = MetricMetadata.TYPE.toString().toLowerCase();
 
     protected static TenantTtlProvider TTL_PROVIDER = SafetyTtlProvider.getInstance();
@@ -85,23 +84,6 @@ public abstract class AbstractMetricsRW implements MetricsRW {
         for (IMetric metric: metrics)
             map.put(metric.getLocator(), metric);
         return map;
-    }
-
-    /**
-     * For a particular {@link com.rackspacecloud.blueflood.types.Locator}, get
-     * its corresponding {@link com.rackspacecloud.blueflood.types.DataType}
-     *
-     * @param locator
-     * @param dataTypeCacheKey
-     * @return
-     * @throws CacheException
-     */
-    protected DataType getDataType(Locator locator, String dataTypeCacheKey) throws CacheException {
-        String meta = metadataCache.get(locator, dataTypeCacheKey);
-        if (meta != null) {
-            return new DataType(meta);
-        }
-        return DataType.NUMERIC;
     }
 
     /**

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IOContainer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IOContainer.java
@@ -87,9 +87,10 @@ public class IOContainer {
             shardStateIO = new DShardStateIO();
             locatorIO = new DLocatorIO();
             excessEnumIO = new DExcessEnumIO();
-            enumReaderIO = new DEnumIO();
-            basicMetricsRW = new DBasicMetricsRW(stringMetricsDropped, tenantIdsKept);
-            preAggregatedMetricsRW = new DPreaggregatedMetricsRW();
+            DEnumIO enumIO = new DEnumIO();
+            enumReaderIO = enumIO;
+            basicMetricsRW = new DBasicMetricsRW(locatorIO, stringMetricsDropped, tenantIdsKept);
+            preAggregatedMetricsRW = new DPreaggregatedMetricsRW(enumIO, locatorIO);
 
         } else {
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
@@ -25,7 +25,16 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
 
     private static final Logger LOG = LoggerFactory.getLogger( DAbstractMetricsRW.class );
 
-    protected final LocatorIO locatorIO = new DLocatorIO();
+    protected final LocatorIO locatorIO;
+
+
+    /**
+     * Constructor
+     * @param locatorIO
+     */
+    protected DAbstractMetricsRW(LocatorIO locatorIO) {
+        this.locatorIO = locatorIO;
+    }
 
     /**
      * Return the appropriate IO object which interacts with the Cassandra database.
@@ -126,6 +135,8 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
 
         try {
 
+            MetadataCache metadataCache = MetadataCache.getInstance();
+
             // in this loop, we will fire all the executeAsync() of
             // various select statements, the collect all of the
             // ResultSetFutures
@@ -135,7 +146,7 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
             for (Locator locator : locators) {
                 try {
 
-                    String rType = metadataCache.get( locator, MetricMetadata.ROLLUP_TYPE.name().toLowerCase() );
+                    String rType = metadataCache.get(locator, MetricMetadata.ROLLUP_TYPE.name().toLowerCase());
 
                     DAbstractMetricIO io = getIO( rType, granularity );
 
@@ -156,7 +167,7 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
 
                 } catch (CacheException ex) {
                     Instrumentation.markReadError();
-                LOG.error(String.format("Error looking up locator %s in cache", locator), ex);
+                    LOG.error(String.format("Error looking up locator %s in cache", locator), ex);
                 }
             }
             return resultSetsToMetricData(locatorToFuturesMap, locatorIOMap, granularity);
@@ -276,5 +287,24 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
             Object value = tsRollupMap.values().iterator().next();
             return value instanceof Rollup ? ( (Rollup) value ).getRollupType() : null;
         }
+    }
+
+
+    /**
+     * For a particular {@link com.rackspacecloud.blueflood.types.Locator}, get
+     * its corresponding {@link com.rackspacecloud.blueflood.types.DataType}
+     *
+     * @param locator
+     * @param dataTypeCacheKey
+     * @return
+     * @throws CacheException
+     */
+    protected DataType getDataType(Locator locator, String dataTypeCacheKey) throws CacheException {
+        MetadataCache metadataCache = MetadataCache.getInstance();
+        String meta = metadataCache.get(locator, dataTypeCacheKey);
+        if (meta != null) {
+            return new DataType(meta);
+        }
+        return DataType.NUMERIC;
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
@@ -36,8 +36,8 @@ public class DBasicMetricsRW extends DAbstractMetricsRW {
      * ingestion of String metrics for all tenants.
      * See #DBasicMetricsRW(boolean, List) to change the behavior.
      */
-    public DBasicMetricsRW() {
-        this(false, new ArrayList<String>());
+    public DBasicMetricsRW(LocatorIO locatorIO) {
+        this(locatorIO, false, new ArrayList<String>());
     }
 
     /**
@@ -46,7 +46,8 @@ public class DBasicMetricsRW extends DAbstractMetricsRW {
      * @param ignoreStringMetrics
      * @param tenantIdsKept
      */
-    public DBasicMetricsRW(boolean ignoreStringMetrics, List<String> tenantIdsKept) {
+    public DBasicMetricsRW(LocatorIO locatorIO, boolean ignoreStringMetrics, List<String> tenantIdsKept) {
+        super(locatorIO);
         this.areStringMetricsDropped = ignoreStringMetrics;
         this.keptTenantIdsSet  = new HashSet<String>(tenantIdsKept);
     }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
@@ -54,6 +54,9 @@ public class DLocatorIO implements LocatorIO {
     private PreparedStatement getValue;
     private PreparedStatement putValue;
 
+    /**
+     * Constructor
+     */
     public DLocatorIO() {
         createPreparedStatements();
     }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetricsCFPreparedStatements.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetricsCFPreparedStatements.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2016 Rackspace.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspacecloud.blueflood.io.datastax;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.rackspacecloud.blueflood.io.CassandraModel;
+import com.rackspacecloud.blueflood.rollup.Granularity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A class that holds together all the Datastax PreparedStatement related to
+ * inserting/querying ColumnFamilies used to store the actual metrics
+ * (i.e: metrics_full, metrics_{gran}, metrics_preaggregated_full, and
+ * metrics_preaggregated_{gran})
+ *
+ * This is a singleton to ensure that the PreparedStatements are created
+ * only once.
+ */
+public class DMetricsCFPreparedStatements {
+
+    protected static final String INSERT_KEY_COLUMN_VALUE_TTL_FORMAT = "INSERT INTO %s (key, column1, value) VALUES (?, ?, ?) USING TTL ?";
+    protected static final String SELECT_FOR_KEY_RANGE_FORMAT = "SELECT * FROM %s WHERE key = :locator AND column1 >= :tsStart AND column1 <= :tsEnd";
+
+    /**
+     * The key of the metrics_* and metrics_preaggregated_* Column Families
+     */
+    public static final String KEY = "key";
+
+    /**
+     * The name of the first column
+     */
+    public static final String COLUMN1 = "column1";
+
+    /**
+     * The name of the value column
+     */
+    public static final String VALUE = "value";
+
+    private static final DMetricsCFPreparedStatements INSTANCE = new DMetricsCFPreparedStatements();
+
+    protected final PreparedStatement insertToMetricsPreaggrFullStatement;
+    protected final PreparedStatement insertToMetricsPreaggr5MStatement;
+    protected final PreparedStatement insertToMetricsPreaggr20MStatement;
+    protected final PreparedStatement insertToMetricsPreaggr60MStatement;
+    protected final PreparedStatement insertToMetricsPreaggr240MStatement;
+    protected final PreparedStatement insertToMetricsPreaggr1440MStatement;
+
+    protected final PreparedStatement selectFromMetricsPreaggrFullForRangeStatement;
+    protected final PreparedStatement selectFromMetricsPreaggr5MForRangeStatement;
+    protected final PreparedStatement selectFromMetricsPreaggr20MForRangeStatement;
+    protected final PreparedStatement selectFromMetricsPreaggr60MForRangeStatement;
+    protected final PreparedStatement selectFromMetricsPreaggr240MForRangeStatement;
+    protected final PreparedStatement selectFromMetricsPreaggr1440MForRangeStatement;
+
+    protected final PreparedStatement insertToMetricsBasicFullStatement;
+    protected final PreparedStatement insertToMetricsBasic5MStatement;
+    protected final PreparedStatement insertToMetricsBasic20MStatement;
+    protected final PreparedStatement insertToMetricsBasic60MStatement;
+    protected final PreparedStatement insertToMetricsBasic240MStatement;
+    protected final PreparedStatement insertToMetricsBasic1440MStatement;
+
+    protected final PreparedStatement selectFromMetricsStringForRangeStatement;
+
+    protected final PreparedStatement selectFromMetricsBasicFullForRangeStatement;
+    protected final PreparedStatement selectFromMetricsBasic5MForRangeStatement;
+    protected final PreparedStatement selectFromMetricsBasic20MForRangeStatement;
+    protected final PreparedStatement selectFromMetricsBasic60MForRangeStatement;
+    protected final PreparedStatement selectFromMetricsBasic240MForRangeStatement;
+    protected final PreparedStatement selectFromMetricsBasic1440MForRangeStatement;
+
+    protected Map<String, PreparedStatement> cfNameToSelectStatement;
+    protected Map<Granularity, PreparedStatement> preaggrGranToInsertStatement;
+    protected Map<Granularity, PreparedStatement> basicGranToInsertStatement;
+
+    private DMetricsCFPreparedStatements() {
+        Session session = DatastaxIO.getSession();
+
+        //
+        // Preaggr insert statements
+        //
+        insertToMetricsPreaggrFullStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_FULL_NAME));
+        insertToMetricsPreaggr5MStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_5M_NAME));
+        insertToMetricsPreaggr20MStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_20M_NAME));
+        insertToMetricsPreaggr60MStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_60M_NAME));
+        insertToMetricsPreaggr240MStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_240M_NAME));
+        insertToMetricsPreaggr1440MStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_1440M_NAME));
+
+        //
+        // Preaggr select statements
+        //
+        selectFromMetricsPreaggrFullForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_FULL_NAME));
+        selectFromMetricsPreaggr5MForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_5M_NAME));
+        selectFromMetricsPreaggr20MForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_20M_NAME));
+        selectFromMetricsPreaggr60MForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_60M_NAME));
+        selectFromMetricsPreaggr240MForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_240M_NAME));
+        selectFromMetricsPreaggr1440MForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_PREAGGREGATED_1440M_NAME));
+
+        cfNameToSelectStatement = new HashMap<String, PreparedStatement>() {{
+            put(CassandraModel.CF_METRICS_PREAGGREGATED_FULL_NAME, selectFromMetricsPreaggrFullForRangeStatement);
+            put(CassandraModel.CF_METRICS_PREAGGREGATED_5M_NAME, selectFromMetricsPreaggr5MForRangeStatement);
+            put(CassandraModel.CF_METRICS_PREAGGREGATED_20M_NAME, selectFromMetricsPreaggr20MForRangeStatement);
+            put(CassandraModel.CF_METRICS_PREAGGREGATED_60M_NAME, selectFromMetricsPreaggr60MForRangeStatement);
+            put(CassandraModel.CF_METRICS_PREAGGREGATED_240M_NAME, selectFromMetricsPreaggr240MForRangeStatement);
+            put(CassandraModel.CF_METRICS_PREAGGREGATED_1440M_NAME, selectFromMetricsPreaggr1440MForRangeStatement);
+        }};
+
+        preaggrGranToInsertStatement = new HashMap<Granularity, PreparedStatement>() {{
+            put(Granularity.FULL, insertToMetricsPreaggrFullStatement);
+            put(Granularity.MIN_5, insertToMetricsPreaggr5MStatement);
+            put(Granularity.MIN_20, insertToMetricsPreaggr20MStatement);
+            put(Granularity.MIN_60, insertToMetricsPreaggr60MStatement);
+            put(Granularity.MIN_240, insertToMetricsPreaggr240MStatement);
+            put(Granularity.MIN_1440, insertToMetricsPreaggr1440MStatement);
+        }};
+
+        //
+        // Basic insert statements
+        //
+        insertToMetricsBasicFullStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_FULL_NAME));
+        insertToMetricsBasic5MStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_5M_NAME));
+        insertToMetricsBasic20MStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_20M_NAME));
+        insertToMetricsBasic60MStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_60M_NAME));
+        insertToMetricsBasic240MStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_240M_NAME));
+        insertToMetricsBasic1440MStatement = session.prepare(
+                String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
+                        CassandraModel.CF_METRICS_1440M_NAME));
+
+        //
+        // Basic select statements
+        //
+        selectFromMetricsStringForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_STRING_NAME));
+        selectFromMetricsBasicFullForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_FULL_NAME));
+        selectFromMetricsBasic5MForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_5M_NAME));
+        selectFromMetricsBasic20MForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_20M_NAME));
+        selectFromMetricsBasic60MForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_60M_NAME));
+        selectFromMetricsBasic240MForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_240M_NAME));
+        selectFromMetricsBasic1440MForRangeStatement = session.prepare(
+                String.format(SELECT_FOR_KEY_RANGE_FORMAT,
+                        CassandraModel.CF_METRICS_1440M_NAME));
+
+        cfNameToSelectStatement.put( CassandraModel.CF_METRICS_STRING_NAME, selectFromMetricsStringForRangeStatement );
+
+        cfNameToSelectStatement.put( CassandraModel.CF_METRICS_FULL_NAME, selectFromMetricsBasicFullForRangeStatement );
+        cfNameToSelectStatement.put( CassandraModel.CF_METRICS_5M_NAME, selectFromMetricsBasic5MForRangeStatement );
+        cfNameToSelectStatement.put( CassandraModel.CF_METRICS_20M_NAME, selectFromMetricsBasic20MForRangeStatement );
+        cfNameToSelectStatement.put( CassandraModel.CF_METRICS_60M_NAME, selectFromMetricsBasic60MForRangeStatement );
+        cfNameToSelectStatement.put( CassandraModel.CF_METRICS_240M_NAME, selectFromMetricsBasic240MForRangeStatement );
+        cfNameToSelectStatement.put(CassandraModel.CF_METRICS_1440M_NAME, selectFromMetricsBasic1440MForRangeStatement);
+
+        basicGranToInsertStatement = new HashMap<Granularity, PreparedStatement>() {{
+            // NOTE:  this shoudn't be called.  explain why later
+            put(Granularity.FULL, insertToMetricsBasicFullStatement );
+            put(Granularity.MIN_5, insertToMetricsBasic5MStatement);
+            put(Granularity.MIN_20, insertToMetricsBasic20MStatement);
+            put(Granularity.MIN_60, insertToMetricsBasic60MStatement);
+            put(Granularity.MIN_240, insertToMetricsBasic240MStatement);
+            put(Granularity.MIN_1440, insertToMetricsBasic1440MStatement);
+        }};
+    }
+
+    /**
+     * Method to fetch the singleton instance
+     * @return
+     */
+    public static DMetricsCFPreparedStatements getInstance() { return INSTANCE; }
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
@@ -40,7 +40,6 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
     private static final Logger LOG = LoggerFactory.getLogger(DPreaggregatedMetricsRW.class);
 
     private final DCounterIO counterIO = new DCounterIO();
-    private final DEnumIO enumIO = new DEnumIO();
     private final DGagueIO gaugeIO = new DGagueIO();
     private final DSetIO setIO = new DSetIO();
     private final DTimerIO timerIO = new DTimerIO();
@@ -48,14 +47,20 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
     // a map of RollupType to its IO class that knows
     // how to read/write that particular type of rollup
     private final Map<RollupType, DAbstractMetricIO> rollupTypeToIO =
-            new HashMap<RollupType, DAbstractMetricIO>() {{
-                put(RollupType.COUNTER, counterIO);
-                put(RollupType.ENUM, enumIO);
-                put(RollupType.GAUGE, gaugeIO);
-                put(RollupType.SET, setIO);
-                put(RollupType.TIMER, timerIO);
-            }};
+            new HashMap<RollupType, DAbstractMetricIO>();
 
+    /**
+     * Constructor
+     * @param locatorIO
+     */
+    public DPreaggregatedMetricsRW(DAbstractMetricIO enumIO, LocatorIO locatorIO) {
+        super(locatorIO);
+        rollupTypeToIO.put(RollupType.COUNTER, counterIO);
+        rollupTypeToIO.put(RollupType.ENUM, enumIO);
+        rollupTypeToIO.put(RollupType.GAUGE, gaugeIO);
+        rollupTypeToIO.put(RollupType.SET, setIO);
+        rollupTypeToIO.put(RollupType.TIMER, timerIO);
+    }
 
     /**
      * Inserts a collection of metrics to the metrics_preaggregated_full column family
@@ -80,6 +85,7 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
     @Override
     public void insertMetrics(Collection<IMetric> metrics,
                               Granularity granularity) throws IOException {
+
         Timer.Context ctx = Instrumentation.getWriteTimerContext(
                 CassandraModel.getPreaggregatedColumnFamilyName(granularity));
         try {


### PR DESCRIPTION
This PR fixes some of the warning logs coming out from Datastax, indicating that most of our PreparedStatements are created more than once. The PreparedStatements are mostly created inside of the *IO classes constructors. In particular, the PreparedStatements were created more than once for the following cases:
* Both IOContainer and DAbstractMetricsRW classes instantiate new instance of DLocatorIO. This is fixed by making DAbstractMetricsRW constructor takes a LocatorIO.
* IOContainer holds instance of *BasicMetricsRW and *PreagggregatedMetricsRW. The first time ```IOContainer.fromConfig()``` is called, it will instantiate all the *IO classes and the *RW classes. The two *RW classes hold an instance of MetadataCache. But MetadataCache needs an instance of MetadataIO class, so it calls ```IOContainer.fromConfig().getMetadataIO()```. The call to ```fromConfig()``` causes IOContainer to create another set of *IO classes and *RW classes. This is fixed by delaying the call to MetadataCache.getInstance() inside the methods that need it.
* A lot of PreparedStatements live inside DAbstractMetricsIO, which many other *IO classes extend from. Everytime we create DEnumIO, DLocatorIO, etc, new instances of these PreparedStatements are created. This is fixed by moving all the PreparedStatements to a singleton class ```DMetricsCFPreparedStatement```