### PR TITLE
Datastax rollup writes changed from using async to batch statements

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
@@ -77,6 +77,28 @@ public abstract class DAbstractMetricIO {
         }
     }
 
+    public Statement createStatement(Locator locator, long collectionTime, Rollup rollup, Granularity granularity, int ttl) {
+        final PreparedStatement statement;
+
+        if( rollup.getRollupType() == RollupType.BF_BASIC ) {
+
+            // Strings and Booleans don't get rolled up.  I'd like to verify
+            // that none are passed in, but that would require a db access
+
+            statement = metricsCFPreparedStatements.basicGranToInsertStatement.get( granularity );
+        }
+        else {
+            statement = metricsCFPreparedStatements.preaggrGranToInsertStatement.get(granularity);
+        }
+
+        BoundStatement bound = statement.bind(locator.toString(),
+                collectionTime,
+                toByteBuffer(rollup),
+                ttl);
+
+        return bound;
+    }
+
     /**
      * Fetch rollup objects for a {@link com.rackspacecloud.blueflood.types.Locator}
      * from the specified column family and range.
@@ -158,24 +180,8 @@ public abstract class DAbstractMetricIO {
                                     long collectionTime,
                                     Granularity granularity,
                                     int ttl) {
-        PreparedStatement statement;
-
-        if( rollup.getRollupType() == RollupType.BF_BASIC ) {
-
-            // Strings and Booleans don't get rolled up.  I'd like to verify
-            // that none are passed in, but that would require a db access
-
-            statement = metricsCFPreparedStatements.basicGranToInsertStatement.get( granularity );
-        }
-        else {
-            statement = metricsCFPreparedStatements.preaggrGranToInsertStatement.get(granularity);
-        }
-
-        BoundStatement bound = statement.bind(locator.toString(),
-                                    collectionTime,
-                                    toByteBuffer(rollup),
-                                    ttl);
-        batch.add(bound);
+        Statement statement = createStatement(locator, collectionTime, rollup, granularity, ttl);
+        batch.add(statement);
     }
 
     /**

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
@@ -1,7 +1,10 @@
 package com.rackspacecloud.blueflood.io.datastax;
 
 import com.codahale.metrics.Timer;
+import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
 import com.google.common.collect.Table;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.exceptions.CacheException;
@@ -48,11 +51,14 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
     protected abstract DAbstractMetricIO getIO( String rollupType, Granularity gran );
 
     /**
-     * This method inserts a collection of metrics in the
-     * {@link com.rackspacecloud.blueflood.service.SingleRollupWriteContext}
-     * objects to the appropriate Cassandra column family
+     * This method inserts a collection of {@link com.rackspacecloud.blueflood.service.SingleRollupWriteContext} objects
+     * to the appropriate Cassandra column family.
+     *
+     * It performs the inserts by executing an UNLOGGED BATCH statement.
      *
      * @param writeContexts
+     *
+     * @throws IOException
      */
     @Override
     public void insertRollups(List<SingleRollupWriteContext> writeContexts) {
@@ -61,9 +67,12 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
             return;
         }
 
-        Map<ResultSetFuture, SingleRollupWriteContext> futureLocatorMap = new HashMap<ResultSetFuture, SingleRollupWriteContext>();
         Timer.Context ctx = Instrumentation.getWriteTimerContext( writeContexts.get( 0 ).getDestinationCF().getName() );
+
         try {
+
+            BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
+
             for (SingleRollupWriteContext writeContext : writeContexts) {
                 Rollup rollup = writeContext.getRollup();
                 Locator locator = writeContext.getLocator();
@@ -74,22 +83,16 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
                 RollupType rollupType = writeContext.getRollup().getRollupType();
                 DAbstractMetricIO io = getIO(rollupType.name().toLowerCase(), granularity);
 
-                ResultSetFuture future = io.putAsync(locator, writeContext.getTimestamp(), rollup, writeContext.getGranularity(), ttl);
-                futureLocatorMap.put(future, writeContext);
+                Statement statement = io.createStatement(locator, writeContext.getTimestamp(), rollup, writeContext.getGranularity(), ttl);
+                batch.add(statement);
             }
 
-            for (final ResultSetFuture future : futureLocatorMap.keySet()) {
-                try {
-                    future.getUninterruptibly().all();
-                } catch (Exception ex) {
-                    Instrumentation.markWriteError();
-                    final SingleRollupWriteContext writeContext = futureLocatorMap.get(future);
-                    LOG.error(String.format("error writing locator %s, granularity %s, timestamp %d",
-                                        writeContext.getLocator(), writeContext.getGranularity(),
-                                        writeContext.getTimestamp()),
-                                ex);
-                }
-            }
+            Session session = DatastaxIO.getSession();
+            session.execute(batch);
+
+        } catch (Exception ex) {
+            Instrumentation.markWriteError();
+            LOG.error(String.format("error writing locator batch of size %s, granularity %s", writeContexts.size(), writeContexts.get(0).getGranularity()), ex);
         } finally {
             ctx.stop();
         }


### PR DESCRIPTION
We had noticed that switching from datastax to astyanax has increased the rollup write time by 5x. The one major difference between datastax and astyanax with respect to rollup writes are in datastax, each write is a separate async call whereas in astyanax, we do a synchronous batch(MutationBatch) request. 

Based on several blogs(see References section) which talk about this, have found that using "unlogged batch statements" with datastax tend to have better performance than using async even though the documention clearly says to use "unlogged batch statements" only when we can batch them by partition key to see any benefits.