### PR TITLE
New perf script

### DIFF
--- a/contrib/grinder/scripts/annotationsingest.py
+++ b/contrib/grinder/scripts/annotationsingest.py
@@ -1,78 +1,80 @@
 import random
-try: 
-  from com.xhaus.jyson import JysonCodec as json
+
+try:
+    from com.xhaus.jyson import JysonCodec as json
 except ImportError:
-  import json
+    import json
 from utils import *
 from net.grinder.script import Test
 from net.grinder.plugin.http import HTTPRequest
 
+
 class AnnotationsIngestThread(AbstractThread):
-  # The list of metric numbers for all threads in this worker
-  annotations = []
+    # The list of metric numbers for all threads in this worker
+    annotations = []
 
-  # Grinder test reporting infrastructure
-  test1 = Test(2, "Annotations Ingest test")
-  request = HTTPRequest()
-  test1.record(request)
+    # Grinder test reporting infrastructure
+    test1 = Test(2, "Annotations Ingest test")
+    request = HTTPRequest()
+    test1.record(request)
 
+    @classmethod
+    def create_metrics(cls, agent_number):
+        """ Generate all the annotations for this worker
 
-  @classmethod
-  def create_metrics(cls, agent_number):
-    """ Generate all the annotations for this worker
+        """
+        cls.annotations = generate_metrics_tenants(
+            default_config['annotations_num_tenants'],
+            default_config['annotations_per_tenant'], agent_number,
+            default_config['num_nodes'],
+            cls.generate_annotations_for_tenant)
 
-    """
-    cls.annotations = generate_metrics_tenants(default_config['annotations_num_tenants'],
-                                            default_config['annotations_per_tenant'], agent_number,
-                                            default_config['num_nodes'], 
-                                            cls.generate_annotations_for_tenant)
+    @classmethod
+    def num_threads(cls):
+        return default_config['annotations_concurrency']
 
+    @classmethod
+    def generate_annotations_for_tenant(cls, tenant_id, annotations_per_tenant):
+        l = [];
+        for x in range(annotations_per_tenant):
+            l.append([tenant_id, x])
+        return l
 
-  @classmethod
-  def num_threads(cls):
-    return default_config['annotations_concurrency']
+    def __init__(self, thread_num):
+        AbstractThread.__init__(self, thread_num)
+        # Initialize the "slice" of the metrics to be sent by this thread
+        start, end = generate_job_range(len(self.annotations),
+                                        self.num_threads(), thread_num)
+        self.slice = self.annotations[start:end]
 
-  @classmethod
-  def generate_annotations_for_tenant(cls, tenant_id, annotations_per_tenant):
-    l = [];
-    for x in range(annotations_per_tenant):
-      l.append([tenant_id, x])
-    return l
+    def generate_annotation(self, time, metric_id):
+        metric_name = generate_metric_name(metric_id)
+        return {'what': 'annotation ' + metric_name,
+                'when': time,
+                'tags': 'tag',
+                'data': 'data'}
 
-  def __init__(self, thread_num):
-    AbstractThread.__init__(self, thread_num)
-    # Initialize the "slice" of the metrics to be sent by this thread
-    start, end = generate_job_range(len(self.annotations),
-                                    self.num_threads(), thread_num)
-    self.slice = self.annotations[start:end]
+    def generate_payload(self, time, metric_id):
+        payload = self.generate_annotation(time, metric_id)
+        return json.dumps(payload)
 
-  def generate_annotation(self, time, metric_id):
-    metric_name = generate_metric_name(metric_id)
-    return {'what': 'annotation '+metric_name,
-            'when': time,
-            'tags': 'tag',
-            'data': 'data'}
+    def ingest_url(self, tenant_id):
+        return "%s/v2.0/%s/events" % (default_config['url'], tenant_id)
 
-  def generate_payload(self, time, metric_id):
-    payload = self.generate_annotation(time, metric_id)
-    return json.dumps(payload)
+    def make_request(self, logger):
+        if len(self.slice) == 0:
+            logger("Warning: no work for current thread")
+            self.sleep(1000000)
+            return None
+        self.check_position(logger, len(self.slice))
+        batch = self.slice[self.position]
+        tenant_id = batch[0]
+        metric_id = batch[1]
+        payload = self.generate_payload(int(self.time()), metric_id)
 
-  def ingest_url(self, tenant_id):
-    return "%s/v2.0/%s/events" % (default_config['url'], tenant_id)
+        self.position += 1
+        result = self.request.POST(self.ingest_url(tenant_id), payload)
+        return result
 
-  def make_request(self, logger):
-    if len(self.slice) == 0:
-      logger("Warning: no work for current thread")
-      self.sleep(1000000)
-      return None
-    self.check_position(logger, len(self.slice))
-    batch = self.slice[self.position]
-    tenant_id = batch[0]
-    metric_id = batch[1]
-    payload = self.generate_payload(int(self.time()), metric_id)
-
-    self.position += 1
-    result = self.request.POST(self.ingest_url(tenant_id), payload)
-    return result
 
 ThreadManager.add_type(AnnotationsIngestThread)

--- a/contrib/grinder/scripts/annotationsingest.py
+++ b/contrib/grinder/scripts/annotationsingest.py
@@ -36,7 +36,7 @@ class AnnotationsIngestThread(AbstractThread):
     @classmethod
     def generate_annotations_for_tenant(cls, tenant_id,
                                         annotations_per_tenant):
-        l = [];
+        l = []
         for x in range(annotations_per_tenant):
             l.append([tenant_id, x])
         return l

--- a/contrib/grinder/scripts/annotationsingest.py
+++ b/contrib/grinder/scripts/annotationsingest.py
@@ -34,7 +34,8 @@ class AnnotationsIngestThread(AbstractThread):
         return default_config['annotations_concurrency']
 
     @classmethod
-    def generate_annotations_for_tenant(cls, tenant_id, annotations_per_tenant):
+    def generate_annotations_for_tenant(cls, tenant_id,
+                                        annotations_per_tenant):
         l = [];
         for x in range(annotations_per_tenant):
             l.append([tenant_id, x])

--- a/contrib/grinder/scripts/grinder.py
+++ b/contrib/grinder/scripts/grinder.py
@@ -4,17 +4,17 @@ import ingestenum
 import annotationsingest
 import query
 
-#ENTRY POINT into the Grinder
+# ENTRY POINT into the Grinder
 
-#The code inside the TestRunner class is gets executed by each worker thread
-#Outside the class is executed before any of the workers begin
+# The code inside the TestRunner class is gets executed by each worker thread
+# Outside the class is executed before any of the workers begin
 thread_manager = ingest.ThreadManager(grinder)
 thread_manager.create_all_metrics(grinder.getAgentNumber())
- 
+
+
 class TestRunner:
-  def __init__(self):
-    self.thread = thread_manager.setup_thread(grinder.getThreadNumber())
+    def __init__(self):
+        self.thread = thread_manager.setup_thread(grinder.getThreadNumber())
 
-  def __call__(self):
-    result = self.thread.make_request(grinder.logger.info)
-
+    def __call__(self):
+        result = self.thread.make_request(grinder.logger.info)

--- a/contrib/grinder/scripts/ingest.py
+++ b/contrib/grinder/scripts/ingest.py
@@ -22,14 +22,14 @@ class IngestThread(AbstractThread):
     def create_metrics(cls, agent_number):
         """ Generate all the metrics for this worker
 
-        The metrics are a list of batches.  Each batch is a list of metrics processed by
-        a single metrics ingest request.
+        The metrics are a list of batches.  Each batch is a list of metrics
+        processed by a single metrics ingest request.
         """
-        metrics = generate_metrics_tenants(default_config['num_tenants'],
-                                           default_config['metrics_per_tenant'],
-                                           agent_number,
-                                           default_config['num_nodes'],
-                                           cls.generate_metrics_for_tenant)
+        metrics = generate_metrics_tenants(
+            default_config['num_tenants'],
+            default_config['metrics_per_tenant'],
+            agent_number, default_config['num_nodes'],
+            cls.generate_metrics_for_tenant)
 
         cls.metrics = cls.divide_metrics_into_batches(metrics, default_config[
             'batch_size'])

--- a/contrib/grinder/scripts/ingest.py
+++ b/contrib/grinder/scripts/ingest.py
@@ -1,95 +1,99 @@
 import random
-try: 
-  from com.xhaus.jyson import JysonCodec as json
+
+try:
+    from com.xhaus.jyson import JysonCodec as json
 except ImportError:
-  import json
+    import json
 from utils import *
 from net.grinder.script import Test
 from net.grinder.plugin.http import HTTPRequest
 
+
 class IngestThread(AbstractThread):
-  # The list of metric numbers for all threads in this worker
-  metrics = []
-  
-  # Grinder test reporting infrastructure
-  test1 = Test(1, "Ingest test")
-  request = HTTPRequest()
-  test1.record(request)
+    # The list of metric numbers for all threads in this worker
+    metrics = []
 
+    # Grinder test reporting infrastructure
+    test1 = Test(1, "Ingest test")
+    request = HTTPRequest()
+    test1.record(request)
 
-  @classmethod
-  def create_metrics(cls, agent_number):
-    """ Generate all the metrics for this worker
+    @classmethod
+    def create_metrics(cls, agent_number):
+        """ Generate all the metrics for this worker
 
-    The metrics are a list of batches.  Each batch is a list of metrics processed by
-    a single metrics ingest request.
-    """
-    metrics =  generate_metrics_tenants(default_config['num_tenants'],
-                                            default_config['metrics_per_tenant'], agent_number, 
-                                            default_config['num_nodes'], 
-                                            cls.generate_metrics_for_tenant)
+        The metrics are a list of batches.  Each batch is a list of metrics processed by
+        a single metrics ingest request.
+        """
+        metrics = generate_metrics_tenants(default_config['num_tenants'],
+                                           default_config['metrics_per_tenant'],
+                                           agent_number,
+                                           default_config['num_nodes'],
+                                           cls.generate_metrics_for_tenant)
 
-    cls.metrics = cls.divide_metrics_into_batches(metrics, default_config['batch_size'])
+        cls.metrics = cls.divide_metrics_into_batches(metrics, default_config[
+            'batch_size'])
 
-  @classmethod
-  def num_threads(cls):
-    return default_config['ingest_concurrency']
+    @classmethod
+    def num_threads(cls):
+        return default_config['ingest_concurrency']
 
-  @classmethod
-  def generate_metrics_for_tenant(cls, tenant_id, metrics_per_tenant):
-    l = [];
-    for x in range(metrics_per_tenant):
-      l.append([tenant_id, x])
-    return l
+    @classmethod
+    def generate_metrics_for_tenant(cls, tenant_id, metrics_per_tenant):
+        l = [];
+        for x in range(metrics_per_tenant):
+            l.append([tenant_id, x])
+        return l
 
-  @classmethod
-  def divide_metrics_into_batches(cls, metrics, batch_size):
-    b = []
-    for i in range(0, len(metrics), batch_size):
-      b.append(metrics[i:i+batch_size])
-    return b
+    @classmethod
+    def divide_metrics_into_batches(cls, metrics, batch_size):
+        b = []
+        for i in range(0, len(metrics), batch_size):
+            b.append(metrics[i:i + batch_size])
+        return b
 
-  def __init__(self, thread_num):
-    AbstractThread.__init__(self, thread_num)
-    # Initialize the "slice" of the metrics to be sent by this thread
-    start, end = generate_job_range(len(self.metrics), 
-                                    self.num_threads(), thread_num)
-    self.slice = self.metrics[start:end]
+    def __init__(self, thread_num):
+        AbstractThread.__init__(self, thread_num)
+        # Initialize the "slice" of the metrics to be sent by this thread
+        start, end = generate_job_range(len(self.metrics),
+                                        self.num_threads(), thread_num)
+        self.slice = self.metrics[start:end]
 
-  def generate_metric(self, time, tenant_id, metric_id):
-    ingest_delay_millis = default_config['ingest_delay_millis']
+    def generate_metric(self, time, tenant_id, metric_id):
+        ingest_delay_millis = default_config['ingest_delay_millis']
 
-    collection_time = time
-    # all even tenants have possible delayed metrics
-    if len(ingest_delay_millis) > 0 and tenant_id % 2 == 0:
-        collection_times = [time - long(delay) for delay in ingest_delay_millis.split(",")]
-        collection_time = random.choice(collection_times)
+        collection_time = time
+        # all even tenants have possible delayed metrics
+        if len(ingest_delay_millis) > 0 and tenant_id % 2 == 0:
+            collection_times = [time - long(delay) for delay in
+                                ingest_delay_millis.split(",")]
+            collection_time = random.choice(collection_times)
 
-    return {'tenantId': str(tenant_id),
-            'metricName': generate_metric_name(metric_id),
-            'unit': self.generate_unit(tenant_id),
-            'metricValue': random.randint(0, RAND_MAX),
-            'ttlInSeconds': (2 * 24 * 60 * 60),
-            'collectionTime': collection_time}
+        return {'tenantId': str(tenant_id),
+                'metricName': generate_metric_name(metric_id),
+                'unit': self.generate_unit(tenant_id),
+                'metricValue': random.randint(0, RAND_MAX),
+                'ttlInSeconds': (2 * 24 * 60 * 60),
+                'collectionTime': collection_time}
 
-  def generate_payload(self, time, batch):
-    payload = map(lambda x:self.generate_metric(time,*x), batch)
-    return json.dumps(payload)
+    def generate_payload(self, time, batch):
+        payload = map(lambda x: self.generate_metric(time, *x), batch)
+        return json.dumps(payload)
 
-  def ingest_url(self):
-    return "%s/v2.0/tenantId/ingest/multi" % default_config['url']
+    def ingest_url(self):
+        return "%s/v2.0/tenantId/ingest/multi" % default_config['url']
 
+    def make_request(self, logger):
+        if len(self.slice) == 0:
+            logger("Warning: no work for current thread")
+            self.sleep(1000000)
+            return None
+        self.check_position(logger, len(self.slice))
+        payload = self.generate_payload(int(self.time()),
+                                        self.slice[self.position])
+        self.position += 1
+        result = self.request.POST(self.ingest_url(), payload)
+        return result
 
-  def make_request(self, logger):
-    if len(self.slice) == 0:
-      logger("Warning: no work for current thread")
-      self.sleep(1000000)
-      return None
-    self.check_position(logger, len(self.slice))
-    payload = self.generate_payload(int(self.time()),
-                                           self.slice[self.position])
-    self.position += 1
-    result = self.request.POST(self.ingest_url(), payload)
-    return result
 
 ThreadManager.add_type(IngestThread)

--- a/contrib/grinder/scripts/ingest.py
+++ b/contrib/grinder/scripts/ingest.py
@@ -40,7 +40,7 @@ class IngestThread(AbstractThread):
 
     @classmethod
     def generate_metrics_for_tenant(cls, tenant_id, metrics_per_tenant):
-        l = [];
+        l = []
         for x in range(metrics_per_tenant):
             l.append([tenant_id, x])
         return l

--- a/contrib/grinder/scripts/ingestenum.py
+++ b/contrib/grinder/scripts/ingestenum.py
@@ -42,7 +42,7 @@ class EnumIngestThread(AbstractThread):
 
     @classmethod
     def generate_metrics_for_tenant(cls, tenant_id, metrics_per_tenant):
-        l = [];
+        l = []
         for x in range(metrics_per_tenant):
             l.append([tenant_id, x])
         return l

--- a/contrib/grinder/scripts/ingestenum.py
+++ b/contrib/grinder/scripts/ingestenum.py
@@ -1,89 +1,96 @@
 import random
 import time
+
 try:
-  from com.xhaus.jyson import JysonCodec as json
+    from com.xhaus.jyson import JysonCodec as json
 except ImportError:
-  import json
+    import json
 from utils import *
 from net.grinder.script import Test
 from net.grinder.plugin.http import HTTPRequest
 
+
 class EnumIngestThread(AbstractThread):
-  # The list of metric numbers for all threads in this worker
-  metrics = []
+    # The list of metric numbers for all threads in this worker
+    metrics = []
 
-  # Grinder test reporting infrastructure
-  test1 = Test(7, "Enum Ingest test")
-  request = HTTPRequest()
-  test1.record(request)
+    # Grinder test reporting infrastructure
+    test1 = Test(7, "Enum Ingest test")
+    request = HTTPRequest()
+    test1.record(request)
 
-  @classmethod
-  def create_metrics(cls, agent_number):
-    """ Generate all the metrics for this worker
+    @classmethod
+    def create_metrics(cls, agent_number):
+        """ Generate all the metrics for this worker
 
-    The metrics are a list of batches.  Each batch is a list of metrics processed by
-    a single metrics ingest request.
-    """
-    metrics =  generate_metrics_tenants(default_config['enum_num_tenants'],
-                                            default_config['enum_metrics_per_tenant'], agent_number,
-                                            default_config['num_nodes'],
-                                            cls.generate_metrics_for_tenant)
+        The metrics are a list of batches.  Each batch is a list of metrics processed by
+        a single metrics ingest request.
+        """
+        metrics = generate_metrics_tenants(default_config['enum_num_tenants'],
+                                           default_config[
+                                               'enum_metrics_per_tenant'],
+                                           agent_number,
+                                           default_config['num_nodes'],
+                                           cls.generate_metrics_for_tenant)
 
-    cls.metrics = cls.divide_metrics_into_batches(metrics, default_config['batch_size'])
+        cls.metrics = cls.divide_metrics_into_batches(metrics, default_config[
+            'batch_size'])
 
-  @classmethod
-  def num_threads(cls):
-    return default_config['enum_ingest_concurrency']
+    @classmethod
+    def num_threads(cls):
+        return default_config['enum_ingest_concurrency']
 
-  @classmethod
-  def generate_metrics_for_tenant(cls, tenant_id, metrics_per_tenant):
-    l = [];
-    for x in range(metrics_per_tenant):
-      l.append([tenant_id, x])
-    return l
+    @classmethod
+    def generate_metrics_for_tenant(cls, tenant_id, metrics_per_tenant):
+        l = [];
+        for x in range(metrics_per_tenant):
+            l.append([tenant_id, x])
+        return l
 
-  @classmethod
-  def divide_metrics_into_batches(cls, metrics, batch_size):
-    b = []
-    for i in range(0, len(metrics), batch_size):
-      b.append(metrics[i:i+batch_size])
-    return b
+    @classmethod
+    def divide_metrics_into_batches(cls, metrics, batch_size):
+        b = []
+        for i in range(0, len(metrics), batch_size):
+            b.append(metrics[i:i + batch_size])
+        return b
 
-  def __init__(self, thread_num):
-    AbstractThread.__init__(self, thread_num)
-    # Initialize the "slice" of the metrics to be sent by this thread
-    start, end = generate_job_range(len(self.metrics),
-                                    self.num_threads(), thread_num)
-    self.slice = self.metrics[start:end]
+    def __init__(self, thread_num):
+        AbstractThread.__init__(self, thread_num)
+        # Initialize the "slice" of the metrics to be sent by this thread
+        start, end = generate_job_range(len(self.metrics),
+                                        self.num_threads(), thread_num)
+        self.slice = self.metrics[start:end]
 
-  def generate_enum_suffix(self):
-    return "_" + str(random.randint(0, default_config['enum_num_values']))
+    def generate_enum_suffix(self):
+        return "_" + str(random.randint(0, default_config['enum_num_values']))
 
-  def generate_enum_metric(self, time, tenant_id, metric_id):
-    return {'tenantId': str(tenant_id),
-            'timestamp': time,
-            'enums': [{'name': generate_enum_metric_name(metric_id),
-                       'value': 'e_g_'+str(metric_id) + self.generate_enum_suffix()}]
-            }
+    def generate_enum_metric(self, time, tenant_id, metric_id):
+        return {'tenantId': str(tenant_id),
+                'timestamp': time,
+                'enums': [{'name': generate_enum_metric_name(metric_id),
+                           'value': 'e_g_' + str(
+                               metric_id) + self.generate_enum_suffix()}]
+                }
 
-  def generate_payload(self, time, batch):
-    payload = map(lambda x:self.generate_enum_metric(time,*x), batch)
-    return json.dumps(payload)
+    def generate_payload(self, time, batch):
+        payload = map(lambda x: self.generate_enum_metric(time, *x), batch)
+        return json.dumps(payload)
 
-  def ingest_url(self):
-    return "%s/v2.0/tenantId/ingest/aggregated/multi" % default_config['url']
+    def ingest_url(self):
+        return "%s/v2.0/tenantId/ingest/aggregated/multi" % default_config[
+            'url']
 
+    def make_request(self, logger):
+        if len(self.slice) == 0:
+            logger("Warning: no work for current thread")
+            self.sleep(1000000)
+            return None
+        self.check_position(logger, len(self.slice))
+        payload = self.generate_payload(int(self.time()),
+                                        self.slice[self.position])
+        self.position += 1
+        result = self.request.POST(self.ingest_url(), payload)
+        return result
 
-  def make_request(self, logger):
-    if len(self.slice) == 0:
-      logger("Warning: no work for current thread")
-      self.sleep(1000000)
-      return None
-    self.check_position(logger, len(self.slice))
-    payload = self.generate_payload(int(self.time()),
-                                           self.slice[self.position])
-    self.position += 1
-    result = self.request.POST(self.ingest_url(), payload)
-    return result
 
 ThreadManager.add_type(EnumIngestThread)

--- a/contrib/grinder/scripts/ingestenum.py
+++ b/contrib/grinder/scripts/ingestenum.py
@@ -23,8 +23,8 @@ class EnumIngestThread(AbstractThread):
     def create_metrics(cls, agent_number):
         """ Generate all the metrics for this worker
 
-        The metrics are a list of batches.  Each batch is a list of metrics processed by
-        a single metrics ingest request.
+        The metrics are a list of batches.  Each batch is a list of metrics
+        processed by a single metrics ingest request.
         """
         metrics = generate_metrics_tenants(default_config['enum_num_tenants'],
                                            default_config[

--- a/contrib/grinder/scripts/query.py
+++ b/contrib/grinder/scripts/query.py
@@ -1,211 +1,238 @@
 import random
-try: 
-  from com.xhaus.jyson import JysonCodec as json
+
+try:
+    from com.xhaus.jyson import JysonCodec as json
 except ImportError:
-  import json
+    import json
 from utils import *
 from net.grinder.script import Test
 from net.grinder.plugin.http import HTTPRequest
 import itertools
 
+
 class AbstractQuery(object):
-  one_day = (1000 * 60 * 60 * 24)
+    one_day = (1000 * 60 * 60 * 24)
 
-  query_interval_name = None
-  num_queries_for_current_node = 0
-  query_request = None
-  query_name = None
-  test_number = 0
+    query_interval_name = None
+    num_queries_for_current_node = 0
+    query_request = None
+    query_name = None
+    test_number = 0
 
-  @classmethod
-  def create_metrics(cls, agent_number):
-    #divide the total number of each query type into the ones need by this worker
-    total_queries = default_config[cls.query_interval_name]
-    start_job, end_job = generate_job_range(total_queries, 
-                                                default_config['num_nodes'], agent_number)
-    cls.num_queries_for_current_node = end_job - start_job
+    @classmethod
+    def create_metrics(cls, agent_number):
+        # divide the total number of each query type into the ones need by this worker
+        total_queries = default_config[cls.query_interval_name]
+        start_job, end_job = generate_job_range(total_queries,
+                                                default_config['num_nodes'],
+                                                agent_number)
+        cls.num_queries_for_current_node = end_job - start_job
 
-    # Grinder test infrastructure
-    test = Test(cls.test_number, cls.query_name)
-    cls.query_request = HTTPRequest()
-    test.record(cls.query_request)
-    return [cls] * cls.num_queries_for_current_node
+        # Grinder test infrastructure
+        test = Test(cls.test_number, cls.query_name)
+        cls.query_request = HTTPRequest()
+        test.record(cls.query_request)
+        return [cls] * cls.num_queries_for_current_node
 
-  def generate(self, time, logger):
-    raise Exception("Can't instantiate abstract query")
+    def generate(self, time, logger):
+        raise Exception("Can't instantiate abstract query")
 
-  
+
 class SinglePlotQuery(AbstractQuery):
-  query_interval_name = 'singleplot_per_interval'
-  query_name = "SinglePlotQuery"
-  test_number = 3
+    query_interval_name = 'singleplot_per_interval'
+    query_name = "SinglePlotQuery"
+    test_number = 3
 
-  def generate(self, time, logger):
-    tenant_id = random.randint(0, default_config['num_tenants'])
-    metric_name = generate_metric_name(random.randint(0, default_config['metrics_per_tenant']))
-    to = time
-    frm = time - self.one_day
-    resolution = 'FULL'
-    url =  "%s/v2.0/%d/views/%s?from=%d&to=%s&resolution=%s" % (default_config['query_url'],
-                                                                tenant_id, metric_name, frm,
-                                                                to, resolution)
-    result = self.query_request.GET(url)
-#    logger(result.getText())
-    return result
+    def generate(self, time, logger):
+        tenant_id = random.randint(0, default_config['num_tenants'])
+        metric_name = generate_metric_name(
+            random.randint(0, default_config['metrics_per_tenant']))
+        to = time
+        frm = time - self.one_day
+        resolution = 'FULL'
+        url = "%s/v2.0/%d/views/%s?from=%d&to=%s&resolution=%s" % (
+        default_config['query_url'],
+        tenant_id, metric_name, frm,
+        to, resolution)
+        result = self.query_request.GET(url)
+        #    logger(result.getText())
+        return result
 
 
 class MultiPlotQuery(AbstractQuery):
-  query_interval_name = 'multiplot_per_interval'
-  query_name = "MultiPlotQuery"
-  test_number = 4
+    query_interval_name = 'multiplot_per_interval'
+    query_name = "MultiPlotQuery"
+    test_number = 4
 
-  def generate_multiplot_payload(self):
-    metrics_count = min(default_config['max_multiplot_metrics'], 
-                        random.randint(0, default_config['metrics_per_tenant']))
-    metrics_list = map(generate_metric_name, range(metrics_count))
-    return json.dumps(metrics_list)
+    def generate_multiplot_payload(self):
+        metrics_count = min(default_config['max_multiplot_metrics'],
+                            random.randint(0, default_config[
+                                'metrics_per_tenant']))
+        metrics_list = map(generate_metric_name, range(metrics_count))
+        return json.dumps(metrics_list)
 
-  def generate(self, time, logger):
-    tenant_id = random.randint(0, default_config['num_tenants'])
-    payload = self.generate_multiplot_payload()
-    to = time
-    frm = time - self.one_day
-    resolution = 'FULL'
-    url = "%s/v2.0/%d/views?from=%d&to=%d&resolution=%s"  % (default_config['query_url'],
-                                                                tenant_id, frm,
-                                                                to, resolution)
-    result = self.query_request.POST(url, payload)
-#    logger(result.getText())
-    return result
+    def generate(self, time, logger):
+        tenant_id = random.randint(0, default_config['num_tenants'])
+        payload = self.generate_multiplot_payload()
+        to = time
+        frm = time - self.one_day
+        resolution = 'FULL'
+        url = "%s/v2.0/%d/views?from=%d&to=%d&resolution=%s" % (
+        default_config['query_url'],
+        tenant_id, frm,
+        to, resolution)
+        result = self.query_request.POST(url, payload)
+        #    logger(result.getText())
+        return result
 
 
 class SearchQuery(AbstractQuery):
-  query_interval_name = 'search_queries_per_interval'
-  query_name = "SearchQuery"
-  test_number = 5
-    
-  def generate_metrics_regex(self):
-    metric_name = generate_metric_name(random.randint(0, default_config['metrics_per_tenant']))
-    return ".".join(metric_name.split('.')[0:-1]) + ".*"
+    query_interval_name = 'search_queries_per_interval'
+    query_name = "SearchQuery"
+    test_number = 5
 
-  def generate(self, time, logger):
-    tenant_id = random.randint(0, default_config['num_tenants'])
-    metric_regex = self.generate_metrics_regex()
-    url = "%s/v2.0/%d/metrics/search?query=%s" % (default_config['query_url'],
-                                                                tenant_id, metric_regex)
-    result = self.query_request.GET(url)
-#    logger(result.getText())
-    return result
+    def generate_metrics_regex(self):
+        metric_name = generate_metric_name(
+            random.randint(0, default_config['metrics_per_tenant']))
+        return ".".join(metric_name.split('.')[0:-1]) + ".*"
+
+    def generate(self, time, logger):
+        tenant_id = random.randint(0, default_config['num_tenants'])
+        metric_regex = self.generate_metrics_regex()
+        url = "%s/v2.0/%d/metrics/search?query=%s" % (
+        default_config['query_url'],
+        tenant_id, metric_regex)
+        result = self.query_request.GET(url)
+        #    logger(result.getText())
+        return result
+
 
 class AnnotationsQuery(AbstractQuery):
-  query_interval_name = 'annotations_queries_per_interval'
-  query_name = "AnnotationsQuery"
-  test_number = 6
+    query_interval_name = 'annotations_queries_per_interval'
+    query_name = "AnnotationsQuery"
+    test_number = 6
 
-  def generate(self, time, logger):
-    tenant_id = random.randint(0, default_config['annotations_num_tenants'])
-    to = time
-    frm = time - self.one_day
-    url = "%s/v2.0/%d/events/getEvents?from=%d&until=%d" % (default_config['query_url'], tenant_id, frm, to)
-    result = self.query_request.GET(url)
-    return result
+    def generate(self, time, logger):
+        tenant_id = random.randint(0, default_config['annotations_num_tenants'])
+        to = time
+        frm = time - self.one_day
+        url = "%s/v2.0/%d/events/getEvents?from=%d&until=%d" % (
+        default_config['query_url'], tenant_id, frm, to)
+        result = self.query_request.GET(url)
+        return result
+
 
 class EnumSearchQuery(AbstractQuery):
-  query_interval_name = 'enum_search_queries_per_interval'
-  query_name = "EnumSearchQuery"
-  test_number = 8
+    query_interval_name = 'enum_search_queries_per_interval'
+    query_name = "EnumSearchQuery"
+    test_number = 8
 
-  def generate_metrics_regex(self):
-    metric_name = 'enum_grinder_' + generate_metric_name(random.randint(0, default_config['enum_metrics_per_tenant']))
-    return ".".join(metric_name.split('.')[0:-1]) + ".*"
+    def generate_metrics_regex(self):
+        metric_name = 'enum_grinder_' + generate_metric_name(
+            random.randint(0, default_config['enum_metrics_per_tenant']))
+        return ".".join(metric_name.split('.')[0:-1]) + ".*"
 
-  def generate(self, time, logger):
-    tenant_id = random.randint(0, default_config['enum_num_tenants'])
-    metric_regex = self.generate_metrics_regex()
-    url = "%s/v2.0/%d/metrics/search?query=%s&include_enum_values=true" % (default_config['query_url'],
-                                                                tenant_id, metric_regex)
-    result = self.query_request.GET(url)
-    return result
+    def generate(self, time, logger):
+        tenant_id = random.randint(0, default_config['enum_num_tenants'])
+        metric_regex = self.generate_metrics_regex()
+        url = "%s/v2.0/%d/metrics/search?query=%s&include_enum_values=true" % (
+        default_config['query_url'],
+        tenant_id, metric_regex)
+        result = self.query_request.GET(url)
+        return result
+
 
 class EnumSinglePlotQuery(AbstractQuery):
-  query_interval_name = 'enum_single_plot_queries_per_interval'
-  query_name = "EnumSinglePlotQuery"
-  test_number = 9
+    query_interval_name = 'enum_single_plot_queries_per_interval'
+    query_name = "EnumSinglePlotQuery"
+    test_number = 9
 
-  def generate(self, time, logger):
-    tenant_id = random.randint(0, default_config['enum_num_tenants'])
-    metric_name = generate_enum_metric_name(random.randint(0, default_config['enum_metrics_per_tenant']))
-    to = time
-    frm = time - self.one_day
-    resolution = 'FULL'
-    url =  "%s/v2.0/%d/views/%s?from=%d&to=%s&resolution=%s" % (default_config['query_url'],
-                                                                tenant_id, metric_name, frm,
-                                                                to, resolution)
-    result = self.query_request.GET(url)
-#    logger(result.getText())
-    return result
+    def generate(self, time, logger):
+        tenant_id = random.randint(0, default_config['enum_num_tenants'])
+        metric_name = generate_enum_metric_name(
+            random.randint(0, default_config['enum_metrics_per_tenant']))
+        to = time
+        frm = time - self.one_day
+        resolution = 'FULL'
+        url = "%s/v2.0/%d/views/%s?from=%d&to=%s&resolution=%s" % (
+        default_config['query_url'],
+        tenant_id, metric_name, frm,
+        to, resolution)
+        result = self.query_request.GET(url)
+        #    logger(result.getText())
+        return result
+
 
 class EnumMultiPlotQuery(AbstractQuery):
-  query_interval_name = 'enum_multiplot_per_interval'
-  query_name = "EnumMultiPlotQuery"
-  test_number = 10
+    query_interval_name = 'enum_multiplot_per_interval'
+    query_name = "EnumMultiPlotQuery"
+    test_number = 10
 
-  def generate_multiplot_payload(self):
-    metrics_count = min(default_config['max_multiplot_metrics'],
-                        random.randint(0, default_config['enum_metrics_per_tenant']))
-    metrics_list = map(generate_enum_metric_name, range(metrics_count))
-    return json.dumps(metrics_list)
+    def generate_multiplot_payload(self):
+        metrics_count = min(default_config['max_multiplot_metrics'],
+                            random.randint(0, default_config[
+                                'enum_metrics_per_tenant']))
+        metrics_list = map(generate_enum_metric_name, range(metrics_count))
+        return json.dumps(metrics_list)
 
-  def generate(self, time, logger):
-    tenant_id = random.randint(0, default_config['enum_num_tenants'])
-    payload = self.generate_multiplot_payload()
-    to = time
-    frm = time - self.one_day
-    resolution = 'FULL'
-    url = "%s/v2.0/%d/views?from=%d&to=%d&resolution=%s"  % (default_config['query_url'],
-                                                                tenant_id, frm,
-                                                                to, resolution)
-    result = self.query_request.POST(url, payload)
-#    logger(result.getText())
-    return result
+    def generate(self, time, logger):
+        tenant_id = random.randint(0, default_config['enum_num_tenants'])
+        payload = self.generate_multiplot_payload()
+        to = time
+        frm = time - self.one_day
+        resolution = 'FULL'
+        url = "%s/v2.0/%d/views?from=%d&to=%d&resolution=%s" % (
+        default_config['query_url'],
+        tenant_id, frm,
+        to, resolution)
+        result = self.query_request.POST(url, payload)
+        #    logger(result.getText())
+        return result
+
 
 class QueryThread(AbstractThread):
-  # The list of queries to be invoked across all threads in this worker
-  queries = []
+    # The list of queries to be invoked across all threads in this worker
+    queries = []
 
-  query_types = [SinglePlotQuery, MultiPlotQuery, SearchQuery, EnumSearchQuery, EnumSinglePlotQuery, AnnotationsQuery, EnumMultiPlotQuery]
+    query_types = [SinglePlotQuery, MultiPlotQuery, SearchQuery,
+                   EnumSearchQuery, EnumSinglePlotQuery, AnnotationsQuery,
+                   EnumMultiPlotQuery]
 
-  @classmethod
-  def create_metrics(cls, agent_number):
-    cls.queries = list(itertools.chain(*[x.create_metrics(agent_number) for x in cls.query_types]))
-    random.shuffle(cls.queries)
-    
-  @classmethod
-  def num_threads(cls):
-    return default_config['query_concurrency']
+    @classmethod
+    def create_metrics(cls, agent_number):
+        cls.queries = list(itertools.chain(
+            *[x.create_metrics(agent_number) for x in cls.query_types]))
+        random.shuffle(cls.queries)
 
-  def __init__(self, thread_num):
-    AbstractThread.__init__(self, thread_num)
-    self.query_instances = [x(thread_num, self.num_threads()) for x in self.query_types]
-    total_queries_for_current_node = reduce(lambda x,y: x+y, 
-                                            [x.num_queries_for_current_node 
-                                             for x in self.query_instances])
-    start, end = generate_job_range(total_queries_for_current_node,
-                                                                 self.num_threads(),
-                                                                 thread_num)
-       
-    self.slice = self.queries[start:end]
-    self.query_fn_dict =  dict([[type(x), x.generate] for x in self.query_instances])
+    @classmethod
+    def num_threads(cls):
+        return default_config['query_concurrency']
 
+    def __init__(self, thread_num):
+        AbstractThread.__init__(self, thread_num)
+        self.query_instances = [x(thread_num, self.num_threads()) for x in
+                                self.query_types]
+        total_queries_for_current_node = reduce(lambda x, y: x + y,
+                                                [x.num_queries_for_current_node
+                                                 for x in self.query_instances])
+        start, end = generate_job_range(total_queries_for_current_node,
+                                        self.num_threads(),
+                                        thread_num)
 
-  def make_request(self, logger):
-    if len(self.slice) == 0:
-      logger("Warning: no work for current thread")
-      self.sleep(1000000)
-      return None
-    self.check_position(logger, len(self.slice))
-    result = self.query_fn_dict[self.slice[self.position]](int(self.time()), logger)
-    self.position += 1
-    return result
+        self.slice = self.queries[start:end]
+        self.query_fn_dict = dict(
+            [[type(x), x.generate] for x in self.query_instances])
+
+    def make_request(self, logger):
+        if len(self.slice) == 0:
+            logger("Warning: no work for current thread")
+            self.sleep(1000000)
+            return None
+        self.check_position(logger, len(self.slice))
+        result = self.query_fn_dict[self.slice[self.position]](int(self.time()),
+                                                               logger)
+        self.position += 1
+        return result
+
 
 ThreadManager.add_type(QueryThread)

--- a/contrib/grinder/scripts/query.py
+++ b/contrib/grinder/scripts/query.py
@@ -52,9 +52,9 @@ class SinglePlotQuery(AbstractQuery):
         frm = time - self.one_day
         resolution = 'FULL'
         url = "%s/v2.0/%d/views/%s?from=%d&to=%s&resolution=%s" % (
-        default_config['query_url'],
-        tenant_id, metric_name, frm,
-        to, resolution)
+            default_config['query_url'],
+            tenant_id, metric_name, frm,
+            to, resolution)
         result = self.query_request.GET(url)
         #    logger(result.getText())
         return result
@@ -79,9 +79,9 @@ class MultiPlotQuery(AbstractQuery):
         frm = time - self.one_day
         resolution = 'FULL'
         url = "%s/v2.0/%d/views?from=%d&to=%d&resolution=%s" % (
-        default_config['query_url'],
-        tenant_id, frm,
-        to, resolution)
+            default_config['query_url'],
+            tenant_id, frm,
+            to, resolution)
         result = self.query_request.POST(url, payload)
         #    logger(result.getText())
         return result
@@ -101,8 +101,8 @@ class SearchQuery(AbstractQuery):
         tenant_id = random.randint(0, default_config['num_tenants'])
         metric_regex = self.generate_metrics_regex()
         url = "%s/v2.0/%d/metrics/search?query=%s" % (
-        default_config['query_url'],
-        tenant_id, metric_regex)
+            default_config['query_url'],
+            tenant_id, metric_regex)
         result = self.query_request.GET(url)
         #    logger(result.getText())
         return result
@@ -119,7 +119,7 @@ class AnnotationsQuery(AbstractQuery):
         to = time
         frm = time - self.one_day
         url = "%s/v2.0/%d/events/getEvents?from=%d&until=%d" % (
-        default_config['query_url'], tenant_id, frm, to)
+            default_config['query_url'], tenant_id, frm, to)
         result = self.query_request.GET(url)
         return result
 
@@ -138,8 +138,8 @@ class EnumSearchQuery(AbstractQuery):
         tenant_id = random.randint(0, default_config['enum_num_tenants'])
         metric_regex = self.generate_metrics_regex()
         url = "%s/v2.0/%d/metrics/search?query=%s&include_enum_values=true" % (
-        default_config['query_url'],
-        tenant_id, metric_regex)
+            default_config['query_url'],
+            tenant_id, metric_regex)
         result = self.query_request.GET(url)
         return result
 
@@ -157,9 +157,9 @@ class EnumSinglePlotQuery(AbstractQuery):
         frm = time - self.one_day
         resolution = 'FULL'
         url = "%s/v2.0/%d/views/%s?from=%d&to=%s&resolution=%s" % (
-        default_config['query_url'],
-        tenant_id, metric_name, frm,
-        to, resolution)
+            default_config['query_url'],
+            tenant_id, metric_name, frm,
+            to, resolution)
         result = self.query_request.GET(url)
         #    logger(result.getText())
         return result
@@ -184,9 +184,9 @@ class EnumMultiPlotQuery(AbstractQuery):
         frm = time - self.one_day
         resolution = 'FULL'
         url = "%s/v2.0/%d/views?from=%d&to=%d&resolution=%s" % (
-        default_config['query_url'],
-        tenant_id, frm,
-        to, resolution)
+            default_config['query_url'],
+            tenant_id, frm,
+            to, resolution)
         result = self.query_request.POST(url, payload)
         #    logger(result.getText())
         return result

--- a/contrib/grinder/scripts/query.py
+++ b/contrib/grinder/scripts/query.py
@@ -21,7 +21,8 @@ class AbstractQuery(object):
 
     @classmethod
     def create_metrics(cls, agent_number):
-        # divide the total number of each query type into the ones need by this worker
+        # divide the total number of each query type into the ones need by this
+        # worker
         total_queries = default_config[cls.query_interval_name]
         start_job, end_job = generate_job_range(total_queries,
                                                 default_config['num_nodes'],
@@ -113,7 +114,8 @@ class AnnotationsQuery(AbstractQuery):
     test_number = 6
 
     def generate(self, time, logger):
-        tenant_id = random.randint(0, default_config['annotations_num_tenants'])
+        tenant_id = random.randint(0,
+                                   default_config['annotations_num_tenants'])
         to = time
         frm = time - self.one_day
         url = "%s/v2.0/%d/events/getEvents?from=%d&until=%d" % (
@@ -212,9 +214,10 @@ class QueryThread(AbstractThread):
         AbstractThread.__init__(self, thread_num)
         self.query_instances = [x(thread_num, self.num_threads()) for x in
                                 self.query_types]
-        total_queries_for_current_node = reduce(lambda x, y: x + y,
-                                                [x.num_queries_for_current_node
-                                                 for x in self.query_instances])
+        total_queries_for_current_node = reduce(
+            lambda x, y: x + y,
+            [x.num_queries_for_current_node
+             for x in self.query_instances])
         start, end = generate_job_range(total_queries_for_current_node,
                                         self.num_threads(),
                                         thread_num)
@@ -229,8 +232,8 @@ class QueryThread(AbstractThread):
             self.sleep(1000000)
             return None
         self.check_position(logger, len(self.slice))
-        result = self.query_fn_dict[self.slice[self.position]](int(self.time()),
-                                                               logger)
+        result = self.query_fn_dict[self.slice[self.position]](
+            int(self.time()), logger)
         self.position += 1
         return result
 

--- a/contrib/grinder/scripts/tests.py
+++ b/contrib/grinder/scripts/tests.py
@@ -1,5 +1,5 @@
-# It is difficult to invoke the Python coverage tool externally with Jython, so it
-# is being invoked internally here:
+# It is difficult to invoke the Python coverage tool externally with Jython, so
+# it is being invoked internally here:
 from __future__ import division
 import net.grinder.script.Grinder
 
@@ -102,7 +102,8 @@ class BluefloodTests(unittest.TestCase):
         t1 = self.tm.setup_thread(0)
         self.assertEqual(type(t1), ingest.IngestThread)
 
-        # confirm that the threadnum after all ingest threads is EnumIngestThread
+        # confirm that the threadnum after all ingest threads is
+        # EnumIngestThread
         t1 = self.tm.setup_thread(
             ingestenum.default_config['enum_ingest_concurrency'])
         self.assertEqual(type(t1), ingestenum.EnumIngestThread)
@@ -113,14 +114,16 @@ class BluefloodTests(unittest.TestCase):
                                       'enum_ingest_concurrency'])
         self.assertEqual(type(t1), query.QueryThread)
 
-        # confirm that the threadnum after all ingest+query threads is an annotations query thread
+        # confirm that the threadnum after all ingest+query threads is an
+        # annotations query thread
         t1 = self.tm.setup_thread(ingest.default_config['ingest_concurrency'] +
                                   ingestenum.default_config[
                                       'enum_ingest_concurrency'] +
                                   ingest.default_config['query_concurrency'])
         self.assertEqual(type(t1), annotationsingest.AnnotationsIngestThread)
 
-        # confirm that a threadnum after all valid thread types raises an exception
+        # confirm that a threadnum after all valid thread types raises an
+        # exception
         tot_threads = (
         ingest.default_config['ingest_concurrency'] + ingest.default_config[
             'enum_ingest_concurrency'] + ingest.default_config[
@@ -128,7 +131,8 @@ class BluefloodTests(unittest.TestCase):
             'annotations_concurrency'])
         self.assertRaises(Exception, self.tm.setup_thread, tot_threads)
 
-        # confirm that the correct batches of ingest metrics are created for worker 0
+        # confirm that the correct batches of ingest metrics are created for
+        # worker 0
         self.tm.create_all_metrics(0)
 
         # confirm annotationsingest
@@ -162,7 +166,8 @@ class BluefloodTests(unittest.TestCase):
                           [[1, 2], [1, 3], [1, 4]],
                           [[1, 5], [1, 6]]])
 
-        # confirm that the correct batch slices are created for individual threads
+        # confirm that the correct batch slices are created for individual
+        # threads
         thread = ingest.IngestThread(0)
         self.assertEqual(thread.slice,
                          [[[0, 0], [0, 1], [0, 2]],
@@ -181,26 +186,31 @@ class BluefloodTests(unittest.TestCase):
             query.default_config['singleplot_per_interval'] / num_query_nodes))
         multi_plot_queries_agent0 = int(math.ceil(
             query.default_config['multiplot_per_interval'] / num_query_nodes))
-        search_queries_agent0 = int(math.ceil(query.default_config[
-                                                  'search_queries_per_interval'] / num_query_nodes))
-        enum_search_queries_agent0 = int(math.ceil(query.default_config[
-                                                       'enum_search_queries_per_interval'] / num_query_nodes))
-        enum_single_plot_queries_agent0 = int(math.ceil(query.default_config[
-                                                            'enum_single_plot_queries_per_interval'] / num_query_nodes))
-        enum_multi_plot_queries_agent0 = int(math.ceil(query.default_config[
-                                                           'enum_multiplot_per_interval'] / num_query_nodes))
-        annotation_queries_agent0 = int(math.ceil(query.default_config[
-                                                      'annotations_queries_per_interval'] / num_query_nodes))
+        search_queries_agent0 = int(math.ceil(
+            query.default_config[
+                'search_queries_per_interval'] / num_query_nodes))
+        enum_search_queries_agent0 = int(math.ceil(
+            query.default_config[
+                'enum_search_queries_per_interval'] / num_query_nodes))
+        enum_single_plot_queries_agent0 = int(math.ceil(
+            query.default_config[
+                'enum_single_plot_queries_per_interval'] / num_query_nodes))
+        enum_multi_plot_queries_agent0 = int(math.ceil(
+            query.default_config[
+                'enum_multiplot_per_interval'] / num_query_nodes))
+        annotation_queries_agent0 = int(math.ceil(
+            query.default_config[
+                'annotations_queries_per_interval'] / num_query_nodes))
 
-        self.assertEqual(query.QueryThread.queries,
-                         ([
-                              query.SinglePlotQuery] * single_plot_queries_agent0 + [
-                              query.MultiPlotQuery] * multi_plot_queries_agent0 + [
-                              query.SearchQuery] * search_queries_agent0 + [
-                              query.EnumSearchQuery] * enum_search_queries_agent0 + [
-                              query.EnumSinglePlotQuery] * enum_single_plot_queries_agent0 + [
-                              query.AnnotationsQuery] * annotation_queries_agent0) + [
-                             query.EnumMultiPlotQuery] * enum_multi_plot_queries_agent0)
+        self.assertEqual(
+            query.QueryThread.queries,
+            ([query.SinglePlotQuery] * single_plot_queries_agent0 +
+             [query.MultiPlotQuery] * multi_plot_queries_agent0 +
+             [query.SearchQuery] * search_queries_agent0 +
+             [query.EnumSearchQuery] * enum_search_queries_agent0 +
+             [query.EnumSinglePlotQuery] * enum_single_plot_queries_agent0 +
+             [query.AnnotationsQuery] * annotation_queries_agent0) +
+            [query.EnumMultiPlotQuery] * enum_multi_plot_queries_agent0)
 
         thread = query.QueryThread(0)
         self.assertEqual(thread.slice, [query.SinglePlotQuery] * 2)
@@ -223,7 +233,8 @@ class BluefloodTests(unittest.TestCase):
         thread = query.QueryThread(16)
         self.assertEqual(thread.slice, [query.EnumMultiPlotQuery] * 1)
 
-        # confirm that the correct batches of ingest metrics are created for worker 1
+        # confirm that the correct batches of ingest metrics are created for
+        # worker 1
         self.tm.create_all_metrics(1)
         self.assertEqual(ingest.IngestThread.metrics,
                          [[[2, 0], [2, 1], [2, 2]],
@@ -242,30 +253,37 @@ class BluefloodTests(unittest.TestCase):
                          [[[2, 6]]])
 
         # confirm that the correct batches of queries are created for worker 1
-        single_plot_queries_agent1 = query.default_config[
-                                         'singleplot_per_interval'] - single_plot_queries_agent0
-        multi_plot_queries_agent1 = query.default_config[
-                                        'multiplot_per_interval'] - multi_plot_queries_agent0
-        search_queries_agent1 = query.default_config[
-                                    'search_queries_per_interval'] - search_queries_agent0
-        enum_search_queries_agent1 = query.default_config[
-                                         'enum_search_queries_per_interval'] - enum_search_queries_agent0
-        enum_single_plot_queries_agent1 = query.default_config[
-                                              'enum_single_plot_queries_per_interval'] - enum_single_plot_queries_agent0
-        annotation_queries_agent1 = query.default_config[
-                                        'annotations_queries_per_interval'] - annotation_queries_agent0
-        enum_multi_plot_queries_agent1 = query.default_config[
-                                             'enum_multiplot_per_interval'] - enum_multi_plot_queries_agent0
+        single_plot_queries_agent1 = \
+            query.default_config['singleplot_per_interval'] - \
+            single_plot_queries_agent0
+        multi_plot_queries_agent1 = \
+            query.default_config['multiplot_per_interval'] - \
+            multi_plot_queries_agent0
+        search_queries_agent1 = \
+            query.default_config['search_queries_per_interval'] - \
+            search_queries_agent0
+        enum_search_queries_agent1 = \
+            query.default_config['enum_search_queries_per_interval'] - \
+            enum_search_queries_agent0
+        enum_single_plot_queries_agent1 = \
+            query.default_config['enum_single_plot_queries_per_interval'] - \
+            enum_single_plot_queries_agent0
+        annotation_queries_agent1 = \
+            query.default_config['annotations_queries_per_interval'] - \
+            annotation_queries_agent0
+        enum_multi_plot_queries_agent1 = \
+            query.default_config['enum_multiplot_per_interval'] - \
+            enum_multi_plot_queries_agent0
 
-        self.assertEqual(query.QueryThread.queries,
-                         ([
-                              query.SinglePlotQuery] * single_plot_queries_agent1 + [
-                              query.MultiPlotQuery] * multi_plot_queries_agent1 + [
-                              query.SearchQuery] * search_queries_agent1 + [
-                              query.EnumSearchQuery] * enum_search_queries_agent1 + [
-                              query.EnumSinglePlotQuery] * enum_single_plot_queries_agent1 + [
-                              query.AnnotationsQuery] * annotation_queries_agent1) + [
-                             query.EnumMultiPlotQuery] * enum_multi_plot_queries_agent1)
+        self.assertEqual(
+            query.QueryThread.queries,
+            ([query.SinglePlotQuery] * single_plot_queries_agent1 +
+             [query.MultiPlotQuery] * multi_plot_queries_agent1 +
+             [query.SearchQuery] * search_queries_agent1 +
+             [query.EnumSearchQuery] * enum_search_queries_agent1 +
+             [query.EnumSinglePlotQuery] * enum_single_plot_queries_agent1 +
+             [query.AnnotationsQuery] * annotation_queries_agent1) +
+            [query.EnumMultiPlotQuery] * enum_multi_plot_queries_agent1)
 
         thread = query.QueryThread(0)
         self.assertEqual(thread.slice, [query.SinglePlotQuery] * 2)
@@ -353,8 +371,9 @@ class BluefloodTests(unittest.TestCase):
 
         url, payload = thread.make_request(pp)
         # confirm request generates proper URL and payload
-        self.assertEqual(url,
-                         'http://qe01.metrics-ingest.api.rackspacecloud.com/v2.0/2/events')
+        self.assertEqual(
+            url,
+            'http://qe01.metrics-ingest.api.rackspacecloud.com/v2.0/2/events')
         self.assertEqual(eval(payload), valid_payload)
 
         # confirm request increments position if not at end of report interval

--- a/contrib/grinder/scripts/tests.py
+++ b/contrib/grinder/scripts/tests.py
@@ -125,10 +125,10 @@ class BluefloodTests(unittest.TestCase):
         # confirm that a threadnum after all valid thread types raises an
         # exception
         tot_threads = (
-        ingest.default_config['ingest_concurrency'] + ingest.default_config[
-            'enum_ingest_concurrency'] + ingest.default_config[
-            'query_concurrency'] + ingest.default_config[
-            'annotations_concurrency'])
+            ingest.default_config['ingest_concurrency'] +
+            ingest.default_config['enum_ingest_concurrency'] +
+            ingest.default_config['query_concurrency'] +
+            ingest.default_config['annotations_concurrency'])
         self.assertRaises(Exception, self.tm.setup_thread, tot_threads)
 
         # confirm that the correct batches of ingest metrics are created for

--- a/contrib/grinder/scripts/tests.py
+++ b/contrib/grinder/scripts/tests.py
@@ -2,10 +2,14 @@
 # is being invoked internally here:
 from __future__ import division
 import net.grinder.script.Grinder
-package_path = net.grinder.script.Grinder.grinder.getProperties().getProperty("grinder.package_path")
+
+package_path = net.grinder.script.Grinder.grinder.getProperties().getProperty(
+    "grinder.package_path")
 import sys
+
 sys.path.append(package_path)
 from coverage import coverage
+
 cov = coverage()
 cov.start()
 
@@ -20,11 +24,10 @@ import random
 import math
 import grinder
 
-
-try: 
-  from com.xhaus.jyson import JysonCodec as json
+try:
+    from com.xhaus.jyson import JysonCodec as json
 except ImportError:
-  import json
+    import json
 import pprint
 
 pp = pprint.pprint
@@ -33,390 +36,471 @@ get_url = None
 post_url = None
 post_payload = None
 
+
 def mock_sleep(cls, x):
-  global sleep_time
-  sleep_time = x
+    global sleep_time
+    sleep_time = x
+
 
 class MockReq():
-  def POST(self, url, payload):
-    global post_url, post_payload
-    post_url = url
-    post_payload = payload
-    return url, payload
+    def POST(self, url, payload):
+        global post_url, post_payload
+        post_url = url
+        post_payload = payload
+        return url, payload
 
-  def GET(self, url):
-    global get_url
-    get_url = url
-    return url
+    def GET(self, url):
+        global get_url
+        get_url = url
+        return url
+
 
 class BluefloodTests(unittest.TestCase):
-  def setUp(self):
-    self.real_shuffle = random.shuffle
-    self.real_randint = random.randint
-    self.real_time = utils.AbstractThread.time
-    self.real_sleep = utils.AbstractThread.sleep
-    self.tm = ingest.ThreadManager(net.grinder.script.Grinder.grinder)
-    req = MockReq()
-    ingest.IngestThread.request = req
-    ingestenum.EnumIngestThread.request = req
-    annotationsingest.AnnotationsIngestThread.request = req
-    for x in query.QueryThread.query_types:
-      x.query_request = req
-    random.shuffle = lambda x: None
-    random.randint = lambda x,y: 0
-    utils.AbstractThread.time = lambda x:1000
-    utils.AbstractThread.sleep = mock_sleep
+    def setUp(self):
+        self.real_shuffle = random.shuffle
+        self.real_randint = random.randint
+        self.real_time = utils.AbstractThread.time
+        self.real_sleep = utils.AbstractThread.sleep
+        self.tm = ingest.ThreadManager(net.grinder.script.Grinder.grinder)
+        req = MockReq()
+        ingest.IngestThread.request = req
+        ingestenum.EnumIngestThread.request = req
+        annotationsingest.AnnotationsIngestThread.request = req
+        for x in query.QueryThread.query_types:
+            x.query_request = req
+        random.shuffle = lambda x: None
+        random.randint = lambda x, y: 0
+        utils.AbstractThread.time = lambda x: 1000
+        utils.AbstractThread.sleep = mock_sleep
 
-    test_config = {'report_interval': (1000 * 6),
-                   'num_tenants': 3,
-                   'enum_num_tenants': 4,
-                   'annotations_num_tenants': 3,
-                   'metrics_per_tenant': 7,
-                   'enum_metrics_per_tenant': 2,
-                   'annotations_per_tenant': 2,
-                   'batch_size': 3,
-                   'ingest_concurrency': 2,
-                   'enum_ingest_concurrency': 2,
-                   'query_concurrency': 20,
-                   'annotations_concurrency':2,
-                   'singleplot_per_interval': 11,
-                   'multiplot_per_interval': 10,
-                   'search_queries_per_interval': 9,
-                   'enum_search_queries_per_interval': 9,
-                   'enum_single_plot_queries_per_interval':10,
-                   'enum_multiplot_per_interval': 10,
-                   'annotations_queries_per_interval': 8,
-                   'name_fmt': "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.%d",
-                   'num_nodes': 2}
+        test_config = {'report_interval': (1000 * 6),
+                       'num_tenants': 3,
+                       'enum_num_tenants': 4,
+                       'annotations_num_tenants': 3,
+                       'metrics_per_tenant': 7,
+                       'enum_metrics_per_tenant': 2,
+                       'annotations_per_tenant': 2,
+                       'batch_size': 3,
+                       'ingest_concurrency': 2,
+                       'enum_ingest_concurrency': 2,
+                       'query_concurrency': 20,
+                       'annotations_concurrency': 2,
+                       'singleplot_per_interval': 11,
+                       'multiplot_per_interval': 10,
+                       'search_queries_per_interval': 9,
+                       'enum_search_queries_per_interval': 9,
+                       'enum_single_plot_queries_per_interval': 10,
+                       'enum_multiplot_per_interval': 10,
+                       'annotations_queries_per_interval': 8,
+                       'name_fmt': "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.%d",
+                       'num_nodes': 2}
 
-    ingest.default_config.update(test_config)
-    
-  def test_init_process(self):
+        ingest.default_config.update(test_config)
 
-    #confirm that threadnum 0 is an ingest thread
-    t1 = self.tm.setup_thread(0)
-    self.assertEqual(type(t1), ingest.IngestThread)
+    def test_init_process(self):
+        # confirm that threadnum 0 is an ingest thread
+        t1 = self.tm.setup_thread(0)
+        self.assertEqual(type(t1), ingest.IngestThread)
 
-    #confirm that the threadnum after all ingest threads is EnumIngestThread
-    t1 = self.tm.setup_thread(ingestenum.default_config['enum_ingest_concurrency'])
-    self.assertEqual(type(t1), ingestenum.EnumIngestThread)
+        # confirm that the threadnum after all ingest threads is EnumIngestThread
+        t1 = self.tm.setup_thread(
+            ingestenum.default_config['enum_ingest_concurrency'])
+        self.assertEqual(type(t1), ingestenum.EnumIngestThread)
 
-    #confirm that the threadnum after all ingest threads is a query thread
-    t1 = self.tm.setup_thread(ingest.default_config['ingest_concurrency']+ingestenum.default_config['enum_ingest_concurrency'])
-    self.assertEqual(type(t1), query.QueryThread)
+        # confirm that the threadnum after all ingest threads is a query thread
+        t1 = self.tm.setup_thread(ingest.default_config['ingest_concurrency'] +
+                                  ingestenum.default_config[
+                                      'enum_ingest_concurrency'])
+        self.assertEqual(type(t1), query.QueryThread)
 
-    #confirm that the threadnum after all ingest+query threads is an annotations query thread
-    t1 = self.tm.setup_thread(ingest.default_config['ingest_concurrency']+ingestenum.default_config['enum_ingest_concurrency']+ingest.default_config['query_concurrency'])
-    self.assertEqual(type(t1), annotationsingest.AnnotationsIngestThread)
+        # confirm that the threadnum after all ingest+query threads is an annotations query thread
+        t1 = self.tm.setup_thread(ingest.default_config['ingest_concurrency'] +
+                                  ingestenum.default_config[
+                                      'enum_ingest_concurrency'] +
+                                  ingest.default_config['query_concurrency'])
+        self.assertEqual(type(t1), annotationsingest.AnnotationsIngestThread)
 
-    #confirm that a threadnum after all valid thread types raises an exception
-    tot_threads = (ingest.default_config['ingest_concurrency'] + ingest.default_config['enum_ingest_concurrency'] + ingest.default_config['query_concurrency'] + ingest.default_config['annotations_concurrency'])
-    self.assertRaises(Exception,self.tm.setup_thread, tot_threads)
+        # confirm that a threadnum after all valid thread types raises an exception
+        tot_threads = (
+        ingest.default_config['ingest_concurrency'] + ingest.default_config[
+            'enum_ingest_concurrency'] + ingest.default_config[
+            'query_concurrency'] + ingest.default_config[
+            'annotations_concurrency'])
+        self.assertRaises(Exception, self.tm.setup_thread, tot_threads)
 
-    #confirm that the correct batches of ingest metrics are created for worker 0
-    self.tm.create_all_metrics(0)
+        # confirm that the correct batches of ingest metrics are created for worker 0
+        self.tm.create_all_metrics(0)
 
-    # confirm annotationsingest
-    self.assertEqual(annotationsingest.AnnotationsIngestThread.annotations,
-                             [[0, 0], [0, 1], [1, 0], [1, 1]])
+        # confirm annotationsingest
+        self.assertEqual(annotationsingest.AnnotationsIngestThread.annotations,
+                         [[0, 0], [0, 1], [1, 0], [1, 1]])
 
-    thread = annotationsingest.AnnotationsIngestThread(0)
-    self.assertEqual(thread.slice, [[0, 0], [0, 1]])
+        thread = annotationsingest.AnnotationsIngestThread(0)
+        self.assertEqual(thread.slice, [[0, 0], [0, 1]])
 
-    thread = annotationsingest.AnnotationsIngestThread(1)
-    self.assertEqual(thread.slice, [[1, 0], [1, 1]])
+        thread = annotationsingest.AnnotationsIngestThread(1)
+        self.assertEqual(thread.slice, [[1, 0], [1, 1]])
 
-    #confirm enum metrics ingest
-    self.assertEqual(ingestenum.EnumIngestThread.metrics,
-                        [
-                            [[0, 0], [0, 1], [1, 0]],
-                            [[1, 1]]
-                        ])
+        # confirm enum metrics ingest
+        self.assertEqual(ingestenum.EnumIngestThread.metrics,
+                         [
+                             [[0, 0], [0, 1], [1, 0]],
+                             [[1, 1]]
+                         ])
 
-    thread = ingestenum.EnumIngestThread(0)
-    self.assertEqual(thread.slice, [[[0, 0], [0, 1], [1, 0]]])
+        thread = ingestenum.EnumIngestThread(0)
+        self.assertEqual(thread.slice, [[[0, 0], [0, 1], [1, 0]]])
 
-    thread = ingestenum.EnumIngestThread(1)
-    self.assertEqual(thread.slice, [[[1, 1]]])
+        thread = ingestenum.EnumIngestThread(1)
+        self.assertEqual(thread.slice, [[[1, 1]]])
 
-    # confirm metrics ingest
-    self.assertEqual(ingest.IngestThread.metrics,
-                             [[[0, 0], [0, 1], [0, 2]],
-                              [[0, 3], [0, 4], [0, 5]],
-                              [[0, 6], [1, 0], [1, 1]],
-                              [[1, 2], [1, 3], [1, 4]],
-                              [[1, 5], [1, 6]]])
-    
+        # confirm metrics ingest
+        self.assertEqual(ingest.IngestThread.metrics,
+                         [[[0, 0], [0, 1], [0, 2]],
+                          [[0, 3], [0, 4], [0, 5]],
+                          [[0, 6], [1, 0], [1, 1]],
+                          [[1, 2], [1, 3], [1, 4]],
+                          [[1, 5], [1, 6]]])
 
-    #confirm that the correct batch slices are created for individual threads
-    thread = ingest.IngestThread(0)
-    self.assertEqual(thread.slice,
-                             [[[0, 0], [0, 1], [0, 2]],
-                              [[0, 3], [0, 4], [0, 5]],
-                              [[0, 6], [1, 0], [1, 1]]])
-    thread = ingest.IngestThread(1)
-    self.assertEqual(thread.slice,
-                             [[[1, 2], [1, 3], [1, 4]], 
-                              [[1, 5], [1, 6]]])
+        # confirm that the correct batch slices are created for individual threads
+        thread = ingest.IngestThread(0)
+        self.assertEqual(thread.slice,
+                         [[[0, 0], [0, 1], [0, 2]],
+                          [[0, 3], [0, 4], [0, 5]],
+                          [[0, 6], [1, 0], [1, 1]]])
+        thread = ingest.IngestThread(1)
+        self.assertEqual(thread.slice,
+                         [[[1, 2], [1, 3], [1, 4]],
+                          [[1, 5], [1, 6]]])
 
-    # confirm that the number of queries is correctly distributed across
-    #  each thread in this worker process
+        # confirm that the number of queries is correctly distributed across
+        #  each thread in this worker process
 
-    num_query_nodes = query.default_config['num_nodes']
-    single_plot_queries_agent0 = int(math.ceil(query.default_config['singleplot_per_interval']/num_query_nodes))
-    multi_plot_queries_agent0 = int(math.ceil(query.default_config['multiplot_per_interval']/num_query_nodes))
-    search_queries_agent0 = int(math.ceil(query.default_config['search_queries_per_interval']/num_query_nodes))
-    enum_search_queries_agent0 = int(math.ceil(query.default_config['enum_search_queries_per_interval']/num_query_nodes))
-    enum_single_plot_queries_agent0 = int(math.ceil(query.default_config['enum_single_plot_queries_per_interval']/num_query_nodes))
-    enum_multi_plot_queries_agent0 = int(math.ceil(query.default_config['enum_multiplot_per_interval']/num_query_nodes))
-    annotation_queries_agent0 = int(math.ceil(query.default_config['annotations_queries_per_interval']/num_query_nodes))
+        num_query_nodes = query.default_config['num_nodes']
+        single_plot_queries_agent0 = int(math.ceil(
+            query.default_config['singleplot_per_interval'] / num_query_nodes))
+        multi_plot_queries_agent0 = int(math.ceil(
+            query.default_config['multiplot_per_interval'] / num_query_nodes))
+        search_queries_agent0 = int(math.ceil(query.default_config[
+                                                  'search_queries_per_interval'] / num_query_nodes))
+        enum_search_queries_agent0 = int(math.ceil(query.default_config[
+                                                       'enum_search_queries_per_interval'] / num_query_nodes))
+        enum_single_plot_queries_agent0 = int(math.ceil(query.default_config[
+                                                            'enum_single_plot_queries_per_interval'] / num_query_nodes))
+        enum_multi_plot_queries_agent0 = int(math.ceil(query.default_config[
+                                                           'enum_multiplot_per_interval'] / num_query_nodes))
+        annotation_queries_agent0 = int(math.ceil(query.default_config[
+                                                      'annotations_queries_per_interval'] / num_query_nodes))
 
-    
-    self.assertEqual(query.QueryThread.queries,
-                     ([query.SinglePlotQuery] * single_plot_queries_agent0 + [query.MultiPlotQuery] * multi_plot_queries_agent0 + [query.SearchQuery] * search_queries_agent0 + [query.EnumSearchQuery] * enum_search_queries_agent0 + [query.EnumSinglePlotQuery] * enum_single_plot_queries_agent0 + [query.AnnotationsQuery] * annotation_queries_agent0) + [query.EnumMultiPlotQuery] * enum_multi_plot_queries_agent0)
+        self.assertEqual(query.QueryThread.queries,
+                         ([
+                              query.SinglePlotQuery] * single_plot_queries_agent0 + [
+                              query.MultiPlotQuery] * multi_plot_queries_agent0 + [
+                              query.SearchQuery] * search_queries_agent0 + [
+                              query.EnumSearchQuery] * enum_search_queries_agent0 + [
+                              query.EnumSinglePlotQuery] * enum_single_plot_queries_agent0 + [
+                              query.AnnotationsQuery] * annotation_queries_agent0) + [
+                             query.EnumMultiPlotQuery] * enum_multi_plot_queries_agent0)
 
-    thread = query.QueryThread(0)
-    self.assertEqual(thread.slice, [query.SinglePlotQuery] * 2)
+        thread = query.QueryThread(0)
+        self.assertEqual(thread.slice, [query.SinglePlotQuery] * 2)
 
-    thread = query.QueryThread(3)
-    self.assertEqual(thread.slice, [query.MultiPlotQuery] * 2)
+        thread = query.QueryThread(3)
+        self.assertEqual(thread.slice, [query.MultiPlotQuery] * 2)
 
-    thread = query.QueryThread(6)
-    self.assertEqual(thread.slice, [query.SearchQuery] * 2)
+        thread = query.QueryThread(6)
+        self.assertEqual(thread.slice, [query.SearchQuery] * 2)
 
-    thread = query.QueryThread(9)
-    self.assertEqual(thread.slice, [query.EnumSearchQuery] * 2)
+        thread = query.QueryThread(9)
+        self.assertEqual(thread.slice, [query.EnumSearchQuery] * 2)
 
-    thread = query.QueryThread(12)
-    self.assertEqual(thread.slice, [query.EnumSinglePlotQuery] * 2)
+        thread = query.QueryThread(12)
+        self.assertEqual(thread.slice, [query.EnumSinglePlotQuery] * 2)
 
-    thread = query.QueryThread(14)
-    self.assertEqual(thread.slice, [query.AnnotationsQuery] * 2)
+        thread = query.QueryThread(14)
+        self.assertEqual(thread.slice, [query.AnnotationsQuery] * 2)
 
-    thread = query.QueryThread(16)
-    self.assertEqual(thread.slice, [query.EnumMultiPlotQuery] * 1)
+        thread = query.QueryThread(16)
+        self.assertEqual(thread.slice, [query.EnumMultiPlotQuery] * 1)
 
-    #confirm that the correct batches of ingest metrics are created for worker 1
-    self.tm.create_all_metrics(1)
-    self.assertEqual(ingest.IngestThread.metrics,
-                             [[[2, 0], [2, 1], [2, 2]], 
-                              [[2, 3], [2, 4], [2, 5]], 
-                              [[2, 6]]])
+        # confirm that the correct batches of ingest metrics are created for worker 1
+        self.tm.create_all_metrics(1)
+        self.assertEqual(ingest.IngestThread.metrics,
+                         [[[2, 0], [2, 1], [2, 2]],
+                          [[2, 3], [2, 4], [2, 5]],
+                          [[2, 6]]])
 
-    self.assertEqual(annotationsingest.AnnotationsIngestThread.annotations,
-                     [[2, 0], [2, 1]])
+        self.assertEqual(annotationsingest.AnnotationsIngestThread.annotations,
+                         [[2, 0], [2, 1]])
 
-    
-    thread = ingest.IngestThread(0)
-    self.assertEqual(thread.slice,
-                             [[[2, 0], [2, 1], [2, 2]], 
-                              [[2, 3], [2, 4], [2, 5]]])
-    thread = ingest.IngestThread(1)
-    self.assertEqual(thread.slice,
-                             [[[2, 6]]])
+        thread = ingest.IngestThread(0)
+        self.assertEqual(thread.slice,
+                         [[[2, 0], [2, 1], [2, 2]],
+                          [[2, 3], [2, 4], [2, 5]]])
+        thread = ingest.IngestThread(1)
+        self.assertEqual(thread.slice,
+                         [[[2, 6]]])
 
-    #confirm that the correct batches of queries are created for worker 1
-    single_plot_queries_agent1 = query.default_config['singleplot_per_interval'] - single_plot_queries_agent0
-    multi_plot_queries_agent1 = query.default_config['multiplot_per_interval'] - multi_plot_queries_agent0
-    search_queries_agent1 = query.default_config['search_queries_per_interval'] - search_queries_agent0
-    enum_search_queries_agent1 = query.default_config['enum_search_queries_per_interval'] - enum_search_queries_agent0
-    enum_single_plot_queries_agent1 = query.default_config['enum_single_plot_queries_per_interval'] - enum_single_plot_queries_agent0
-    annotation_queries_agent1 = query.default_config['annotations_queries_per_interval'] - annotation_queries_agent0
-    enum_multi_plot_queries_agent1 = query.default_config['enum_multiplot_per_interval'] - enum_multi_plot_queries_agent0
+        # confirm that the correct batches of queries are created for worker 1
+        single_plot_queries_agent1 = query.default_config[
+                                         'singleplot_per_interval'] - single_plot_queries_agent0
+        multi_plot_queries_agent1 = query.default_config[
+                                        'multiplot_per_interval'] - multi_plot_queries_agent0
+        search_queries_agent1 = query.default_config[
+                                    'search_queries_per_interval'] - search_queries_agent0
+        enum_search_queries_agent1 = query.default_config[
+                                         'enum_search_queries_per_interval'] - enum_search_queries_agent0
+        enum_single_plot_queries_agent1 = query.default_config[
+                                              'enum_single_plot_queries_per_interval'] - enum_single_plot_queries_agent0
+        annotation_queries_agent1 = query.default_config[
+                                        'annotations_queries_per_interval'] - annotation_queries_agent0
+        enum_multi_plot_queries_agent1 = query.default_config[
+                                             'enum_multiplot_per_interval'] - enum_multi_plot_queries_agent0
 
-    self.assertEqual(query.QueryThread.queries,
-                     ([query.SinglePlotQuery] * single_plot_queries_agent1 + [query.MultiPlotQuery] * multi_plot_queries_agent1 + [query.SearchQuery] * search_queries_agent1 + [query.EnumSearchQuery] * enum_search_queries_agent1 + [query.EnumSinglePlotQuery] * enum_single_plot_queries_agent1 + [query.AnnotationsQuery] * annotation_queries_agent1) + [query.EnumMultiPlotQuery] * enum_multi_plot_queries_agent1)
+        self.assertEqual(query.QueryThread.queries,
+                         ([
+                              query.SinglePlotQuery] * single_plot_queries_agent1 + [
+                              query.MultiPlotQuery] * multi_plot_queries_agent1 + [
+                              query.SearchQuery] * search_queries_agent1 + [
+                              query.EnumSearchQuery] * enum_search_queries_agent1 + [
+                              query.EnumSinglePlotQuery] * enum_single_plot_queries_agent1 + [
+                              query.AnnotationsQuery] * annotation_queries_agent1) + [
+                             query.EnumMultiPlotQuery] * enum_multi_plot_queries_agent1)
 
-    thread = query.QueryThread(0)
-    self.assertEqual(thread.slice, [query.SinglePlotQuery] * 2)
+        thread = query.QueryThread(0)
+        self.assertEqual(thread.slice, [query.SinglePlotQuery] * 2)
 
-    thread = query.QueryThread(4)
-    self.assertEqual(thread.slice, [query.MultiPlotQuery] * 2)
+        thread = query.QueryThread(4)
+        self.assertEqual(thread.slice, [query.MultiPlotQuery] * 2)
 
-    thread = query.QueryThread(6)
-    self.assertEqual(thread.slice, [query.SearchQuery] * 2)
+        thread = query.QueryThread(6)
+        self.assertEqual(thread.slice, [query.SearchQuery] * 2)
 
-    thread = query.QueryThread(8)
-    self.assertEqual(thread.slice, [query.EnumSearchQuery] * 2)
+        thread = query.QueryThread(8)
+        self.assertEqual(thread.slice, [query.EnumSearchQuery] * 2)
 
-    thread = query.QueryThread(10)
-    self.assertEqual(thread.slice, [query.EnumSinglePlotQuery] * 2)
+        thread = query.QueryThread(10)
+        self.assertEqual(thread.slice, [query.EnumSinglePlotQuery] * 2)
 
-    thread = query.QueryThread(12)
-    self.assertEqual(thread.slice, [query.AnnotationsQuery] * 1)
+        thread = query.QueryThread(12)
+        self.assertEqual(thread.slice, [query.AnnotationsQuery] * 1)
 
-    thread = query.QueryThread(16)
-    self.assertEqual(thread.slice, [query.EnumMultiPlotQuery] * 1)
+        thread = query.QueryThread(16)
+        self.assertEqual(thread.slice, [query.EnumMultiPlotQuery] * 1)
+
+    def test_generate_payload(self):
+        self.tm.create_all_metrics(1)
+        thread = ingest.IngestThread(0)
+        payload = json.loads(
+            thread.generate_payload(0, [[2, 3], [2, 4], [2, 5]]))
+        valid_payload = [{u'collectionTime': 0,
+                          u'metricName': u'int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.3',
+                          u'metricValue': 0,
+                          u'tenantId': u'2',
+                          u'ttlInSeconds': 172800,
+                          u'unit': u'days'},
+                         {u'collectionTime': 0,
+                          u'metricName': u'int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.4',
+                          u'metricValue': 0,
+                          u'tenantId': u'2',
+                          u'ttlInSeconds': 172800,
+                          u'unit': u'days'},
+                         {u'collectionTime': 0,
+                          u'metricName': u'int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.5',
+                          u'metricValue': 0,
+                          u'tenantId': u'2',
+                          u'ttlInSeconds': 172800,
+                          u'unit': u'days'}]
+        self.assertEqual(payload, valid_payload)
+
+    def test_generate_enum_payload(self):
+        self.tm.create_all_metrics(1)
+        thread = ingestenum.EnumIngestThread(0)
+        payload = json.loads(thread.generate_payload(1, [[2, 1], [2, 2]]))
+        valid_payload = [{u'timestamp': 1,
+                          u'tenantId': u'2',
+                          u'enums': [{u'value': u'e_g_1_0',
+                                      u'name': utils.generate_enum_metric_name(
+                                          1)}]},
+                         {u'timestamp': 1,
+                          u'tenantId': u'2',
+                          u'enums': [{u'value': u'e_g_2_0',
+                                      u'name': utils.generate_enum_metric_name(
+                                          2)}]}
+                         ]
+        self.assertEqual(payload, valid_payload)
+
+    def test_generate_annotations_payload(self):
+        self.tm.create_all_metrics(1)
+        thread = annotationsingest.AnnotationsIngestThread(0)
+        payload = json.loads(thread.generate_payload(0, 3))
+        valid_payload = {
+            'what': 'annotation int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.3',
+            'when': 0,
+            'tags': 'tag',
+            'data': 'data'}
+        self.assertEqual(payload, valid_payload)
+
+    def test_annotationsingest_make_request(self):
+        global sleep_time
+        thread = annotationsingest.AnnotationsIngestThread(0)
+        thread.slice = [[2, 0]]
+        thread.position = 0
+        thread.finish_time = 10000
+        valid_payload = {
+            "what": "annotation int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.0",
+            "when": 1000, "tags": "tag", "data": "data"}
+
+        url, payload = thread.make_request(pp)
+        # confirm request generates proper URL and payload
+        self.assertEqual(url,
+                         'http://qe01.metrics-ingest.api.rackspacecloud.com/v2.0/2/events')
+        self.assertEqual(eval(payload), valid_payload)
+
+        # confirm request increments position if not at end of report interval
+        self.assertEqual(thread.position, 1)
+        self.assertEqual(thread.finish_time, 10000)
+        thread.position = 2
+        thread.make_request(pp)
+
+        # confirm request resets position at end of report interval
+        self.assertEqual(sleep_time, 9000)
+        self.assertEqual(thread.position, 1)
+        self.assertEqual(thread.finish_time, 16000)
+
+    def test_ingest_make_request(self):
+        global sleep_time
+        thread = ingest.IngestThread(0)
+        thread.slice = [[[2, 0], [2, 1]]]
+        thread.position = 0
+        thread.finish_time = 10000
+        valid_payload = [
+            {"collectionTime": 1000, "ttlInSeconds": 172800, "tenantId": "2",
+             "metricValue": 0, "unit": "days",
+             "metricName": "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.0"},
+            {"collectionTime": 1000, "ttlInSeconds": 172800, "tenantId": "2",
+             "metricValue": 0, "unit": "days",
+             "metricName": "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.1"}]
+
+        url, payload = thread.make_request(pp)
+        # confirm request generates proper URL and payload
+        self.assertEqual(url,
+                         'http://qe01.metrics-ingest.api.rackspacecloud.com/v2.0/tenantId/ingest/multi')
+        self.assertEqual(eval(payload), valid_payload)
+
+        # confirm request increments position if not at end of report interval
+        self.assertEqual(thread.position, 1)
+        self.assertEqual(thread.finish_time, 10000)
+        thread.position = 2
+        thread.make_request(pp)
+        # confirm request resets position at end of report interval
+        self.assertEqual(sleep_time, 9000)
+        self.assertEqual(thread.position, 1)
+        self.assertEqual(thread.finish_time, 16000)
+
+    def test_ingest_enum_make_request(self):
+        global sleep_time
+        thread = ingestenum.EnumIngestThread(0)
+        thread.slice = [[[2, 0], [2, 1]]]
+        thread.position = 0
+        thread.finish_time = 10000
+        valid_payload = [{'tenantId': '2', 'timestamp': 1000, 'enums': [
+            {'value': 'e_g_0_0', 'name': utils.generate_enum_metric_name(0)}]},
+                         {'tenantId': '2', 'timestamp': 1000, 'enums': [
+                             {'value': 'e_g_1_0',
+                              'name': utils.generate_enum_metric_name(1)}]}]
+
+        url, payload = thread.make_request(pp)
+        # confirm request generates proper URL and payload
+        self.assertEqual(url,
+                         'http://qe01.metrics-ingest.api.rackspacecloud.com/v2.0/tenantId/ingest/aggregated/multi')
+        self.assertEqual(eval(payload), valid_payload)
+
+        # confirm request increments position if not at end of report interval
+        self.assertEqual(thread.position, 1)
+        self.assertEqual(thread.finish_time, 10000)
+        thread.position = 2
+        thread.make_request(pp)
+        # confirm request resets position at end of report interval
+        self.assertEqual(sleep_time, 9000)
+        self.assertEqual(thread.position, 1)
+        self.assertEqual(thread.finish_time, 16000)
+
+    def test_query_make_request(self):
+        thread = query.QueryThread(0)
+        thread.slice = [query.SinglePlotQuery, query.SearchQuery,
+                        query.MultiPlotQuery, query.AnnotationsQuery,
+                        query.EnumSearchQuery, query.EnumSinglePlotQuery,
+                        query.EnumMultiPlotQuery]
+        thread.position = 0
+        thread.make_request(pp)
+        self.assertEqual(get_url,
+                         "http://qe01.metrics.api.rackspacecloud.com/v2.0/0/views/int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.0?from=-86399000&to=1000&resolution=FULL")
+
+        random.randint = lambda x, y: 10
+        thread.make_request(pp)
+        self.assertEqual(get_url,
+                         "http://qe01.metrics.api.rackspacecloud.com/v2.0/10/metrics/search?query=int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.*")
+
+        random.randint = lambda x, y: 20
+        thread.make_request(pp)
+        self.assertEqual(post_url,
+                         "http://qe01.metrics.api.rackspacecloud.com/v2.0/20/views?from=-86399000&to=1000&resolution=FULL")
+        self.assertEqual(eval(post_payload), [
+            "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.0",
+            "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.1",
+            "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.2",
+            "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.3",
+            "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.4",
+            "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.5",
+            "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.6",
+            "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.7",
+            "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.8",
+            "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.9"])
+
+        random.randint = lambda x, y: 30
+        thread.make_request(pp)
+        self.assertEqual(get_url,
+                         "http://qe01.metrics.api.rackspacecloud.com/v2.0/30/events/getEvents?from=-86399000&until=1000")
+
+        random.randint = lambda x, y: 40
+        thread.make_request(pp)
+        self.assertEqual(get_url,
+                         "http://qe01.metrics.api.rackspacecloud.com/v2.0/40/metrics/search?query=enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.*&include_enum_values=true")
+
+        random.randint = lambda x, y: 50
+        thread.make_request(pp)
+        self.assertEqual(get_url,
+                         "http://qe01.metrics.api.rackspacecloud.com/v2.0/50/views/enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.50?from=-86399000&to=1000&resolution=FULL")
+
+        random.randint = lambda x, y: 4
+        thread.make_request(pp)
+        self.assertEqual(post_url,
+                         "http://qe01.metrics.api.rackspacecloud.com/v2.0/4/views?from=-86399000&to=1000&resolution=FULL")
+        self.assertEqual(eval(post_payload), [
+            "enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.0",
+            "enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.1",
+            "enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.2",
+            "enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.3"])
+
+    def tearDown(self):
+        random.shuffle = self.real_shuffle
+        random.randint = self.real_randint
+        utils.AbstractThread.time = self.real_time
+        utils.AbstractThread.sleep = self.real_sleep
 
 
-  def test_generate_payload(self):
-    self.tm.create_all_metrics(1)
-    thread = ingest.IngestThread(0)
-    payload = json.loads(thread.generate_payload(0, [[2, 3], [2, 4], [2, 5]]))
-    valid_payload = [{u'collectionTime': 0,
-                      u'metricName': u'int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.3',
-                      u'metricValue': 0,
-                      u'tenantId': u'2',
-                      u'ttlInSeconds': 172800,
-                      u'unit': u'days'},
-                     {u'collectionTime': 0,
-                      u'metricName': u'int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.4',
-                      u'metricValue': 0,
-                      u'tenantId': u'2',
-                      u'ttlInSeconds': 172800,
-                      u'unit': u'days'},
-                     {u'collectionTime': 0,
-                      u'metricName': u'int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.5',
-                      u'metricValue': 0,
-                      u'tenantId': u'2',
-                      u'ttlInSeconds': 172800,
-                      u'unit': u'days'}]
-    self.assertEqual(payload, valid_payload)
-
-  def test_generate_enum_payload(self):
-    self.tm.create_all_metrics(1)
-    thread = ingestenum.EnumIngestThread(0)
-    payload = json.loads(thread.generate_payload(1, [[2, 1], [2, 2]]))
-    valid_payload = [{u'timestamp': 1,
-                      u'tenantId': u'2',
-                      u'enums': [{u'value': u'e_g_1_0', u'name': utils.generate_enum_metric_name(1)}]},
-                     {u'timestamp': 1,
-                      u'tenantId': u'2',
-                      u'enums': [{u'value': u'e_g_2_0', u'name': utils.generate_enum_metric_name(2)}]}
-                    ]
-    self.assertEqual(payload, valid_payload)
-
-  def test_generate_annotations_payload(self):
-    self.tm.create_all_metrics(1)
-    thread = annotationsingest.AnnotationsIngestThread(0)
-    payload = json.loads(thread.generate_payload(0, 3))
-    valid_payload = {'what': 'annotation int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.3',
-                      'when': 0,
-                      'tags': 'tag',
-                      'data': 'data'}
-    self.assertEqual(payload, valid_payload)
-
-  def test_annotationsingest_make_request(self):
-    global sleep_time
-    thread = annotationsingest.AnnotationsIngestThread(0)
-    thread.slice = [[2, 0]]
-    thread.position = 0
-    thread.finish_time = 10000
-    valid_payload = {"what": "annotation int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.0", "when": 1000, "tags": "tag", "data": "data"}
-
-    url, payload = thread.make_request(pp)
-    #confirm request generates proper URL and payload
-    self.assertEqual(url, 
-                     'http://qe01.metrics-ingest.api.rackspacecloud.com/v2.0/2/events')
-    self.assertEqual(eval(payload), valid_payload)
-
-    #confirm request increments position if not at end of report interval
-    self.assertEqual(thread.position, 1)
-    self.assertEqual(thread.finish_time, 10000)
-    thread.position = 2
-    thread.make_request(pp)
-
-    #confirm request resets position at end of report interval
-    self.assertEqual(sleep_time, 9000)
-    self.assertEqual(thread.position, 1)
-    self.assertEqual(thread.finish_time, 16000)
-
-  def test_ingest_make_request(self):
-    global sleep_time
-    thread = ingest.IngestThread(0)
-    thread.slice = [[[2, 0], [2, 1]]]
-    thread.position = 0
-    thread.finish_time = 10000
-    valid_payload = [{"collectionTime": 1000, "ttlInSeconds": 172800, "tenantId": "2", "metricValue": 0, "unit": "days", "metricName": "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.0"}, {"collectionTime": 1000, "ttlInSeconds": 172800, "tenantId": "2", "metricValue": 0, "unit": "days", "metricName": "int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.1"}]
-
-    url, payload = thread.make_request(pp)
-    #confirm request generates proper URL and payload
-    self.assertEqual(url,
-                     'http://qe01.metrics-ingest.api.rackspacecloud.com/v2.0/tenantId/ingest/multi')
-    self.assertEqual(eval(payload), valid_payload)
-
-    #confirm request increments position if not at end of report interval
-    self.assertEqual(thread.position, 1)
-    self.assertEqual(thread.finish_time, 10000)
-    thread.position = 2
-    thread.make_request(pp)
-    #confirm request resets position at end of report interval
-    self.assertEqual(sleep_time, 9000)
-    self.assertEqual(thread.position, 1)
-    self.assertEqual(thread.finish_time, 16000)
-
-  def test_ingest_enum_make_request(self):
-      global sleep_time
-      thread = ingestenum.EnumIngestThread(0)
-      thread.slice = [[[2, 0], [2, 1]]]
-      thread.position = 0
-      thread.finish_time = 10000
-      valid_payload = [{'tenantId': '2', 'timestamp': 1000, 'enums': [{'value': 'e_g_0_0', 'name': utils.generate_enum_metric_name(0)}]}, {'tenantId': '2', 'timestamp': 1000, 'enums': [{'value': 'e_g_1_0', 'name': utils.generate_enum_metric_name(1)}]}]
-
-      url, payload = thread.make_request(pp)
-      #confirm request generates proper URL and payload
-      self.assertEqual(url,
-                       'http://qe01.metrics-ingest.api.rackspacecloud.com/v2.0/tenantId/ingest/aggregated/multi')
-      self.assertEqual(eval(payload), valid_payload)
-
-      #confirm request increments position if not at end of report interval
-      self.assertEqual(thread.position, 1)
-      self.assertEqual(thread.finish_time, 10000)
-      thread.position = 2
-      thread.make_request(pp)
-      #confirm request resets position at end of report interval
-      self.assertEqual(sleep_time, 9000)
-      self.assertEqual(thread.position, 1)
-      self.assertEqual(thread.finish_time, 16000)
-
-  def test_query_make_request(self):
-    thread = query.QueryThread(0)
-    thread.slice = [query.SinglePlotQuery, query.SearchQuery, query.MultiPlotQuery, query.AnnotationsQuery, query.EnumSearchQuery, query.EnumSinglePlotQuery, query.EnumMultiPlotQuery]
-    thread.position = 0
-    thread.make_request(pp)
-    self.assertEqual(get_url, "http://qe01.metrics.api.rackspacecloud.com/v2.0/0/views/int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.0?from=-86399000&to=1000&resolution=FULL")
-
-    random.randint = lambda x,y: 10
-    thread.make_request(pp)
-    self.assertEqual(get_url, "http://qe01.metrics.api.rackspacecloud.com/v2.0/10/metrics/search?query=int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.*")
-
-    random.randint = lambda x,y: 20
-    thread.make_request(pp)
-    self.assertEqual(post_url, "http://qe01.metrics.api.rackspacecloud.com/v2.0/20/views?from=-86399000&to=1000&resolution=FULL")
-    self.assertEqual(eval(post_payload), ["int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.0","int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.1","int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.2","int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.3","int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.4","int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.5","int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.6","int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.7","int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.8","int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.9"])
-
-    random.randint = lambda x,y: 30
-    thread.make_request(pp)
-    self.assertEqual(get_url, "http://qe01.metrics.api.rackspacecloud.com/v2.0/30/events/getEvents?from=-86399000&until=1000")
-
-    random.randint = lambda x,y: 40
-    thread.make_request(pp)
-    self.assertEqual(get_url, "http://qe01.metrics.api.rackspacecloud.com/v2.0/40/metrics/search?query=enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.*&include_enum_values=true")
-
-    random.randint = lambda x,y: 50
-    thread.make_request(pp)
-    self.assertEqual(get_url, "http://qe01.metrics.api.rackspacecloud.com/v2.0/50/views/enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.50?from=-86399000&to=1000&resolution=FULL")
-
-    random.randint = lambda x,y: 4
-    thread.make_request(pp)
-    self.assertEqual(post_url, "http://qe01.metrics.api.rackspacecloud.com/v2.0/4/views?from=-86399000&to=1000&resolution=FULL")
-    self.assertEqual(eval(post_payload), ["enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.0","enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.1","enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.2","enum_grinder_int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.3"])
-
-
-  def tearDown(self):
-    random.shuffle = self.real_shuffle
-    random.randint = self.real_randint
-    utils.AbstractThread.time = self.real_time
-    utils.AbstractThread.sleep = self.real_sleep
-
-#if __name__ == '__main__':
-unittest.TextTestRunner().run(unittest.TestLoader().loadTestsFromTestCase(BluefloodTests))
+# if __name__ == '__main__':
+unittest.TextTestRunner().run(
+    unittest.TestLoader().loadTestsFromTestCase(BluefloodTests))
 
 cov.stop()
 cov.save()
-class TestRunner:
-  def __init__(self):
-    pass
 
-  def __call__(self):
-    pass
+
+class TestRunner:
+    def __init__(self):
+        pass
+
+    def __call__(self):
+        pass

--- a/contrib/grinder/scripts/utils.py
+++ b/contrib/grinder/scripts/utils.py
@@ -28,7 +28,8 @@ default_config = {
     'enum_num_values': 10,
     'singleplot_per_interval': 10,
     'annotations_queries_per_interval': 8,
-    # ingest_delay_millis is comma separated list of delays used during ingestion
+    # ingest_delay_millis is comma separated list of delays used during
+    # ingestion
     'ingest_delay_millis': ""}
 
 units_map = {0: 'minutes',
@@ -70,26 +71,31 @@ class ThreadManager(object):
             default_config[k] = self.convert(entry.value)
 
     def __init__(self, grinder):
-        # tot_threads is the value passed to the grinder at startup for the number of threads to start
+        # tot_threads is the value passed to the grinder at startup for the
+        # number of threads to start
         self.tot_threads = 0
 
-        # concurrent_threads is the sum of the various thread types, (currently ingest and query)
+        # concurrent_threads is the sum of the various thread types, (currently
+        # ingest and query)
         self.concurrent_threads = 0
         self.setup_config(grinder)
 
-        # Sanity check the concurrent_threads to make sure they are the same as the value
+        # Sanity check the concurrent_threads to make sure they are the same as
+        # the value
         #  passed to the grinder
         if self.tot_threads != self.concurrent_threads:
             raise Exception(
                 "Configuration error: grinder.threads doesn't equal total concurrent threads")
 
     def create_all_metrics(self, agent_number):
-        """Step through all the attached types and have them create their metrics"""
+        """Step through all the attached types and have them create their
+        metrics"""
         for x in self.types:
             x.create_metrics(agent_number)
 
     def setup_thread(self, thread_num):
-        """Figure out which type thread to create based on thread_num and return it
+        """Figure out which type thread to create based on thread_num and
+        return it
 
         Creates threads of various types for use by the grinder to load
         test various parts of blueflood.  The code is structured so that
@@ -97,9 +103,9 @@ class ThreadManager(object):
         properties file determines how many of each type to create based
         on the "ingest_concurrency" and "query_concurrency" options.
 
-        So for example, if "ingest_concurrency" is set to 4, and "query_concurrency"
-        is set to 2, thread numbers 0-3 will be ingest threads and thread numbers 4-5
-        will be query threads.
+        So for example, if "ingest_concurrency" is set to 4, and
+        "query_concurrency" is set to 2, thread numbers 0-3 will be ingest
+        threads and thread numbers 4-5 will be query threads.
 
         """
         thread_type = None
@@ -124,9 +130,10 @@ class ThreadManager(object):
 def generate_job_range(total_jobs, total_servers, server_num):
     """ Determine which subset of the total work the current server is to do.
 
-    The properties file is the same for all the distributed workers and lists the
-    total amount of work to be done for each report interval.  This method allows
-    you to split that work up into the exact subset to be done by the "server_num" worker
+    The properties file is the same for all the distributed workers and lists
+    the total amount of work to be done for each report interval.  This method
+    allows you to split that work up into the exact subset to be done by the
+    "server_num" worker
     """
     jobs_per_server = total_jobs / total_servers
     remainder = total_jobs % total_servers

--- a/contrib/grinder/scripts/utils.py
+++ b/contrib/grinder/scripts/utils.py
@@ -3,33 +3,33 @@ import random
 from net.grinder.script.Grinder import grinder
 
 default_config = {
-  'name_fmt': "t4.int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.%d",
-  'report_interval': (1000 * 10),
-  'annotations_num_tenants':5,
-  'num_tenants': 4,
-  'enum_num_tenants': 4,
-  'metrics_per_tenant': 15,
-  'enum_metrics_per_tenant': 10,
-  'annotations_per_tenant': 10,
-  'batch_size': 5,
-  'ingest_concurrency': 15,
-  'enum_ingest_concurrency': 15,
-  'num_nodes': 1,
-  'url': "http://localhost:19000",
-  'query_url': "http://localhost:20000",
-  'query_concurrency': 10,
-  'annotations_concurrency':5,
-  'max_multiplot_metrics': 10,
-  'search_queries_per_interval': 10,
-  'enum_search_queries_per_interval': 10,
-  'enum_single_plot_queries_per_interval':10,
-  'multiplot_per_interval': 10,
-  'enum_multiplot_per_interval': 10,
-  'enum_num_values': 10,
-  'singleplot_per_interval': 10,
-  'annotations_queries_per_interval': 8,
-  # ingest_delay_millis is comma separated list of delays used during ingestion
-  'ingest_delay_millis': ""}
+    'name_fmt': "t4.int.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.%d",
+    'report_interval': (1000 * 10),
+    'annotations_num_tenants': 5,
+    'num_tenants': 4,
+    'enum_num_tenants': 4,
+    'metrics_per_tenant': 15,
+    'enum_metrics_per_tenant': 10,
+    'annotations_per_tenant': 10,
+    'batch_size': 5,
+    'ingest_concurrency': 15,
+    'enum_ingest_concurrency': 15,
+    'num_nodes': 1,
+    'url': "http://localhost:19000",
+    'query_url': "http://localhost:20000",
+    'query_concurrency': 10,
+    'annotations_concurrency': 5,
+    'max_multiplot_metrics': 10,
+    'search_queries_per_interval': 10,
+    'enum_search_queries_per_interval': 10,
+    'enum_single_plot_queries_per_interval': 10,
+    'multiplot_per_interval': 10,
+    'enum_multiplot_per_interval': 10,
+    'enum_num_values': 10,
+    'singleplot_per_interval': 10,
+    'annotations_queries_per_interval': 8,
+    # ingest_delay_millis is comma separated list of delays used during ingestion
+    'ingest_delay_millis': ""}
 
 units_map = {0: 'minutes',
              1: 'hours',
@@ -38,164 +38,171 @@ units_map = {0: 'minutes',
              4: 'years',
              5: 'decades'}
 
+RAND_MAX = 982374239
 
-RAND_MAX =  982374239
 
 class ThreadManager(object):
-  #keep track of the various thread types
-  types = []
+    # keep track of the various thread types
+    types = []
 
-  @classmethod
-  def add_type(cls, type):
-    cls.types.append(type)
+    @classmethod
+    def add_type(cls, type):
+        cls.types.append(type)
 
-  def convert(self, s):
-    try:
-      return int(s)
-    except:
-      return eval(s)
+    def convert(self, s):
+        try:
+            return int(s)
+        except:
+            return eval(s)
 
-  def setup_config(self, grinder):
-    #Parse the properties file and update default_config dictionary
-    for entry in grinder.getProperties().entrySet():
-      if entry.value.startswith(".."):
-        continue
-      if entry.key == "grinder.threads":
-        self.tot_threads = self.convert(entry.value)
-      if entry.key.find("concurrency") >= 0:
-        self.concurrent_threads += self.convert(entry.value)
-      if not entry.key.startswith("grinder.bf."):
-        continue
-      k = entry.key.replace("grinder.bf.","")
-      default_config[k] = self.convert(entry.value)
+    def setup_config(self, grinder):
+        # Parse the properties file and update default_config dictionary
+        for entry in grinder.getProperties().entrySet():
+            if entry.value.startswith(".."):
+                continue
+            if entry.key == "grinder.threads":
+                self.tot_threads = self.convert(entry.value)
+            if entry.key.find("concurrency") >= 0:
+                self.concurrent_threads += self.convert(entry.value)
+            if not entry.key.startswith("grinder.bf."):
+                continue
+            k = entry.key.replace("grinder.bf.", "")
+            default_config[k] = self.convert(entry.value)
 
-  def __init__(self, grinder):
-    # tot_threads is the value passed to the grinder at startup for the number of threads to start
-    self.tot_threads = 0
+    def __init__(self, grinder):
+        # tot_threads is the value passed to the grinder at startup for the number of threads to start
+        self.tot_threads = 0
 
-    # concurrent_threads is the sum of the various thread types, (currently ingest and query)
-    self.concurrent_threads = 0
-    self.setup_config(grinder)
-    
-    # Sanity check the concurrent_threads to make sure they are the same as the value
-    #  passed to the grinder
-    if self.tot_threads != self.concurrent_threads:
-      raise Exception("Configuration error: grinder.threads doesn't equal total concurrent threads")
+        # concurrent_threads is the sum of the various thread types, (currently ingest and query)
+        self.concurrent_threads = 0
+        self.setup_config(grinder)
 
-  def create_all_metrics(self, agent_number):
-    """Step through all the attached types and have them create their metrics"""
-    for x in self.types:
-      x.create_metrics(agent_number)
+        # Sanity check the concurrent_threads to make sure they are the same as the value
+        #  passed to the grinder
+        if self.tot_threads != self.concurrent_threads:
+            raise Exception(
+                "Configuration error: grinder.threads doesn't equal total concurrent threads")
 
-  def setup_thread(self, thread_num):
-    """Figure out which type thread to create based on thread_num and return it
+    def create_all_metrics(self, agent_number):
+        """Step through all the attached types and have them create their metrics"""
+        for x in self.types:
+            x.create_metrics(agent_number)
 
-    Creates threads of various types for use by the grinder to load
-    test various parts of blueflood.  The code is structured so that
-    the thread type is determined by the thread num.  The grinder
-    properties file determines how many of each type to create based
-    on the "ingest_concurrency" and "query_concurrency" options.
+    def setup_thread(self, thread_num):
+        """Figure out which type thread to create based on thread_num and return it
 
-    So for example, if "ingest_concurrency" is set to 4, and "query_concurrency"
-    is set to 2, thread numbers 0-3 will be ingest threads and thread numbers 4-5
-    will be query threads.
+        Creates threads of various types for use by the grinder to load
+        test various parts of blueflood.  The code is structured so that
+        the thread type is determined by the thread num.  The grinder
+        properties file determines how many of each type to create based
+        on the "ingest_concurrency" and "query_concurrency" options.
 
-    """
-    thread_type = None
-    server_num = thread_num
+        So for example, if "ingest_concurrency" is set to 4, and "query_concurrency"
+        is set to 2, thread numbers 0-3 will be ingest threads and thread numbers 4-5
+        will be query threads.
 
-    for x in self.types:
-      if server_num < x.num_threads():
-        thread_type = x
-        break
-      else:
-        server_num -= x.num_threads()
+        """
+        thread_type = None
+        server_num = thread_num
 
-    if thread_type == None:
-      raise Exception("Invalid Thread Type")
+        for x in self.types:
+            if server_num < x.num_threads():
+                thread_type = x
+                break
+            else:
+                server_num -= x.num_threads()
 
-    return thread_type(server_num)
+        if thread_type == None:
+            raise Exception("Invalid Thread Type")
 
-#ThreadManager class ends here
-#Utility functions below
+        return thread_type(server_num)
+
+
+# ThreadManager class ends here
+# Utility functions below
 
 def generate_job_range(total_jobs, total_servers, server_num):
-  """ Determine which subset of the total work the current server is to do.
+    """ Determine which subset of the total work the current server is to do.
 
-  The properties file is the same for all the distributed workers and lists the
-  total amount of work to be done for each report interval.  This method allows
-  you to split that work up into the exact subset to be done by the "server_num" worker
-  """
-  jobs_per_server = total_jobs/total_servers
-  remainder = total_jobs % total_servers
-  start_job = jobs_per_server * server_num
-  start_job += min(remainder, server_num)
-  end_job = start_job + jobs_per_server
-  if server_num < remainder:
-    end_job += 1
-  return (start_job, end_job)
+    The properties file is the same for all the distributed workers and lists the
+    total amount of work to be done for each report interval.  This method allows
+    you to split that work up into the exact subset to be done by the "server_num" worker
+    """
+    jobs_per_server = total_jobs / total_servers
+    remainder = total_jobs % total_servers
+    start_job = jobs_per_server * server_num
+    start_job += min(remainder, server_num)
+    end_job = start_job + jobs_per_server
+    if server_num < remainder:
+        end_job += 1
+    return (start_job, end_job)
+
 
 def generate_metrics_tenants(num_tenants, metrics_per_tenant,
                              agent_number, num_nodes, gen_fn):
-  """ generate the subset of the total metrics to be done by this agent"""
-  tenants_in_shard = range(*generate_job_range(num_tenants, num_nodes, agent_number))
-  metrics = []
-  for y in map(lambda x: gen_fn(x, metrics_per_tenant), tenants_in_shard):
-    metrics += y
-  random.shuffle(metrics)
-  return metrics
+    """ generate the subset of the total metrics to be done by this agent"""
+    tenants_in_shard = range(
+        *generate_job_range(num_tenants, num_nodes, agent_number))
+    metrics = []
+    for y in map(lambda x: gen_fn(x, metrics_per_tenant), tenants_in_shard):
+        metrics += y
+    random.shuffle(metrics)
+    return metrics
+
 
 def generate_metric_name(metric_id):
-  return default_config['name_fmt'] % metric_id
+    return default_config['name_fmt'] % metric_id
 
-#TODO: Add enum prefix to config
+
+# TODO: Add enum prefix to config
 def generate_enum_metric_name(metric_id):
-  return "enum_grinder_"+default_config['name_fmt'] % metric_id
+    return "enum_grinder_" + default_config['name_fmt'] % metric_id
 
-#Utility functions end here
+
+# Utility functions end here
 
 class AbstractThread(object):
-  #superclass for the various thread types
-  @classmethod
-  def create_metrics(cls, agent_number):
-    raise Exception("Can't create abstract thread")
+    # superclass for the various thread types
+    @classmethod
+    def create_metrics(cls, agent_number):
+        raise Exception("Can't create abstract thread")
 
-  @classmethod
-  def num_threads(cls):
-    raise Exception("Can't create abstract thread")
+    @classmethod
+    def num_threads(cls):
+        raise Exception("Can't create abstract thread")
 
-  def make_request(self, logger):
-    raise Exception("Can't create abstract thread")
+    def make_request(self, logger):
+        raise Exception("Can't create abstract thread")
 
-  def __init__(self, thread_num):
-    # The threads only do so many invocations for each 'report_interval'
-    # position refers to the current position for current interval
-    self.position = 0
+    def __init__(self, thread_num):
+        # The threads only do so many invocations for each 'report_interval'
+        # position refers to the current position for current interval
+        self.position = 0
 
-    # finish_time is the end time of the interval
-    self.finish_time = self.time() + default_config['report_interval']
+        # finish_time is the end time of the interval
+        self.finish_time = self.time() + default_config['report_interval']
 
-  def generate_unit(self, tenant_id):
-    unit_number = tenant_id % 6
-    return units_map[unit_number]
+    def generate_unit(self, tenant_id):
+        unit_number = tenant_id % 6
+        return units_map[unit_number]
 
-  def check_position(self, logger, max_position):
-    """Sleep if finished all work for report interval"""
-    if self.position >= max_position:
-      self.position = 0
-      sleep_time = self.finish_time - self.time()
-      self.finish_time += default_config['report_interval']
-      if sleep_time < 0:
-        #return error
-        logger("finish time error")
-      else:
-        logger("pausing for %d" % sleep_time)
-        self.sleep(sleep_time)
+    def check_position(self, logger, max_position):
+        """Sleep if finished all work for report interval"""
+        if self.position >= max_position:
+            self.position = 0
+            sleep_time = self.finish_time - self.time()
+            self.finish_time += default_config['report_interval']
+            if sleep_time < 0:
+                # return error
+                logger("finish time error")
+            else:
+                logger("pausing for %d" % sleep_time)
+                self.sleep(sleep_time)
 
-  @classmethod
-  def time(cls):
-    return int(time.time() * 1000)
+    @classmethod
+    def time(cls):
+        return int(time.time() * 1000)
 
-  @classmethod
-  def sleep(cls, x):
-    return time.sleep(x/1000)
+    @classmethod
+    def sleep(cls, x):
+        return time.sleep(x / 1000)


### PR DESCRIPTION
This PR cleans up the python code. It almost completely whitespace changes. It makes no changes to the functionality. It reduces the neumber of `pep8` violations from 500 down to 47. Some violations were not removed:
* Line-too-long violations due to long string literals
* "module level import not at top of file" violations in `tests.py`, due to having to modify the package path before importing
* One instance of `x == None` instead of `x is None`, which if fixed could change behavior in some rare circumstances