### PR TITLE
Check if in rollup mode before starting Zookeeper

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/BluefloodServiceStarter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/BluefloodServiceStarter.java
@@ -306,9 +306,10 @@ public class BluefloodServiceStarter {
         final Collection<Integer> shards = Collections.unmodifiableCollection(
                 Util.parseShards(config.getStringProperty(CoreConfig.SHARDS)));
         final String zkCluster = config.getStringProperty(CoreConfig.ZOOKEEPER_CLUSTER);
-        final ScheduleContext rollupContext = "NONE".equals(zkCluster) ?
-                new ScheduleContext(System.currentTimeMillis(), shards) :
-                new ScheduleContext(System.currentTimeMillis(), shards, zkCluster);
+        final boolean rollupMode = config.getBooleanProperty(CoreConfig.ROLLUP_MODE);
+        final ScheduleContext rollupContext = !"NONE".equals(zkCluster) && rollupMode ?
+                new ScheduleContext(System.currentTimeMillis(), shards, zkCluster) :
+                new ScheduleContext(System.currentTimeMillis(), shards);
 
         log.info("Starting blueflood services");
         startShardStateServices(rollupContext);


### PR DESCRIPTION
Simple sanity check so a node doesn't try to grab ZK locks if it's not actually rolling up.