### PR TITLE
adjust ttl logging

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/ConfigTtlProvider.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/ConfigTtlProvider.java
@@ -52,7 +52,7 @@ public class ConfigTtlProvider implements TenantTtlProvider {
                 stringTTL = new TimeValue(config.getIntegerProperty(TtlConfig.STRING_METRICS_TTL), TimeUnit.DAYS);
             }
         } catch (NumberFormatException ex) {
-            log.warn("No valid String TTL in config.", ex);
+            log.warn("No valid String TTL in config.");
         }
         this.stringTTL = stringTTL;
 
@@ -113,7 +113,7 @@ public class ConfigTtlProvider implements TenantTtlProvider {
             value = config.getIntegerProperty(configKey);
             if (value < 0) return false;
         } catch (NumberFormatException ex) {
-            log.info(String.format("No valid TTL config set for granularity: %s, rollup type: %s",
+            log.debug(String.format("No valid TTL config set for granularity: %s, rollup type: %s",
                     gran.name(), rollupType.name()), ex);
             return false;
         }
@@ -126,8 +126,9 @@ public class ConfigTtlProvider implements TenantTtlProvider {
         final TimeValue ttl = ttlMapper.get(gran, rollupType);
 
         if (ttl == null) {
-            log.warn("No valid TTL entry for granularity: {}, rollup type: {}"
-                + " in config. Resorting to safe TTL values.", gran.name(), rollupType.name());
+            log.debug("No valid TTL entry for granularity: {}, rollup type: {}" +
+                      " in config. Resorting to safe TTL values.",
+                       gran.name(), rollupType.name());
             return Optional.absent();
         }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/ConfigTtlProvider.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/ConfigTtlProvider.java
@@ -52,7 +52,7 @@ public class ConfigTtlProvider implements TenantTtlProvider {
                 stringTTL = new TimeValue(config.getIntegerProperty(TtlConfig.STRING_METRICS_TTL), TimeUnit.DAYS);
             }
         } catch (NumberFormatException ex) {
-            log.warn("No valid String TTL in config.");
+            log.debug("No valid String TTL in config.");
         }
         this.stringTTL = stringTTL;
 


### PR DESCRIPTION
The latest master code prints too much logging. With this PR, I am fixing 2 parts:

* Logging when Blueflood starts up
For every rollup type + granularity, we print this exception when Blueflood starts
```
2016-06-28 16:50:15,734 1699 [main] INFO  com.rackspacecloud.blueflood.cache.ConfigTtlProvider  - No valid TTL config set for granularity: metrics_1440m, rollup type: GAUGE
java.lang.NumberFormatException: For input string: ""
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Integer.parseInt(Integer.java:592)
        at java.lang.Integer.parseInt(Integer.java:615)
        at com.rackspacecloud.blueflood.service.Configuration.intFromString(Configuration.java:115)
        at com.rackspacecloud.blueflood.service.Configuration.getIntegerProperty(Configuration.java:112)
        at com.rackspacecloud.blueflood.service.Configuration.getIntegerProperty(Configuration.java:109)
        at com.rackspacecloud.blueflood.cache.ConfigTtlProvider.put(ConfigTtlProvider.java:113)
        at com.rackspacecloud.blueflood.cache.ConfigTtlProvider.<init>(ConfigTtlProvider.java:92)
        at com.rackspacecloud.blueflood.cache.ConfigTtlProvider.<clinit>(ConfigTtlProvider.java:36)
        at com.rackspacecloud.blueflood.cache.CombinedTtlProvider.<clinit>(CombinedTtlProvider.java:32)
        at com.rackspacecloud.blueflood.io.AbstractMetricsRW.<clinit>(AbstractMetricsRW.java:47)
        at com.rackspacecloud.blueflood.io.IOContainer.<init>(IOContainer.java:92)
        at com.rackspacecloud.blueflood.io.IOContainer.fromConfig(IOContainer.java:63)
        at com.rackspacecloud.blueflood.cache.MetadataCache.<init>(MetadataCache.java:100)
        at com.rackspacecloud.blueflood.cache.MetadataCache.<clinit>(MetadataCache.java:99)
        at com.rackspacecloud.blueflood.service.BluefloodServiceStarter.run(BluefloodServiceStarter.java:276)
        at com.rackspacecloud.blueflood.service.BluefloodServiceStarter.main(BluefloodServiceStarter.java:250)
```

* Logging when Rollup is executed
This gets printed a LOT, probably for every metric we roll up.
```
2016-06-28 16:50:48,169 34134 [pool-12-thread-4] WARN  com.rackspacecloud.blueflood.cache.ConfigTtlProvider  - No valid TTL entry for granularity: metrics_5m, rollup type: BF_BASIC in config. Resorting to safe TTL values.
```