### PR TITLE
add Instrumentation Full-Resolution-Preaggregated-Metrics-Written

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
@@ -43,6 +43,7 @@ public class Instrumentation implements InstrumentationMBean {
     private static final Meter scanAllColumnFamiliesMeter;
     private static final Meter allPoolsExhaustedException;
     private static final Meter fullResMetricWritten;
+    private static final Meter fullResPreaggregatedMetricWritten;
     private static final Meter metricsWithShortDelayReceived;
     private static final Meter metricsWithLongDelayReceived;
     private static final Meter enumMetricWritten;
@@ -57,6 +58,7 @@ public class Instrumentation implements InstrumentationMBean {
         scanAllColumnFamiliesMeter = Metrics.meter(kls, "Scan all ColumnFamilies");
         allPoolsExhaustedException = Metrics.meter(kls, "All Pools Exhausted");
         fullResMetricWritten = Metrics.meter(kls, "Full Resolution Metrics Written");
+        fullResPreaggregatedMetricWritten = Metrics.meter(kls, "Full Resolution Preaggregated Metrics Written");
         enumMetricWritten = Metrics.meter( kls, "Enum Metrics Written" );
         metricsWithShortDelayReceived = Metrics.meter(kls, "Metrics with short delay received");
         metricsWithLongDelayReceived = Metrics.meter(kls, "Metrics with long delay received");
@@ -168,6 +170,10 @@ public class Instrumentation implements InstrumentationMBean {
 
     public static void markFullResMetricWritten() {
         fullResMetricWritten.mark();
+    }
+
+    public static void markFullResPreaggregatedMetricWritten() {
+        fullResPreaggregatedMetricWritten.mark();
     }
 
     public static void markEnumMetricWritten() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxWriter.java
@@ -277,7 +277,9 @@ public class AstyanaxWriter extends AstyanaxIO {
                                 metric.getMetricValue(),
                                 (AbstractSerializer) (Serializers.serializerFor(metric.getMetricValue().getClass())),
                                 metric.getTtlInSeconds());
-                        Instrumentation.markFullResPreaggregatedMetricWritten();
+                        if (cf.getName().equals(CassandraModel.CF_METRICS_PREAGGREGATED_FULL_NAME)) {
+                            Instrumentation.markFullResPreaggregatedMetricWritten();
+                        }
                     }
                 }
                 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxWriter.java
@@ -277,6 +277,7 @@ public class AstyanaxWriter extends AstyanaxIO {
                                 metric.getMetricValue(),
                                 (AbstractSerializer) (Serializers.serializerFor(metric.getMetricValue().getClass())),
                                 metric.getTtlInSeconds());
+                        Instrumentation.markFullResPreaggregatedMetricWritten();
                     }
                 }
                 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
@@ -128,7 +128,9 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
             for (ResultSetFuture future : futureLocatorMap.keySet()) {
                 try {
                     future.getUninterruptibly().all();
-                    Instrumentation.markFullResPreaggregatedMetricWritten();
+                    if (granularity == Granularity.FULL) {
+                        Instrumentation.markFullResPreaggregatedMetricWritten();
+                    }
                 } catch (Exception ex) {
                     Instrumentation.markWriteError();
                     LOG.error(String.format("error writing preaggregated metric for locator %s, granularity %s",

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DPreaggregatedMetricsRW.java
@@ -128,6 +128,7 @@ public class DPreaggregatedMetricsRW extends DAbstractMetricsRW implements Preag
             for (ResultSetFuture future : futureLocatorMap.keySet()) {
                 try {
                     future.getUninterruptibly().all();
+                    Instrumentation.markFullResPreaggregatedMetricWritten();
                 } catch (Exception ex) {
                     Instrumentation.markWriteError();
                     LOG.error(String.format("error writing preaggregated metric for locator %s, granularity %s",

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayloadTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayloadTest.java
@@ -18,7 +18,7 @@ import static junit.framework.Assert.assertTrue;
  */
 public class AggregatedPayloadTest {
 
-    private static final long TIME_DIFF_MS = 2000;
+    private static final long TIME_DIFF_MS = 30000;
     private static final String POSTFIX = ".post";
 
     private AggregatedPayload payload;

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerTest.java
@@ -21,6 +21,7 @@ import com.rackspacecloud.blueflood.types.Event;
 import io.netty.channel.*;
 import io.netty.handler.codec.http.*;
 import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.*;
@@ -34,7 +35,12 @@ public class HttpEventsQueryHandlerTest extends BaseHandlerTest {
     private ChannelHandlerContext context;
     private Channel channel;
     private ChannelFuture channelFuture;
+    private DateTime nowDateTime;
 
+    @Before
+    public void setup() {
+        nowDateTime = new DateTime().withSecondOfMinute(0).withMillisOfSecond(0);
+    }
 
     public HttpEventsQueryHandlerTest() {
         searchIO = mock(EventsIO.class);
@@ -90,6 +96,6 @@ public class HttpEventsQueryHandlerTest extends BaseHandlerTest {
     }
 
     private String nowTimestamp() {
-        return Long.toString(convertDateTimeToTimestamp(new DateTime().withSecondOfMinute(0).withMillisOfSecond(0)));
+        return Long.toString(convertDateTimeToTimestamp(nowDateTime));
     }
 }


### PR DESCRIPTION
# What

Add codahale instrumentation meter to mark Preaggregated Metrics ingestion

# Why

So we can track and view preaggregated metrics ingestion rate, for monitoring system health and status.

# How

- Add meter metric fullResPreaggregatedMetricWritten to the Instrumentation class, with method call markFullResPreaggregatedMetricWritten().

- Call markFullResPreaggregatedMetricWritten() from AstyanaxWriter when writing preaggregated metrics via AstyanaxDriver, and from DPreaggregatedMetricsRW when writing via Datastax driver.

# Test

Create dashboard panel in graphite00 using datasource:  graphite, and target   "targets": [
    {
      "target": "aliasByNode(maximumAbove(nonNegativeDerivative(*.*.blueflood.ingest.com.rackspacecloud.blueflood.io.Instrumentation.Full-Resolution-Preaggregated-Metrics-Written.count),-1),0)"
    }
  ]
