### PR TITLE
track delayed metrics when they are sent to /aggregated and /aggregated/multi

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
@@ -16,6 +16,8 @@
 
 package com.rackspacecloud.blueflood.inputs.formats;
 
+import com.google.gson.Gson;
+import com.rackspacecloud.blueflood.io.Instrumentation;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.*;
@@ -26,6 +28,8 @@ import java.util.*;
 public class AggregatedPayload {
 
     private static final long TRACKER_DELAYED_METRICS_MILLIS = Configuration.getInstance().getLongProperty(CoreConfig.TRACKER_DELAYED_METRICS_MILLIS);
+    private static final long MAX_AGE_ALLOWED = Configuration.getInstance().getLongProperty(CoreConfig.ROLLUP_DELAY_MILLIS);
+    private static final long SHORT_DELAY = Configuration.getInstance().getLongProperty(CoreConfig.SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS);
     private final long BEFORE_CURRENT_COLLECTIONTIME_MS = Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
     private final long AFTER_CURRENT_COLLECTIONTIME_MS = Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
 
@@ -42,6 +46,11 @@ public class AggregatedPayload {
     private BluefloodEnum[] enums;
     
     private Map<String, Object> metadata;
+
+    public static AggregatedPayload create(String json) {
+        AggregatedPayload payload = new Gson().fromJson(json, AggregatedPayload.class);
+        return payload;
+    }
     
     public String toString() {
         return String.format("%s (%d)", tenantId, timestamp);
@@ -75,16 +84,44 @@ public class AggregatedPayload {
         return errors;
     }
 
+    /**
+     * Determines if the metrics represented in this {@link AggregatedPayload}
+     * has collection timestamp that we consider "late" or "delayed".
+     *
+     * @param ingestTime
+     * @return
+     */
     public boolean hasDelayedMetrics(long ingestTime) {
-        if ( getDelayTime(ingestTime) > TRACKER_DELAYED_METRICS_MILLIS ) {
-            return true;
-        } else {
-            return false;
-        }
+        return getDelayTime(ingestTime) > TRACKER_DELAYED_METRICS_MILLIS;
     }
 
+    /**
+     * Calculates how many milliseconds is the collection timestamp of
+     * this {@link AggregatedPayload} delayed by.
+     *
+     * @param ingestTime  ingest timestamp in milliseconds
+     * @return
+     */
     public long getDelayTime(long ingestTime) {
         return ingestTime - timestamp;
+    }
+
+    /**
+     * Marks/instruments our internal metrics that we have received
+     * short or delayed metrics
+     *
+     * @param ingestTime
+     * @return
+     */
+    public void markDelayMetricsReceived(long ingestTime) {
+        long delay = getDelayTime(ingestTime);
+        if ( delay > MAX_AGE_ALLOWED ) {
+            if ( delay <= SHORT_DELAY ) {
+                Instrumentation.markMetricsWithShortDelayReceived();
+            } else {
+                Instrumentation.markMetricsWithLongDelayReceived();
+            }
+        }
     }
 
     public List<String> getAllMetricNames() {
@@ -108,7 +145,7 @@ public class AggregatedPayload {
         }
 
         if ( sets != null && sets.length > 0) {
-            for (int index=0; index<sets.length; index++) {
+            for (int index = 0; index < sets.length; index++) {
                 metricNames.add(sets[index].getName());
             }
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
@@ -25,6 +25,7 @@ import java.util.*;
 // Using nested classes for now. Expect this to be cleaned up.
 public class AggregatedPayload {
 
+    private static final long TRACKER_DELAYED_METRICS_MILLIS = Configuration.getInstance().getLongProperty(CoreConfig.TRACKER_DELAYED_METRICS_MILLIS);
     private final long BEFORE_CURRENT_COLLECTIONTIME_MS = Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
     private final long AFTER_CURRENT_COLLECTIONTIME_MS = Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
 
@@ -72,6 +73,52 @@ public class AggregatedPayload {
         }
 
         return errors;
+    }
+
+    public boolean hasDelayedMetrics(long ingestTime) {
+        if ( getDelayTime(ingestTime) > TRACKER_DELAYED_METRICS_MILLIS ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public long getDelayTime(long ingestTime) {
+        return ingestTime - timestamp;
+    }
+
+    public List<String> getAllMetricNames() {
+        List<String> metricNames = new java.util.ArrayList<String>();
+        if ( gauges != null && gauges.length > 0) {
+            for (int index=0; index<gauges.length; index++) {
+                metricNames.add(gauges[index].getName());
+            }
+        }
+
+        if ( counters != null && counters.length > 0) {
+            for (int index=0; index<counters.length; index++) {
+                metricNames.add(counters[index].getName());
+            }
+        }
+
+        if ( timers != null && timers.length > 0) {
+            for (int index=0; index<timers.length; index++) {
+                metricNames.add(timers[index].getName());
+            }
+        }
+
+        if ( sets != null && sets.length > 0) {
+            for (int index=0; index<sets.length; index++) {
+                metricNames.add(sets[index].getName());
+            }
+        }
+
+        if ( enums != null && enums.length > 0) {
+            for (int index=0; index<enums.length; index++) {
+                metricNames.add(enums[index].getName());
+            }
+        }
+        return metricNames;
     }
 
     //@SafeVarargs (1.7 only doge)

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandler.java
@@ -27,6 +27,8 @@ import com.rackspacecloud.blueflood.inputs.formats.AggregatedPayload;
 import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.tracker.Tracker;
 import com.rackspacecloud.blueflood.types.MetricsCollection;
+import com.rackspacecloud.blueflood.utils.Clock;
+import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
 import com.rackspacecloud.blueflood.utils.Metrics;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import io.netty.channel.ChannelHandlerContext;
@@ -46,6 +48,7 @@ public class HttpAggregatedIngestionHandler implements HttpRequestHandler {
     
     private final HttpMetricsIngestionServer.Processor processor;
     private final TimeValue timeout;
+    private final Clock clock = new DefaultClockImpl();
     
     public HttpAggregatedIngestionHandler(HttpMetricsIngestionServer.Processor processor, TimeValue timeout) {
         this.processor = processor;
@@ -67,14 +70,15 @@ public class HttpAggregatedIngestionHandler implements HttpRequestHandler {
             requestCount.inc();
             MetricsCollection collection = new MetricsCollection();
 
-            AggregatedPayload payload = createPayload( body );
+            AggregatedPayload payload = AggregatedPayload.create( body );
 
-            long ingestTime = System.currentTimeMillis();
+            long ingestTime = clock.now().getMillis();
             if (payload.hasDelayedMetrics(ingestTime)) {
                 Tracker.getInstance().trackDelayedAggregatedMetricsTenant(payload.getTenantId(),
                         payload.getTimestamp(),
                         payload.getDelayTime(ingestTime),
                         payload.getAllMetricNames());
+                payload.markDelayMetricsReceived(ingestTime);
             }
 
             List<String> errors = payload.getValidationErrors();
@@ -113,10 +117,5 @@ public class HttpAggregatedIngestionHandler implements HttpRequestHandler {
             requestCount.dec();
             timerContext.stop();
         }
-    }
-    
-    public static AggregatedPayload createPayload(String json) {
-        AggregatedPayload payload = new Gson().fromJson(json, AggregatedPayload.class);
-        return payload;
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandler.java
@@ -69,6 +69,14 @@ public class HttpAggregatedIngestionHandler implements HttpRequestHandler {
 
             AggregatedPayload payload = createPayload( body );
 
+            long ingestTime = System.currentTimeMillis();
+            if (payload.hasDelayedMetrics(ingestTime)) {
+                Tracker.getInstance().trackDelayedAggregatedMetricsTenant(payload.getTenantId(),
+                        payload.getTimestamp(),
+                        payload.getDelayTime(ingestTime),
+                        payload.getAllMetricNames());
+            }
+
             List<String> errors = payload.getValidationErrors();
             if ( errors.isEmpty() ) {
                 // no validation errors, process bundle

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
@@ -26,6 +26,8 @@ import com.rackspacecloud.blueflood.inputs.formats.AggregatedPayload;
 import com.rackspacecloud.blueflood.io.Constants;
 import com.rackspacecloud.blueflood.tracker.Tracker;
 import com.rackspacecloud.blueflood.types.MetricsCollection;
+import com.rackspacecloud.blueflood.utils.Clock;
+import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
 import com.rackspacecloud.blueflood.utils.Metrics;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import io.netty.channel.ChannelHandlerContext;
@@ -47,6 +49,7 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
 
     private final HttpMetricsIngestionServer.Processor processor;
     private final TimeValue timeout;
+    private final Clock clock = new DefaultClockImpl();
 
     public HttpAggregatedMultiIngestionHandler(HttpMetricsIngestionServer.Processor processor, TimeValue timeout) {
         this.processor = processor;
@@ -60,7 +63,7 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
         Tracker.getInstance().track(request);
 
         final Timer.Context timerContext = handlerTimer.time();
-        long ingestTime = System.currentTimeMillis();
+        long ingestTime = clock.now().getMillis();
 
         // this is all JSON.
         final String body = request.content().toString(Constants.DEFAULT_CHARSET);
@@ -93,6 +96,7 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
                                 bundle.getTimestamp(),
                                 bundle.getDelayTime(ingestTime),
                                 bundle.getAllMetricNames());
+                        bundle.markDelayMetricsReceived(ingestTime);
                     }
                 }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
@@ -60,6 +60,7 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
         Tracker.getInstance().track(request);
 
         final Timer.Context timerContext = handlerTimer.time();
+        long ingestTime = System.currentTimeMillis();
 
         // this is all JSON.
         final String body = request.content().toString(Constants.DEFAULT_CHARSET);
@@ -85,6 +86,13 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
                     else {
                         // failed validation, add to error
                         errors.addAll( bundleValidationErrors );
+                    }
+
+                    if (bundle.hasDelayedMetrics(ingestTime)) {
+                        Tracker.getInstance().trackDelayedAggregatedMetricsTenant(bundle.getTenantId(),
+                                bundle.getTimestamp(),
+                                bundle.getDelayTime(ingestTime),
+                                bundle.getAllMetricNames());
                     }
                 }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
@@ -120,7 +120,7 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
                 }
 
                 if (jsonMetricsContainer.areDelayedMetricsPresent()) {
-                    Tracker.getInstance().trackDelayedMetricsTenant(tenantId, jsonMetricsContainer.getDelayedMetrics());
+                    Tracker.getInstance().trackDelayedAggregatedMetricsTenant(tenantId, jsonMetricsContainer.getDelayedMetrics());
                 }
 
                 metrics = jsonMetricsContainer.getValidMetrics();

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
@@ -120,7 +120,7 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
                 }
 
                 if (jsonMetricsContainer.areDelayedMetricsPresent()) {
-                    Tracker.getInstance().trackDelayedAggregatedMetricsTenant(tenantId, jsonMetricsContainer.getDelayedMetrics());
+                    Tracker.getInstance().trackDelayedMetricsTenant(tenantId, jsonMetricsContainer.getDelayedMetrics());
                 }
 
                 metrics = jsonMetricsContainer.getValidMetrics();

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
@@ -234,7 +234,13 @@ public class Tracker implements TrackerMBean {
 
     }
 
-    public void trackDelayedMetricsTenant(String tenantid, List<Metric> delayedMetrics) {
+    /**
+     * This method is used to log delayed metrics, if tracking delayed metrics
+     * is turned on for this Blueflood service.
+     * @param tenantid
+     * @param delayedMetrics
+     */
+    public void trackDelayedAggregatedMetricsTenant(String tenantid, final List<Metric> delayedMetrics) {
         if (isTrackingDelayedMetrics) {
             String logMessage = String.format("[TRACKER][DELAYED METRIC] Tenant sending delayed metrics %s", tenantid);
             log.info(logMessage);
@@ -250,6 +256,32 @@ public class Tracker implements TrackerMBean {
                         delayedMinutes);
                 log.info(logMessage);
             }
+        }
+    }
+
+    /**
+     * This method logs the delayed aggregated metrics for a particular tenant,
+     * if tracking delayed metric is turned on for this Blueflood service.
+     * Aggregated metrics have one single timestamp for the group of metrics that
+     * are sent in one request.
+     *
+     * @param tenantId              the tenantId who's the sender of the metrics
+     * @param collectionTimeMs      the collection timestamp (ms) in request payload
+     * @param delayTimeMs           the delayed time (ms)
+     * @param delayedMetricNames    the list of delayed metrics in request payload
+     */
+    public void trackDelayedAggregatedMetricsTenant(String tenantId, long collectionTimeMs, long delayTimeMs, List<String> delayedMetricNames) {
+        if (isTrackingDelayedMetrics) {
+            String logMessage = String.format("[TRACKER][DELAYED METRIC] Tenant sending delayed metrics %s", tenantId);
+            log.info(logMessage);
+
+            // log individual delayed metrics locator and collectionTime
+            double delayMin = delayTimeMs / 1000 / 60;
+            logMessage = String.format("[TRACKER][DELAYED METRIC] %s have collectionTime %s which is delayed by %.2f minutes",
+                        String.join(",", delayedMetricNames),
+                        dateFormatter.format(new Date(collectionTimeMs)),
+                        delayMin);
+            log.info(logMessage);
         }
     }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
@@ -240,7 +240,7 @@ public class Tracker implements TrackerMBean {
      * @param tenantid
      * @param delayedMetrics
      */
-    public void trackDelayedAggregatedMetricsTenant(String tenantid, final List<Metric> delayedMetrics) {
+    public void trackDelayedMetricsTenant(String tenantid, final List<Metric> delayedMetrics) {
         if (isTrackingDelayedMetrics) {
             String logMessage = String.format("[TRACKER][DELAYED METRIC] Tenant sending delayed metrics %s", tenantid);
             log.info(logMessage);

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/tracker/Tracker.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -278,7 +279,7 @@ public class Tracker implements TrackerMBean {
             // log individual delayed metrics locator and collectionTime
             double delayMin = delayTimeMs / 1000 / 60;
             logMessage = String.format("[TRACKER][DELAYED METRIC] %s have collectionTime %s which is delayed by %.2f minutes",
-                        String.join(",", delayedMetricNames),
+                    StringUtils.join(delayedMetricNames, ","),
                         dateFormatter.format(new Date(collectionTimeMs)),
                         delayMin);
             log.info(logMessage);

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayloadTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayloadTest.java
@@ -1,0 +1,64 @@
+package com.rackspacecloud.blueflood.inputs.formats;
+
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static com.rackspacecloud.blueflood.TestUtils.FUTURE_COLLECTION_TIME_REGEX;
+import static com.rackspacecloud.blueflood.TestUtils.PAST_COLLECTION_TIME_REGEX;
+import static com.rackspacecloud.blueflood.TestUtils.getJsonFromFile;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Unit tests for the {@link AggregatedPayload} class
+ */
+public class AggregatedPayloadTest {
+
+    private static final long TIME_DIFF_MS = 2000;
+    private static final String POSTFIX = ".post";
+
+    private AggregatedPayload payload;
+
+    @Test
+    public void testTimestampInTheFuture() throws IOException {
+
+        long timestamp = System.currentTimeMillis() + TIME_DIFF_MS
+                + Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
+
+        String json = getJsonFromFile("sample_payload.json", timestamp, POSTFIX);
+        payload = AggregatedPayload.create(json);
+
+        List<String> errors = payload.getValidationErrors();
+        assertTrue( "'" + errors.get(0) + "' does not match pattern " + FUTURE_COLLECTION_TIME_REGEX, Pattern.matches(FUTURE_COLLECTION_TIME_REGEX, errors.get(0)) );
+    }
+
+    @Test
+    public void testTimestampInThePast() throws IOException {
+
+        long timestamp = System.currentTimeMillis() - TIME_DIFF_MS
+                - Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
+
+        String json = getJsonFromFile( "sample_payload.json", timestamp, POSTFIX);
+        payload = AggregatedPayload.create(json);
+
+        List<String> errors = payload.getValidationErrors();
+        assertTrue( "'" + errors.get(0) + "' does not match pattern " + PAST_COLLECTION_TIME_REGEX, Pattern.matches( PAST_COLLECTION_TIME_REGEX, errors.get(0) ) );
+    }
+
+    @Test
+    public void testDelayMetrics() throws IOException {
+        long timeNow = System.currentTimeMillis();
+        long trackerDelayMs = Configuration.getInstance().getLongProperty(CoreConfig.TRACKER_DELAYED_METRICS_MILLIS);
+        long shortDelay = Configuration.getInstance().getLongProperty(CoreConfig.SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS);
+        long collectionTime = timeNow - trackerDelayMs - shortDelay - TIME_DIFF_MS;
+
+        String json = getJsonFromFile( "sample_single_aggregated_payload.json", collectionTime, POSTFIX);
+        payload = AggregatedPayload.create(json);
+
+        assertTrue("payload has delayed metrics", payload.hasDelayedMetrics(timeNow));
+    }
+}

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/wrappers/TestGsonParsing.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/wrappers/TestGsonParsing.java
@@ -31,13 +31,13 @@ public class TestGsonParsing {
     @Test
     public void testLameButValidJSON() {
         String badJson = "{}";
-        AggregatedPayload payload = HttpAggregatedIngestionHandler.createPayload(badJson);
+        AggregatedPayload payload = AggregatedPayload.create(badJson);
     }
     
     @Test(expected = JsonSyntaxException.class)
     public void testInvalidJSON() {
         String badJson = "{tenantId:}";
-        AggregatedPayload payload = HttpAggregatedIngestionHandler.createPayload(badJson);
+        AggregatedPayload payload = AggregatedPayload.create(badJson);
     }
     
     @Test

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
@@ -387,7 +387,7 @@ public class TrackerTest {
     public void testTrackDelayedMetricsTenant() {
         // enable tracking delayed metrics and track
         tracker.setIsTrackingDelayedMetrics();
-        tracker.trackDelayedMetricsTenant(tenantId, delayedMetrics);
+        tracker.trackDelayedAggregatedMetricsTenant(tenantId, delayedMetrics);
 
         // verify
         verify(loggerMock, atLeastOnce()).info("[TRACKER] Tracking delayed metrics started");
@@ -400,7 +400,7 @@ public class TrackerTest {
     public void testDoesNotTrackDelayedMetricsTenant() {
         // disable tracking delayed metrics and track
         tracker.resetIsTrackingDelayedMetrics();
-        tracker.trackDelayedMetricsTenant(tenantId, delayedMetrics);
+        tracker.trackDelayedAggregatedMetricsTenant(tenantId, delayedMetrics);
 
         // verify
         verify(loggerMock, atLeastOnce()).info("[TRACKER] Tracking delayed metrics stopped");
@@ -409,4 +409,36 @@ public class TrackerTest {
         verify(loggerMock, never()).info(contains("[TRACKER][DELAYED METRIC] " + tenantId + ".delayed.metric2 has collectionTime 2016-01-01 00:00:00"));
     }
 
+    @Test
+    public void testTrackDelayedAggregatedMetricsTenant() {
+        // enable tracking delayed metrics and track
+        tracker.setIsTrackingDelayedMetrics();
+
+        List<String> delayedMetricNames = new ArrayList<String>() {{
+            for ( Metric metric : delayedMetrics ) {
+                add(metric.getLocator().toString());
+            }
+        }};
+        long ingestTime = System.currentTimeMillis();
+        tracker.trackDelayedAggregatedMetricsTenant(tenantId, delayedMetrics.get(0).getCollectionTime(), ingestTime, delayedMetricNames);
+
+        // verify
+        verify(loggerMock, atLeastOnce()).info("[TRACKER] Tracking delayed metrics started");
+        verify(loggerMock, atLeastOnce()).info("[TRACKER][DELAYED METRIC] Tenant sending delayed metrics " + tenantId);
+        verify(loggerMock, atLeastOnce()).info(contains("[TRACKER][DELAYED METRIC] " + tenantId + ".delayed.metric1" + "," +
+                                                            tenantId + ".delayed.metric2 have collectionTime 2016-01-01 00:00:00 which is delayed"));
+    }
+
+    @Test
+    public void testDoesNotTrackDelayedAggregatedMetricsTenant() {
+        // disable tracking delayed metrics and track
+        tracker.resetIsTrackingDelayedMetrics();
+        tracker.trackDelayedAggregatedMetricsTenant(tenantId, delayedMetrics);
+
+        // verify
+        verify(loggerMock, atLeastOnce()).info("[TRACKER] Tracking delayed metrics stopped");
+        verify(loggerMock, never()).info("[TRACKER][DELAYED METRIC] Tenant sending delayed metrics " + tenantId);
+        verify(loggerMock, never()).info(contains("[TRACKER][DELAYED METRIC] " + tenantId + ".delayed.metric1" + "," +
+                tenantId + ".delayed.metric2 have collectionTime 2016-01-01 00:00:00 which is delayed"));
+    }
 }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/tracker/TrackerTest.java
@@ -387,7 +387,7 @@ public class TrackerTest {
     public void testTrackDelayedMetricsTenant() {
         // enable tracking delayed metrics and track
         tracker.setIsTrackingDelayedMetrics();
-        tracker.trackDelayedAggregatedMetricsTenant(tenantId, delayedMetrics);
+        tracker.trackDelayedMetricsTenant(tenantId, delayedMetrics);
 
         // verify
         verify(loggerMock, atLeastOnce()).info("[TRACKER] Tracking delayed metrics started");
@@ -400,7 +400,7 @@ public class TrackerTest {
     public void testDoesNotTrackDelayedMetricsTenant() {
         // disable tracking delayed metrics and track
         tracker.resetIsTrackingDelayedMetrics();
-        tracker.trackDelayedAggregatedMetricsTenant(tenantId, delayedMetrics);
+        tracker.trackDelayedMetricsTenant(tenantId, delayedMetrics);
 
         // verify
         verify(loggerMock, atLeastOnce()).info("[TRACKER] Tracking delayed metrics stopped");
@@ -433,7 +433,7 @@ public class TrackerTest {
     public void testDoesNotTrackDelayedAggregatedMetricsTenant() {
         // disable tracking delayed metrics and track
         tracker.resetIsTrackingDelayedMetrics();
-        tracker.trackDelayedAggregatedMetricsTenant(tenantId, delayedMetrics);
+        tracker.trackDelayedMetricsTenant(tenantId, delayedMetrics);
 
         // verify
         verify(loggerMock, atLeastOnce()).info("[TRACKER] Tracking delayed metrics stopped");

--- a/blueflood-http/src/test/resources/sample_single_aggregated_payload.json
+++ b/blueflood-http/src/test/resources/sample_single_aggregated_payload.json
@@ -1,0 +1,10 @@
+{
+    "tenantId":"333333",
+    "timestamp":"%TIMESTAMP%",
+    "gauges":[
+        {
+            "name":"G200ms%POSTFIX%",
+            "value":145
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds the ability to track/log delayed metrics when they are sent to /ingest/aggregated and /ingest/aggregated/multi API. The same functionality exists for /ingest and /ingest/multi.
