### PR TITLE
adding more metrics for rollup

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
@@ -67,14 +67,7 @@ public abstract class DAbstractMetricIO {
         BatchStatement batch = new BatchStatement();
         addRollupToBatch(batch, locator, rollup, collectionTime, granularity, ttl);
 
-        Collection<Statement> statements = batch.getStatements();
-        if ( statements.size() > 1 ) {
-            return session.executeAsync(batch);
-        } else {
-            // if we get here, we have only 1 statement
-            Statement stat = statements.iterator().next();
-            return session.executeAsync(stat);
-        }
+        return session.executeAsync(batch);
     }
 
     /**

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
@@ -66,7 +66,15 @@ public abstract class DAbstractMetricIO {
         // multiple statements
         BatchStatement batch = new BatchStatement();
         addRollupToBatch(batch, locator, rollup, collectionTime, granularity, ttl);
-        return session.executeAsync(batch);
+
+        Collection<Statement> statements = batch.getStatements();
+        if ( statements.size() > 1 ) {
+            return session.executeAsync(batch);
+        } else {
+            // if we get here, we have only 1 statement
+            Statement stat = statements.iterator().next();
+            return session.executeAsync(stat);
+        }
     }
 
     /**

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
@@ -67,7 +67,14 @@ public abstract class DAbstractMetricIO {
         BatchStatement batch = new BatchStatement();
         addRollupToBatch(batch, locator, rollup, collectionTime, granularity, ttl);
 
-        return session.executeAsync(batch);
+        Collection<Statement> statements = batch.getStatements();
+        if ( statements.size() == 1 ) {
+            Statement oneStatement = statements.iterator().next();
+            return session.executeAsync(oneStatement);
+        } else {
+            LOG.debug(String.format("Using BatchStatement for %d statements", statements.size()));
+            return session.executeAsync(batch);
+        }
     }
 
     /**

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
@@ -5,7 +5,6 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.google.common.collect.Table;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.exceptions.CacheException;
-import com.rackspacecloud.blueflood.exceptions.InvalidDataException;
 import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
@@ -18,7 +17,7 @@ import java.io.IOException;
 import java.util.*;
 
 /**
- * This class deals with aspects of reading/writing metrics which are common accross all column families
+ * This class deals with aspects of reading/writing metrics which are common across all column families
  * using Datastax driver
  */
 public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
@@ -26,7 +25,6 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
     private static final Logger LOG = LoggerFactory.getLogger( DAbstractMetricsRW.class );
 
     protected final LocatorIO locatorIO;
-
 
     /**
      * Constructor
@@ -50,6 +48,18 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
     protected abstract DAbstractMetricIO getIO( String rollupType, Granularity gran );
 
     /**
+     * Returns the Timer.Context object for timing the Datastax write
+     * @return
+     */
+    protected abstract Timer.Context startWriteTimer();
+
+    /**
+     * Returns the Timer.Context object for timing the waits of the write results
+     * @return
+     */
+    protected abstract Timer.Context startWaitResultsTimer();
+
+    /**
      * This method inserts a collection of metrics in the
      * {@link com.rackspacecloud.blueflood.service.SingleRollupWriteContext}
      * objects to the appropriate Cassandra column family
@@ -66,28 +76,43 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
         Map<ResultSetFuture, SingleRollupWriteContext> futureLocatorMap = new HashMap<ResultSetFuture, SingleRollupWriteContext>();
         Timer.Context ctx = Instrumentation.getWriteTimerContext( writeContexts.get( 0 ).getDestinationCF().getName() );
         try {
-            for (SingleRollupWriteContext writeContext : writeContexts) {
-                Rollup rollup = writeContext.getRollup();
-                Locator locator = writeContext.getLocator();
-                Granularity granularity = writeContext.getGranularity();
-                int ttl = getTtl(locator, rollup.getRollupType(), granularity);
+            Timer.Context writeOnlyTimer = startWriteTimer();
+            try {
+                for (SingleRollupWriteContext writeContext : writeContexts) {
+                    Rollup rollup = writeContext.getRollup();
+                    Locator locator = writeContext.getLocator();
+                    Granularity granularity = writeContext.getGranularity();
+                    int ttl = getTtl(locator, rollup.getRollupType(), granularity);
 
-                // lookup the right writer
-                RollupType rollupType = writeContext.getRollup().getRollupType();
-                DAbstractMetricIO io = getIO( rollupType.name().toLowerCase(), granularity );
+                    // lookup the right writer
+                    RollupType rollupType = writeContext.getRollup().getRollupType();
+                    DAbstractMetricIO io = getIO(rollupType.name().toLowerCase(), granularity);
 
-                ResultSetFuture future = io.putAsync(locator, writeContext.getTimestamp(), rollup, writeContext.getGranularity(), ttl);
-                futureLocatorMap.put(future, writeContext);
+                    ResultSetFuture future = io.putAsync(locator, writeContext.getTimestamp(), rollup, writeContext.getGranularity(), ttl);
+                    futureLocatorMap.put(future, writeContext);
+                }
+            } finally {
+                writeOnlyTimer.stop();
             }
 
-            for (ResultSetFuture future : futureLocatorMap.keySet()) {
-                try {
-                    future.getUninterruptibly().all();
-                } catch (Exception ex) {
-                    Instrumentation.markWriteError();
-                    SingleRollupWriteContext writeContext = futureLocatorMap.get(future);
-                    LOG.error(String.format("error writing to locator %s, granularity %s", writeContext.getLocator(), writeContext.getGranularity()), ex);
+            try {
+                for (final ResultSetFuture future : futureLocatorMap.keySet()) {
+                    final SingleRollupWriteContext writeContext = futureLocatorMap.get(future);
+                    Timer.Context resultsWaitTimer = startWaitResultsTimer();
+                    try {
+                        future.getUninterruptibly().all();
+                    } catch (Exception ex) {
+                        Instrumentation.markWriteError();
+                        LOG.error(String.format("error writing locator %s, granularity %s, timestamp %d",
+                                        writeContext.getLocator(), writeContext.getGranularity(),
+                                        writeContext.getTimestamp()),
+                                ex);
+                    } finally {
+                        resultsWaitTimer.stop();
+                    }
                 }
+            } finally {
+
             }
         } finally {
             ctx.stop();

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
@@ -23,7 +23,6 @@ import java.util.*;
 public class DBasicMetricsRW extends DAbstractMetricsRW {
 
     private static final Logger LOG = LoggerFactory.getLogger( DBasicMetricsRW.class );
-    private static final Timer writeTimer = Metrics.timer(DBasicMetricsRW.class, "Basic Metrics Write");
     private static final Timer waitResultsTimer = Metrics.timer(DBasicMetricsRW.class, "Basic Metrics Wait Write Results");
 
     private boolean areStringMetricsDropped;
@@ -357,11 +356,6 @@ public class DBasicMetricsRW extends DAbstractMetricsRW {
         return simpleIO;
       else
         return basicIO;
-    }
-
-    @Override
-    public Timer.Context startWriteTimer() {
-        return writeTimer.time();
     }
 
     @Override

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
@@ -357,9 +357,4 @@ public class DBasicMetricsRW extends DAbstractMetricsRW {
       else
         return basicIO;
     }
-
-    @Override
-    public Timer.Context startWaitResultsTimer() {
-        return waitResultsTimer.time();
-    }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicMetricsRW.java
@@ -9,6 +9,7 @@ import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.*;
+import com.rackspacecloud.blueflood.utils.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +23,8 @@ import java.util.*;
 public class DBasicMetricsRW extends DAbstractMetricsRW {
 
     private static final Logger LOG = LoggerFactory.getLogger( DBasicMetricsRW.class );
+    private static final Timer writeTimer = Metrics.timer(DBasicMetricsRW.class, "Basic Metrics Write");
+    private static final Timer waitResultsTimer = Metrics.timer(DBasicMetricsRW.class, "Basic Metrics Wait Write Results");
 
     private boolean areStringMetricsDropped;
     private Set<String> keptTenantIdsSet;
@@ -354,5 +357,15 @@ public class DBasicMetricsRW extends DAbstractMetricsRW {
         return simpleIO;
       else
         return basicIO;
+    }
+
+    @Override
+    public Timer.Context startWriteTimer() {
+        return writeTimer.time();
+    }
+
+    @Override
+    public Timer.Context startWaitResultsTimer() {
+        return waitResultsTimer.time();
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetricsCFPreparedStatements.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetricsCFPreparedStatements.java
@@ -96,6 +96,9 @@ public class DMetricsCFPreparedStatements {
         //
         // Preaggr insert statements
         //
+        // TODO: The call to setConsistency(ONE) is required by
+        // the cassandra-maven-plugin 2.0.0-1, but not by cassandra 2.0.11, which we run.
+        // I believe its due to the bug https://issues.apache.org/jira/browse/CASSANDRA-6238
         insertToMetricsPreaggrFullStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_PREAGGREGATED_FULL_NAME))
@@ -164,6 +167,9 @@ public class DMetricsCFPreparedStatements {
         //
         // Basic insert statements
         //
+        // TODO: The call to setConsistency(ONE) is required by
+        // the cassandra-maven-plugin 2.0.0-1, but not by cassandra 2.0.11, which we run.
+        // I believe its due to the bug https://issues.apache.org/jira/browse/CASSANDRA-6238
         insertToMetricsBasicFullStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_FULL_NAME))

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetricsCFPreparedStatements.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetricsCFPreparedStatements.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.io.datastax;
 
+import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.rackspacecloud.blueflood.io.CassandraModel;
@@ -97,22 +98,28 @@ public class DMetricsCFPreparedStatements {
         //
         insertToMetricsPreaggrFullStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_PREAGGREGATED_FULL_NAME));
+                        CassandraModel.CF_METRICS_PREAGGREGATED_FULL_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
         insertToMetricsPreaggr5MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_PREAGGREGATED_5M_NAME));
+                        CassandraModel.CF_METRICS_PREAGGREGATED_5M_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
         insertToMetricsPreaggr20MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_PREAGGREGATED_20M_NAME));
+                        CassandraModel.CF_METRICS_PREAGGREGATED_20M_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
         insertToMetricsPreaggr60MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_PREAGGREGATED_60M_NAME));
+                        CassandraModel.CF_METRICS_PREAGGREGATED_60M_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
         insertToMetricsPreaggr240MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_PREAGGREGATED_240M_NAME));
+                        CassandraModel.CF_METRICS_PREAGGREGATED_240M_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
         insertToMetricsPreaggr1440MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_PREAGGREGATED_1440M_NAME));
+                        CassandraModel.CF_METRICS_PREAGGREGATED_1440M_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
 
         //
         // Preaggr select statements
@@ -159,22 +166,28 @@ public class DMetricsCFPreparedStatements {
         //
         insertToMetricsBasicFullStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_FULL_NAME));
+                        CassandraModel.CF_METRICS_FULL_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
         insertToMetricsBasic5MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_5M_NAME));
+                        CassandraModel.CF_METRICS_5M_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
         insertToMetricsBasic20MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_20M_NAME));
+                        CassandraModel.CF_METRICS_20M_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
         insertToMetricsBasic60MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_60M_NAME));
+                        CassandraModel.CF_METRICS_60M_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
         insertToMetricsBasic240MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_240M_NAME));
+                        CassandraModel.CF_METRICS_240M_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
         insertToMetricsBasic1440MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
-                        CassandraModel.CF_METRICS_1440M_NAME));
+                        CassandraModel.CF_METRICS_1440M_NAME))
+                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
 
         //
         // Basic select statements

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
@@ -25,6 +25,7 @@ import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.*;
+import com.rackspacecloud.blueflood.utils.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,8 @@ import java.util.*;
 public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements PreaggregatedRW {
 
     private static final Logger LOG = LoggerFactory.getLogger(DPreaggregatedMetricsRW.class);
+    private static final Timer writeTimer = Metrics.timer(DPreaggregatedMetricsRW.class, "PreAggr Metrics Write");
+    private static final Timer waitResultsTimer = Metrics.timer(DPreaggregatedMetricsRW.class, "PreAggr Metrics Wait Write Results");
 
     private final DCounterIO counterIO = new DCounterIO();
     private final DGagueIO gaugeIO = new DGagueIO();
@@ -183,6 +186,16 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
         }
 
         return io;
+    }
+
+    @Override
+    public Timer.Context startWriteTimer() {
+        return writeTimer.time();
+    }
+
+    @Override
+    public Timer.Context startWaitResultsTimer() {
+        return waitResultsTimer.time();
     }
 }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
@@ -39,7 +39,6 @@ import java.util.*;
 public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements PreaggregatedRW {
 
     private static final Logger LOG = LoggerFactory.getLogger(DPreaggregatedMetricsRW.class);
-    private static final Timer writeTimer = Metrics.timer(DPreaggregatedMetricsRW.class, "PreAggr Metrics Write");
     private static final Timer waitResultsTimer = Metrics.timer(DPreaggregatedMetricsRW.class, "PreAggr Metrics Wait Write Results");
 
     private final DCounterIO counterIO = new DCounterIO();
@@ -186,11 +185,6 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
         }
 
         return io;
-    }
-
-    @Override
-    public Timer.Context startWriteTimer() {
-        return writeTimer.time();
     }
 
     @Override

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
@@ -186,10 +186,5 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
 
         return io;
     }
-
-    @Override
-    public Timer.Context startWaitResultsTimer() {
-        return waitResultsTimer.time();
-    }
 }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ExcessEnumReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ExcessEnumReader.java
@@ -17,17 +17,14 @@
 package com.rackspacecloud.blueflood.service;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import com.codahale.metrics.Meter;
 
 import com.rackspacecloud.blueflood.io.IOContainer;
-import com.rackspacecloud.blueflood.io.astyanax.AExcessEnumIO;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.utils.Metrics;
 
-import io.netty.util.internal.ConcurrentSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnable.java
@@ -149,7 +149,8 @@ class LocatorFetchRunnable implements Runnable {
     public void finishExecution(long waitStart, RollupExecutionContext executionContext) {
         if (executionContext.wasSuccessful()) {
             this.scheduleCtx.clearFromRunning(parentSlotKey);
-            log.info("Successful completion of rollups for (gran,slot,shard) {} in {} ms", new Object[] {parentSlotKey, System.currentTimeMillis() - waitStart});
+            log.info("Successful completion of rollups for (gran,slot,shard) {} in {} ms",
+                    new Object[] {parentSlotKey, System.currentTimeMillis() - waitStart});
         } else {
             log.error("Performing BasicRollups for {} failed", parentSlotKey);
             this.scheduleCtx.pushBackToScheduled(parentSlotKey, false);
@@ -166,8 +167,10 @@ class LocatorFetchRunnable implements Runnable {
             // continue on, but log the problem so that we can fix things later.
             executionContext.markUnsuccessful(any);
             executionContext.decrementReadCounter();
-            log.error(any.getMessage(), any);
-            log.error("BasicRollup failed for {} at {}", parentSlotKey, serverTime);
+            log.error(String.format(
+                            "BasicRollup failed for %s, locator %s, at %d",
+                            parentSlotKey, locator, serverTime),
+                    any);
         }
 
         return rollCount;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupBatchWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupBatchWriter.java
@@ -77,13 +77,13 @@ public class RollupBatchWriter {
         }
         if (writeBasicContexts.size() > 0) {
             LOG.debug(
-                    String.format("drainBatch(): kicking off RollupBatchWriteRunnables for %d contexts",
+                    String.format("drainBatch(): kicking off RollupBatchWriteRunnables for %d basic contexts",
                             writeBasicContexts.size()));
             executor.execute(new RollupBatchWriteRunnable(writeBasicContexts, context, basicMetricsRW));
         }
         if (writePreAggrContexts.size() > 0) {
             LOG.debug(
-                    String.format("drainBatch(): kicking off RollupBatchWriteRunnables for %d contexts",
+                    String.format("drainBatch(): kicking off RollupBatchWriteRunnables for %d preAggr contexts",
                             writePreAggrContexts.size()));
             executor.execute(new RollupBatchWriteRunnable(writePreAggrContexts, context, preAggregatedRW));
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -165,6 +165,7 @@ public class RollupRunnable implements Runnable {
                     singleRollupReadContext.getRange().toString(),
                     srcGran.name(),
                     e});
+            executionContext.markUnsuccessful(e);
         } finally {
             executionContext.decrementReadCounter();
             timerContext.stop();

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -165,7 +165,6 @@ public class RollupRunnable implements Runnable {
                     singleRollupReadContext.getRange().toString(),
                     srcGran.name(),
                     e});
-            executionContext.markUnsuccessful(e);
         } finally {
             executionContext.decrementReadCounter();
             timerContext.stop();

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/IOContainerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/io/IOContainerTest.java
@@ -1,5 +1,6 @@
 package com.rackspacecloud.blueflood.io;
 
+import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.Session;
@@ -61,6 +62,8 @@ public class IOContainerTest {
         when( DatastaxIO.getSession()).thenReturn( mockSession );
         PreparedStatement mockPreparedStatement = mock( PreparedStatement.class );
         when( mockSession.prepare( any( RegularStatement.class ) ) ).thenReturn( mockPreparedStatement );
+        when( mockSession.prepare( anyString() ) ).thenReturn( mockPreparedStatement );
+        when( mockPreparedStatement.setConsistencyLevel( any(ConsistencyLevel.class) ) ).thenReturn( mockPreparedStatement );
     }
 
     @Test

--- a/contrib/grinder/scripts/ingest.py
+++ b/contrib/grinder/scripts/ingest.py
@@ -93,7 +93,11 @@ class IngestThread(AbstractThread):
                                         self.slice[self.position])
         self.position += 1
         result = self.request.POST(self.ingest_url(), payload)
+        if result.getStatusCode() == 500:
+            logger("XXXXX: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result
 
+    if result.getStatusCode() == 500:
+      logger("XXXXX: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
 
 ThreadManager.add_type(IngestThread)

--- a/contrib/grinder/scripts/ingest.py
+++ b/contrib/grinder/scripts/ingest.py
@@ -97,7 +97,4 @@ class IngestThread(AbstractThread):
             logger("XXXXX: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result
 
-    if result.getStatusCode() == 500:
-      logger("XXXXX: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
-
 ThreadManager.add_type(IngestThread)

--- a/contrib/grinder/scripts/ingest.py
+++ b/contrib/grinder/scripts/ingest.py
@@ -93,8 +93,6 @@ class IngestThread(AbstractThread):
                                         self.slice[self.position])
         self.position += 1
         result = self.request.POST(self.ingest_url(), payload)
-        if result.getStatusCode() == 500:
-            logger("XXXXX: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result
 
 ThreadManager.add_type(IngestThread)


### PR DESCRIPTION
The main purpose of this PR is to add a few more metrics to Rollup process. Changes include:
* add the following metric:
  * meter for number of Rollup writes (to record num of Rollup writes per min rate)
* minor clarifications on some log statements
