### PR TITLE
Json Validation and Mapping - part 1

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -310,6 +310,24 @@
       <version>${jodatime.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>5.2.4.Final</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.el</groupId>
+      <artifactId>javax.el-api</artifactId>
+      <version>2.2.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.web</groupId>
+      <artifactId>javax.el</artifactId>
+      <version>2.2.4</version>
+    </dependency>
+
     <!-- testing dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/constraints/EpochRange.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/constraints/EpochRange.java
@@ -12,6 +12,16 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+
+/**
+ *
+ * The annotated element has to be in the appropriate range relative to the current time.
+ * Applicable for values of type long which represent time in epoch. The range of the
+ * element is defined as below.
+ *
+ * (currentTime - maxPast) <= element <= (currentTime + maxFuture)
+ *
+ */
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
 @Retention(RUNTIME)
 @Documented

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/constraints/EpochRange.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/constraints/EpochRange.java
@@ -1,0 +1,50 @@
+package com.rackspacecloud.blueflood.inputs.constraints;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.Min;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = { EpochRangeValidator.class })
+@ReportAsSingleViolation
+public @interface EpochRange {
+
+    String message() default "{com.rackspacecloud.blueflood.inputs.constraints.EpochRange.message}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+    /**
+     * @return the element cannot be older than (current time -  maxPast) milli seconds in the past
+     */
+    EpochRangeLimits maxPast();
+
+    /**
+     * @return the element cannot be earlier tha (current time +  maxFuture) milli seconds in the future
+     */
+    EpochRangeLimits maxFuture();
+
+    /**
+     * Defines several {@link Min} annotations on the same element.
+     *
+     * @see Min
+     */
+    @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+    @Retention(RUNTIME)
+    @Documented
+    @interface List {
+
+        EpochRange[] value();
+    }
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/constraints/EpochRangeLimits.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/constraints/EpochRangeLimits.java
@@ -1,0 +1,25 @@
+package com.rackspacecloud.blueflood.inputs.constraints;
+
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+
+/**
+ * Constants to set limits for allowed epoch ranges.
+ */
+public enum EpochRangeLimits {
+
+    BEFORE_CURRENT_TIME_MS(Configuration.getInstance().getLongProperty(CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS)),
+    AFTER_CURRENT_TIME_MS(Configuration.getInstance().getLongProperty(CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS));
+
+    private long value;
+
+    EpochRangeLimits(long value) {
+        this.value = value;
+    }
+
+    public long getValue() {
+        return value;
+    }
+}
+
+

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/constraints/EpochRangeValidator.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/constraints/EpochRangeValidator.java
@@ -1,0 +1,37 @@
+package com.rackspacecloud.blueflood.inputs.constraints;
+
+import com.rackspacecloud.blueflood.utils.Clock;
+import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EpochRangeValidator implements ConstraintValidator<EpochRange, Long> {
+
+    private final Clock clock = new DefaultClockImpl();
+
+    private long maxPast;
+    private long maxFuture;
+
+    @Override
+    public void initialize(EpochRange constraintAnnotation) {
+        this.maxPast = constraintAnnotation.maxPast().getValue();
+        this.maxFuture = constraintAnnotation.maxFuture().getValue();
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+
+        long currentTime = clock.now().getMillis();
+
+        if ( value < currentTime - maxPast ) {
+            // collectionTime is too far in the past
+            return false;
+        } else if ( value > currentTime + maxFuture ) {
+            // collectionTime is too far in the future
+            return false;
+        }
+        
+        return true;
+    }
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricScoped.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricScoped.java
@@ -15,27 +15,14 @@
  */
 package com.rackspacecloud.blueflood.inputs.formats;
 
-import org.apache.commons.lang.StringUtils;
-
-import java.util.List;
+import org.hibernate.validator.constraints.NotEmpty;
 
 public class JSONMetricScoped extends JSONMetric {
+
+    @NotEmpty
     private String tenantId;
 
     public String getTenantId() { return tenantId; }
 
     public void setTenantId(String tenantId) { this.tenantId = tenantId; }
-
-    @Override
-    public List<String> getValidationErrors() {
-
-        List<String> errors = super.getValidationErrors();
-
-        // validate tenantid
-        if (StringUtils.isBlank(tenantId)) {
-            errors.add ( "'" + getMetricName() + "': No tenantId is provided for the metric." );
-        }
-
-        return errors;
-    }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/ErrorResponse.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/ErrorResponse.java
@@ -1,0 +1,91 @@
+package com.rackspacecloud.blueflood.outputs.formats;
+
+import java.util.List;
+
+public class ErrorResponse {
+
+    private List<ErrorData> errors;
+
+    public ErrorResponse() {
+    }
+
+    public ErrorResponse(List<ErrorData> errors) {
+        this.errors = errors;
+    }
+
+    public List<ErrorData> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<ErrorData> errors) {
+        this.errors = errors;
+    }
+
+    @Override
+    public String toString() {
+        return "ErrorResponse{" +
+                "errors=" + errors +
+                '}';
+    }
+
+    public static class ErrorData {
+
+        private String tenantId;
+        private String metricName;
+        private String source;
+        private String message;
+
+        public ErrorData() {
+        }
+
+        public ErrorData(String tenantId, String metricName, String source, String message) {
+            this.tenantId = tenantId == null ? "" : tenantId;
+            this.metricName = metricName == null ? "" : metricName;
+            this.source = source;
+            this.message = message;
+        }
+
+        public String getTenantId() {
+            return tenantId;
+        }
+
+        public String getMetricName() {
+            return metricName;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setTenantId(String tenantId) {
+            this.tenantId = tenantId;
+        }
+
+        public void setMetricName(String metricName) {
+            this.metricName = metricName;
+        }
+
+        public void setSource(String source) {
+            this.source = source;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public String toString() {
+            return "ErrorData{" +
+                    "tenantId='" + tenantId + '\'' +
+                    ", metricName='" + metricName + '\'' +
+                    ", source='" + source + '\'' +
+                    ", message='" + message + '\'' +
+                    '}';
+        }
+    }
+
+}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -148,7 +148,7 @@ public enum CoreConfig implements ConfigDefaults {
     METADATA_CACHE_PERSISTENCE_PERIOD_MINS("10"),
     META_CACHE_RETENTION_IN_MINUTES("10"),
     
-    // how long we typically wait to schedule a rollup.
+    // how long we typicklly wait to schedule a rollup.
     ROLLUP_DELAY_MILLIS("300000"),
     SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS("300000"),
     LONG_DELAY_METRICS_ROLLUP_WAIT_MILLIS("300000"),

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -148,7 +148,7 @@ public enum CoreConfig implements ConfigDefaults {
     METADATA_CACHE_PERSISTENCE_PERIOD_MINS("10"),
     META_CACHE_RETENTION_IN_MINUTES("10"),
     
-    // how long we typicklly wait to schedule a rollup.
+    // how long we typically wait to schedule a rollup.
     ROLLUP_DELAY_MILLIS("300000"),
     SHORT_DELAY_METRICS_ROLLUP_DELAY_MILLIS("300000"),
     LONG_DELAY_METRICS_ROLLUP_WAIT_MILLIS("300000"),

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/constraints/EpochRangeValidatorTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/constraints/EpochRangeValidatorTest.java
@@ -1,0 +1,64 @@
+package com.rackspacecloud.blueflood.inputs.constraints;
+
+import com.rackspacecloud.blueflood.inputs.formats.JSONMetric;
+import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class EpochRangeValidatorTest {
+
+    private Validator validator;
+    private JSONMetric metric = new JSONMetric();
+
+    @Before
+    public void setup() {
+        metric.setMetricName("a.b.c.d");
+        metric.setTtlInSeconds(1);
+        metric.setMetricValue(1);
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void testCollectionTimeValid() {
+        long currentTime = new DefaultClockImpl().now().getMillis();
+
+        metric.setCollectionTime(currentTime);
+
+        Set<ConstraintViolation<JSONMetric>> constraintViolations = validator.validate(metric);
+        assertEquals(0, constraintViolations.size());
+    }
+
+    @Test
+    public void testCollectionTimeInPast() {
+        long currentTime = new DefaultClockImpl().now().getMillis();
+        long collectionTimeInPast = currentTime - EpochRangeLimits.BEFORE_CURRENT_TIME_MS.getValue() - 1000;
+
+        metric.setCollectionTime(collectionTimeInPast);
+
+        Set<ConstraintViolation<JSONMetric>> constraintViolations = validator.validate(metric);
+        assertEquals(1, constraintViolations.size());
+        assertEquals("collectionTime", constraintViolations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    public void testCollectionTimeInFuture() {
+        long currentTime = new DefaultClockImpl().now().getMillis();
+        long collectionTimeInFuture = currentTime + EpochRangeLimits.AFTER_CURRENT_TIME_MS.getValue() + 1000;
+
+        metric.setCollectionTime(collectionTimeInFuture);
+
+        Set<ConstraintViolation<JSONMetric>> constraintViolations = validator.validate(metric);
+        assertEquals(1, constraintViolations.size());
+        assertEquals("collectionTime", constraintViolations.iterator().next().getPropertyPath().toString());
+    }
+}

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandler.java
@@ -19,7 +19,6 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import com.rackspacecloud.blueflood.http.DefaultHandler;
 import com.rackspacecloud.blueflood.http.HttpRequestHandler;
@@ -36,6 +35,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandlerTest.java
@@ -1,0 +1,341 @@
+package com.rackspacecloud.blueflood.inputs.handlers;
+
+import com.rackspacecloud.blueflood.http.HttpRequestWithDecodedQueryParams;
+import com.rackspacecloud.blueflood.inputs.formats.JSONMetric;
+import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainer;
+import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
+import com.rackspacecloud.blueflood.utils.TimeValue;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.*;
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.elasticsearch.common.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mortbay.util.ajax.JSON;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class HttpMetricsIngestionHandlerTest {
+
+    private HttpMetricsIngestionHandler handler;
+    private HttpMetricsIngestionServer.Processor processor;
+
+    private ChannelHandlerContext context;
+    private Channel channel;
+    private ChannelFuture channelFuture;
+
+    private static final String TENANT = "tenant";
+
+    @Before
+    public void setup() {
+        processor = mock(HttpMetricsIngestionServer.Processor.class);
+        handler = new HttpMetricsIngestionHandler(processor, new TimeValue(5, TimeUnit.SECONDS));
+
+        channel = mock(Channel.class);
+        context = mock(ChannelHandlerContext.class);
+        channelFuture = mock(ChannelFuture.class);
+        when(context.channel()).thenReturn(channel);
+        when(channel.write(anyString())).thenReturn(channelFuture);
+    }
+
+    @Test
+    public void testEmptyRequest() throws IOException {
+        String requestBody = "";
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "Cannot parse content", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+
+    @Test
+    public void testEmptyJsonRequest() throws IOException {
+        String requestBody = "{}"; //causes JsonMappingException
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "Cannot parse content", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void testInvalidJsonRequest() throws IOException {
+        String requestBody = "{\"xxxx\": yyyy}"; //causes JsonMappingException
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "Cannot parse content", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void testEmptyJsonArrayRequest() throws IOException {
+        String requestBody = "[]"; //causes JsonMappingException
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "No valid metrics",
+                errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void testEmptyMetricRequest() throws IOException {
+        String requestBody = "[{}]"; //causes JsonMappingException
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 3, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void testSingleMetricInvalidMetricName() throws IOException {
+        String metricName = "";
+        String singleMetric = createRequestBody(metricName, new DefaultClockImpl().now().getMillis(),
+                24 * 60 * 60, 1); //empty metric name
+
+        String requestBody = "[" + singleMetric + "]";
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid metric name", metricName, errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+        assertEquals("Invalid error source", "metricName", errorResponse.getErrors().get(0).getSource());
+        assertEquals("Invalid error message", "may not be empty", errorResponse.getErrors().get(0).getMessage());
+    }
+
+
+    @Test
+    public void testSingleMetricCollectionTimeInPast() throws IOException {
+        long collectionTimeInPast = new DefaultClockImpl().now().getMillis() - 1000
+                - Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
+        String metricName = "a.b.c";
+        String singleMetric = createRequestBody(metricName, collectionTimeInPast, 24 * 60 * 60, 1); //collection in past
+
+        String requestBody = "[" + singleMetric + "]";
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid metric name", metricName, errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+        assertEquals("Invalid error source", "collectionTime", errorResponse.getErrors().get(0).getSource());
+        assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
+                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+    }
+
+    @Test
+    public void testSingleMetricCollectionTimeInFuture() throws IOException {
+        long collectionTimeInFuture = new DefaultClockImpl().now().getMillis() + 1000
+                + Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
+        String metricName = "a.b.c";
+        String singleMetric = createRequestBody(metricName, collectionTimeInFuture, 24 * 60 * 60, 1); //collection in future
+
+        String requestBody = "[" + singleMetric + "]";
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid metric name", metricName, errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+        assertEquals("Invalid error source", "collectionTime", errorResponse.getErrors().get(0).getSource());
+        assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
+                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+    }
+
+    @Test
+    public void testSingleMetricInvalidTTL() throws IOException {
+        String metricName = "a.b.c";
+        String singleMetric = createRequestBody(metricName, new DefaultClockImpl().now().getMillis(), 0, 1); //ttl of 0
+        String requestBody = "[" + singleMetric + "]";
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid metric name", metricName, errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+        assertEquals("Invalid error source", "ttlInSeconds", errorResponse.getErrors().get(0).getSource());
+        assertEquals("Invalid error message", "must be between 1 and 2147483647", errorResponse.getErrors().get(0).getMessage());
+    }
+
+    @Test
+    public void testSingleMetricInvalidMetricValue() throws IOException {
+        String metricName = "a.b.c";
+        String singleMetric = createRequestBody(metricName, new DefaultClockImpl().now().getMillis(),
+                24 * 60 * 60, null); //empty metric value
+
+        String requestBody = "[" + singleMetric + "]";
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+        System.out.println(errorResponse);
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertNull("Invalid metric name", errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+        assertNull("Invalid error source", errorResponse.getErrors().get(0).getSource());
+        assertEquals("Invalid error message", "No valid metrics", errorResponse.getErrors().get(0).getMessage());
+    }
+
+    @Test
+    public void testMultiMetricsInvalidRequest() throws IOException {
+        String metricName1 = "a.b.c.1";
+        String metricName2 = "a.b.c.2";
+        long collectionTimeInPast = new DefaultClockImpl().now().getMillis() - 1000
+                - Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
+
+        String singleMetric1 = createRequestBody(metricName1, new DefaultClockImpl().now().getMillis(),
+                -1, 1); //invalid ttl value
+        String singleMetric2 = createRequestBody(metricName2, collectionTimeInPast, 24 * 60 * 60, 1); //collection in past
+
+        String requestBody = "[" + singleMetric1 + "," + singleMetric2 + "]";
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 2, errorResponse.getErrors().size());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid tenant", metricName1, errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid error source", "ttlInSeconds", errorResponse.getErrors().get(0).getSource());
+        assertEquals("Invalid error message", "must be between 1 and 2147483647", errorResponse.getErrors().get(0).getMessage());
+
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(1).getTenantId());
+        assertEquals("Invalid tenant", metricName2, errorResponse.getErrors().get(1).getMetricName());
+        assertEquals("Invalid error source", "collectionTime", errorResponse.getErrors().get(1).getSource());
+        assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
+                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(1).getMessage());
+
+    }
+
+    private String createRequestBody(String metricName, long collectionTime, int ttl, Object metricValue) throws IOException {
+        JSONMetric metric = new JSONMetric();
+        if (!StringUtils.isEmpty(metricName))
+            metric.setMetricName(metricName);
+        if (collectionTime > 0)
+            metric.setCollectionTime(collectionTime);
+        if (ttl > 0)
+            metric.setTtlInSeconds(ttl);
+        if (metricValue != null)
+            metric.setMetricValue(metricValue);
+
+        return new ObjectMapper().writeValueAsString(metric);
+    }
+
+    private FullHttpRequest createHttpRequest(HttpMethod method, String uri, String requestBody) {
+        DefaultFullHttpRequest rawRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, "/v2.0/" + TENANT + "/ingest/" + uri);
+        rawRequest.headers().set("tenantId", TENANT);
+        if (!requestBody.equals(""))
+            rawRequest.content().writeBytes(Unpooled.copiedBuffer(requestBody.getBytes()));
+        return HttpRequestWithDecodedQueryParams.create(rawRequest);
+    }
+
+
+    private ErrorResponse getErrorResponse(String error) throws IOException {
+        return new ObjectMapper().readValue(error, ErrorResponse.class);
+    }
+
+    public JSONMetricsContainer getContainer(String tenantId, String jsonBody) throws IOException {
+        HttpMetricsIngestionHandler handler = new HttpMetricsIngestionHandler(null, new TimeValue(5, TimeUnit.SECONDS));
+        return handler.createContainer(jsonBody, tenantId);
+    }
+}

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandlerTest.java
@@ -1,0 +1,147 @@
+package com.rackspacecloud.blueflood.inputs.handlers;
+
+import com.rackspacecloud.blueflood.http.HttpRequestWithDecodedQueryParams;
+import com.rackspacecloud.blueflood.inputs.formats.JSONMetric;
+import com.rackspacecloud.blueflood.inputs.formats.JSONMetricScoped;
+import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
+import com.rackspacecloud.blueflood.utils.TimeValue;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.*;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.elasticsearch.common.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class HttpMultitenantMetricsIngestionHandlerTest {
+
+    private HttpMultitenantMetricsIngestionHandler handler;
+    private HttpMetricsIngestionServer.Processor processor;
+
+    private ChannelHandlerContext context;
+    private Channel channel;
+    private ChannelFuture channelFuture;
+
+    private static final String TENANT = "tenant";
+
+    @Before
+    public void setup() {
+        processor = mock(HttpMetricsIngestionServer.Processor.class);
+        handler = new HttpMultitenantMetricsIngestionHandler(processor, new TimeValue(5, TimeUnit.SECONDS));
+
+        channel = mock(Channel.class);
+        context = mock(ChannelHandlerContext.class);
+        channelFuture = mock(ChannelFuture.class);
+        when(context.channel()).thenReturn(channel);
+        when(channel.write(anyString())).thenReturn(channelFuture);
+    }
+
+    @Test
+    public void testSingleMetricEmptyTenantId() throws IOException {
+        String metricName = "a.b.c";
+        String singleMetric = createRequestBody("", metricName, new DefaultClockImpl().now().getMillis(),
+                24 * 60 * 60, 1); //empty metric name
+
+        String requestBody = "[" + singleMetric + "]";
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", "", errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid metric name", metricName, errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+        assertEquals("Invalid error source", "tenantId", errorResponse.getErrors().get(0).getSource());
+        assertEquals("Invalid error message", "may not be empty", errorResponse.getErrors().get(0).getMessage());
+    }
+
+
+    @Test
+    public void testMultiMetricsInvalidRequest() throws IOException {
+        final String TENANT1 = "tenant1";
+        final String TENANT2 = "tenant2";
+
+        final String metricName1 = "a.b.c.1";
+        final String metricName2 = "a.b.c.2";
+        long collectionTimeInPast = new DefaultClockImpl().now().getMillis() - 1000
+                - Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
+
+        String singleMetric1 = createRequestBody(TENANT1, metricName1, new DefaultClockImpl().now().getMillis(),
+                -1, 1); //invalid ttl
+        String singleMetric2 = createRequestBody(TENANT2, metricName2, collectionTimeInPast, 24 * 60 * 60, 1); //collection in past
+
+        String requestBody = "[" + singleMetric1 + "," + singleMetric2 + "]";
+        FullHttpRequest request = createHttpRequest(HttpMethod.POST, "", requestBody);
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 2, errorResponse.getErrors().size());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+
+        assertEquals("Invalid tenant", TENANT1, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid tenant", metricName1, errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid error source", "ttlInSeconds", errorResponse.getErrors().get(0).getSource());
+        assertEquals("Invalid error message", "must be between 1 and 2147483647", errorResponse.getErrors().get(0).getMessage());
+
+        assertEquals("Invalid tenant", TENANT2, errorResponse.getErrors().get(1).getTenantId());
+        assertEquals("Invalid tenant", metricName2, errorResponse.getErrors().get(1).getMetricName());
+        assertEquals("Invalid error source", "collectionTime", errorResponse.getErrors().get(1).getSource());
+        assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
+                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(1).getMessage());
+
+    }
+
+    private String createRequestBody(String tenantId, String metricName, long collectionTime, int ttl, Object metricValue) throws IOException {
+        JSONMetricScoped metric = new JSONMetricScoped();
+        if (!StringUtils.isEmpty(tenantId))
+            metric.setTenantId(tenantId);
+        if (!StringUtils.isEmpty(metricName))
+            metric.setMetricName(metricName);
+        if (collectionTime > 0)
+            metric.setCollectionTime(collectionTime);
+        if (ttl > 0)
+            metric.setTtlInSeconds(ttl);
+        if (metricValue != null)
+            metric.setMetricValue(metricValue);
+
+        return new ObjectMapper().writeValueAsString(metric);
+    }
+
+    private FullHttpRequest createHttpRequest(HttpMethod method, String uri, String requestBody) {
+        DefaultFullHttpRequest rawRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, "/v2.0/" + TENANT + "/ingest/" + uri);
+        rawRequest.headers().set("tenantId", TENANT);
+        if (!requestBody.equals(""))
+            rawRequest.content().writeBytes(Unpooled.copiedBuffer(requestBody.getBytes()));
+        return HttpRequestWithDecodedQueryParams.create(rawRequest);
+    }
+
+
+    private ErrorResponse getErrorResponse(String error) throws IOException {
+        System.out.println(error);
+        return new ObjectMapper().readValue(error, ErrorResponse.class);
+    }
+}


### PR DESCRIPTION
 - Add java bean validation to some /ingest endpoints using hibernate validator
 - Custom constraint to handle validation of collectionTime
 - Cleaned up JsonMetricsContainer; removed validations out of the class;
 - Made all error responses in consistent format

**Previously:**

curl -i -XPOST 'http://localhost:19000/v2.0/887463/ingest' -d '[{}]'
HTTP/1.1 400 Bad Request
Content-Length: 126
Connection: keep-alive
The following errors have been encountered:
'null': 'collectionTime' '0' is more than '259200000' milliseconds into the past.

**After the change: (status code is 400)**
curl -XPOST 'http://localhost:19000/v2.0/887463/ingest' -d '[{}]' | python -m json.tool
```json
{
    "errors": [
        {
            "message": "may not be empty",
            "metricName": "",
            "source": "metricName",
            "tenantId": "887463"
        },
        {
            "message": "Out of bounds. Cannot be more than 259200000 milliseconds into the past. Cannot be more than 259200000 milliseconds into the future",
            "metricName": "",
            "source": "collectionTime",
            "tenantId": "887463"
        },
        {
            "message": "must be between 1 and 2147483647",
            "metricName": "",
            "source": "ttlInSeconds",
            "tenantId": "887463"
        }
    ]
}