### PR TITLE
upgrade to datastax driver 3.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>com.datastax.cassandra</groupId>
         <artifactId>cassandra-driver-core</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.3</version>
       </dependency>
       <dependency>
         <groupId>pl.pragmatists</groupId>


### PR DESCRIPTION
Under stress, the datastax driver started throwing the following exception. After upgrading the datastax driver 3.0.3, we no longer see this exception:

```
2016-09-13 18:55:40,675 836131 [Metric Batch Writing-96] ERROR com.rackspacecloud.blueflood.io.datastax.DBasicMetricsRW  - error writing metric for locator -5075.int.perf01.abcdef
g.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.9
com.datastax.driver.core.exceptions.DriverInternalError: Unexpected error while processing response from /10.223.192.184:9042
        at com.datastax.driver.core.exceptions.DriverInternalError.copy(DriverInternalError.java:42)
        at com.datastax.driver.core.exceptions.DriverInternalError.copy(DriverInternalError.java:24)
        at com.datastax.driver.core.DriverThrowables.propagateCause(DriverThrowables.java:37)
        at com.datastax.driver.core.DefaultResultSetFuture.getUninterruptibly(DefaultResultSetFuture.java:245)
        at com.rackspacecloud.blueflood.io.datastax.DBasicMetricsRW.insertMetrics(DBasicMetricsRW.java:99)
        at com.rackspacecloud.blueflood.io.MetricsRWDelegator.insertMetrics(MetricsRWDelegator.java:148)
        at com.rackspacecloud.blueflood.inputs.processors.BatchWriter$1.call(BatchWriter.java:96)
        at com.rackspacecloud.blueflood.inputs.processors.BatchWriter$1.call(BatchWriter.java:87)
        at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:108)
        at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:41)
        at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:77)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: com.datastax.driver.core.exceptions.DriverInternalError: Unexpected error while processing response from /10.223.192.184:9042
        at com.datastax.driver.core.DefaultResultSetFuture.onSet(DefaultResultSetFuture.java:189)
        at com.datastax.driver.core.RequestHandler.setFinalResult(RequestHandler.java:184)
        at com.datastax.driver.core.RequestHandler.access$2500(RequestHandler.java:43)
        at com.datastax.driver.core.RequestHandler$SpeculativeExecution.setFinalResult(RequestHandler.java:798)
        at com.datastax.driver.core.RequestHandler$SpeculativeExecution.onSet(RequestHandler.java:473)
        at com.datastax.driver.core.Connection$Dispatcher.channelRead0(Connection.java:1005)
        at com.datastax.driver.core.Connection$Dispatcher.channelRead0(Connection.java:928)
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:266)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:293)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:267)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1294)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:911)
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:883)
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:389)
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:305)
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:140)
        ... 1 more
Caused by: java.lang.NullPointerException
        at com.datastax.driver.core.ArrayBackedResultSet.fromMessage(ArrayBackedResultSet.java:82)
        at com.datastax.driver.core.DefaultResultSetFuture.onSet(DefaultResultSetFuture.java:174)
        ... 32 more
```