### PR TITLE
change graphite-api source for pip install in Dockerfile

### DIFF
--- a/contrib/Docker_Grafana_Blueflood/Dockerfile
+++ b/contrib/Docker_Grafana_Blueflood/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     apt-get install -y libcairo2-dev --force-yes && \
     apt-get install -y libffi-dev --force-yes && \
     pip install gunicorn &&\
-	pip install --upgrade "git+http://github.com/rackerlabs/graphite-api.git@george/fetch_multi_with_patches" &&\
+	pip install --upgrade "git+http://github.com/rackerlabs/graphite-api.git@1.1.3-rax.1" &&\
 	git -C /tmp clone https://github.com/rackerlabs/blueflood.git &&\
     git -C /tmp/blueflood checkout master &&\
 	cd /tmp/blueflood/contrib/graphite &&\

--- a/contrib/graphite/scripts/bootstrap.sh
+++ b/contrib/graphite/scripts/bootstrap.sh
@@ -95,7 +95,7 @@ ln -s /etc/nginx/sites-available/grafana /etc/nginx/sites-enabled/grafana
 /etc/init.d/nginx restart
 
 pip install gunicorn
-pip install --upgrade "git+http://github.com/rackerlabs/graphite-api.git@george/fetch_multi_with_patches"
+pip install --upgrade "git+http://github.com/rackerlabs/graphite-api.git@1.1.3-rax.1"
 
 #WE still get the latest code for blueflood_grafana_plugin
 git -C /tmp clone https://github.com/rackerlabs/blueflood.git


### PR DESCRIPTION
# What
Modify the url for installing graphite-api in the Docker scripts.

# Why
we reforked from the official 1.1.3 version of brutasse's graphite-api and added our own changes and tagged it to 1.1.3-rax.1