### PR TITLE
Json Validation and Mapping

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
@@ -45,7 +45,7 @@ public class AggregatedPayload {
 
     @EpochRange(maxPast = EpochRangeLimits.BEFORE_CURRENT_TIME_MS,
             maxFuture = EpochRangeLimits.AFTER_CURRENT_TIME_MS,
-            message = "Out of bounds. Cannot be more than ${maxPast.getValue()} milliseconds into the past. Cannot be more than ${maxPast.getValue()} milliseconds into the future")
+            message = "Out of bounds. Cannot be more than ${maxPast.getValue()} milliseconds into the past. Cannot be more than ${maxFuture.getValue()} milliseconds into the future")
     private long timestamp; // millis since epoch.
 
     // this field is optional

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetric.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetric.java
@@ -32,7 +32,7 @@ public class JSONMetric {
 
     @EpochRange(maxPast = EpochRangeLimits.BEFORE_CURRENT_TIME_MS,
                 maxFuture = EpochRangeLimits.AFTER_CURRENT_TIME_MS,
-                message = "Out of bounds. Cannot be more than ${maxPast.getValue()} milliseconds into the past. Cannot be more than ${maxPast.getValue()} milliseconds into the future")
+                message = "Out of bounds. Cannot be more than ${maxPast.getValue()} milliseconds into the past. Cannot be more than ${maxFuture.getValue()} milliseconds into the future")
     private long collectionTime;
 
     @Range(min=1, max=Integer.MAX_VALUE)

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Event.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/types/Event.java
@@ -16,12 +16,24 @@
 
 package com.rackspacecloud.blueflood.types;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.rackspacecloud.blueflood.inputs.constraints.EpochRange;
+import com.rackspacecloud.blueflood.inputs.constraints.EpochRangeLimits;
+import org.hibernate.validator.constraints.NotEmpty;
+
 import java.util.HashMap;
 import java.util.Map;
 
 public class Event {
+
+    @EpochRange(maxPast = EpochRangeLimits.BEFORE_CURRENT_TIME_MS,
+            maxFuture = EpochRangeLimits.AFTER_CURRENT_TIME_MS,
+            message = "Out of bounds. Cannot be more than ${maxPast.getValue()} milliseconds into the past. Cannot be more than ${maxFuture.getValue()} milliseconds into the future")
     private long when = 0;
+
+    @NotEmpty
     private String what = "";
+
     private String data = "";
     private String tags = "";
 
@@ -36,6 +48,15 @@ public class Event {
     public static final String untilParameterName = "until";
     public static final String fromParameterName = "from";
     public static final String tagsParameterName = FieldLabels.tags.name();
+
+    public Event() {
+    }
+
+    @VisibleForTesting
+    public Event(long when, String what) {
+        this.when = when;
+        this.what = what;
+    }
 
     public Map<String, Object> toMap() {
         return new HashMap<String, Object>() {

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpEnumIntegrationTest.java
@@ -95,7 +95,7 @@ public class HttpEnumIntegrationTest extends HttpIntegrationTestBase {
         assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
         assertEquals("Invalid error source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
     }
 
     @Test
@@ -117,7 +117,7 @@ public class HttpEnumIntegrationTest extends HttpIntegrationTestBase {
         assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
         assertEquals("Invalid error source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
     }
 
     private ErrorResponse getErrorResponse(HttpResponse response) throws IOException {

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
@@ -96,7 +96,7 @@ public class HttpHandlerIntegrationTest extends HttpIntegrationTestBase {
         for (int i = 0; i < 3; i++) {
             assertEquals("Invalid error source", "collectionTime", errorResponse.getErrors().get(i).getSource());
             assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                    " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                    " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
         }
 
     }
@@ -117,7 +117,7 @@ public class HttpHandlerIntegrationTest extends HttpIntegrationTestBase {
         for (int i = 0; i < 3; i++) {
             assertEquals("Invalid error source", "collectionTime", errorResponse.getErrors().get(i).getSource());
             assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                    " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                    " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
         }
     }
 
@@ -159,7 +159,7 @@ public class HttpHandlerIntegrationTest extends HttpIntegrationTestBase {
         assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
         assertEquals("Invalid error source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
     }
 
     @Test
@@ -175,7 +175,7 @@ public class HttpHandlerIntegrationTest extends HttpIntegrationTestBase {
         assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
         assertEquals("Invalid error source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
     }
 
     @Test
@@ -223,7 +223,7 @@ public class HttpHandlerIntegrationTest extends HttpIntegrationTestBase {
         assertEquals("Number of errors invalid", 3, errorResponse.getErrors().size());
         assertEquals("Invalid error source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
     }
 
 
@@ -246,7 +246,7 @@ public class HttpHandlerIntegrationTest extends HttpIntegrationTestBase {
         assertEquals("Number of errors invalid", 3, errorResponse.getErrors().size());
         assertEquals("Invalid error source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
     }
 
     @Test

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerIntegrationTest.java
@@ -19,21 +19,28 @@ package com.rackspacecloud.blueflood.outputs.handlers;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import com.rackspacecloud.blueflood.io.IOContainer;
 import com.rackspacecloud.blueflood.io.MetricsRW;
+import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Metric;
 import com.rackspacecloud.blueflood.utils.TimeValue;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import static junit.framework.Assert.assertEquals;
 
 /**
  * Integration Tests for GET .../metrics/search
@@ -100,16 +107,19 @@ public class HttpMetricsIndexHandlerIntegrationTest extends HttpIntegrationTestB
         HttpGet get = new HttpGet(getQuerySearchURI(tenantId));
         HttpResponse response = client.execute(get);
 
-        String responseString = EntityUtils.toString(response.getEntity());
-        Assert.assertEquals(400, response.getStatusLine().getStatusCode());
-        Assert.assertEquals("Invalid Query String", responseString);
-        assertResponseHeaderAllowOrigin(response);
+        ErrorResponse errorResponse = getErrorResponse(response);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "Invalid Query String", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", tenantId, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST.code(), response.getStatusLine().getStatusCode());
     }
 
     @Test
     public void testHttpMetricsIndexHandler_InvalidQueryParam() throws Exception {
         parameterMap = new HashMap<String, String>();
-        parameterMap.put("query","query ! with bad \\ characters ? <>");
+        parameterMap.put("query", "query ! with bad \\ characters ? <>");
         HttpGet get = new HttpGet(getQuerySearchURI(tenantId));
         HttpResponse response = client.execute(get);
 
@@ -117,4 +127,7 @@ public class HttpMetricsIndexHandlerIntegrationTest extends HttpIntegrationTestB
         assertResponseHeaderAllowOrigin(response);
     }
 
+    private ErrorResponse getErrorResponse(HttpResponse response) throws IOException {
+        return new ObjectMapper().readValue(response.getEntity().getContent(), ErrorResponse.class);
+    }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/QueryStringDecoderAndRouter.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/QueryStringDecoderAndRouter.java
@@ -53,7 +53,7 @@ public class QueryStringDecoderAndRouter extends SimpleChannelInboundHandler<Ful
         // for POST requests, check Content-Type header
         if ( request.getMethod() == HttpMethod.POST ) {
             if (!mediaTypeChecker.isContentTypeValid(request.headers())) {
-                DefaultHandler.sendResponse(ctx, request,
+                DefaultHandler.sendErrorResponse(ctx, request,
                         String.format("Unsupported media type for Content-Type: %s", request.headers().get(HttpHeaders.Names.CONTENT_TYPE)),
                         HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE
                 );
@@ -64,7 +64,7 @@ public class QueryStringDecoderAndRouter extends SimpleChannelInboundHandler<Ful
         // for GET or POST requests, check Accept header
         if ( request.getMethod() == HttpMethod.GET || request.getMethod() == HttpMethod.POST ) {
             if (!mediaTypeChecker.isAcceptValid(request.headers())) {
-                DefaultHandler.sendResponse(ctx, request,
+                DefaultHandler.sendErrorResponse(ctx, request,
                         String.format("Unsupported media type for Accept: %s", request.headers().get(HttpHeaders.Names.ACCEPT)),
                         HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE
                 );

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
@@ -94,15 +94,15 @@ public class HttpEventsIngestionHandler implements HttpRequestHandler {
             searchIO.insert(tenantId, Arrays.asList(event.toMap()));
             DefaultHandler.sendResponse(ctx, request, response, HttpResponseStatus.OK);
         } catch (JsonMappingException e) {
-            log.error(String.format("Exception %s", e.toString()));
+            log.debug(String.format("Exception %s", e.toString()));
             response = String.format("Invalid Data: %s", e.getMessage());
             DefaultHandler.sendErrorResponse(ctx, request, response, HttpResponseStatus.BAD_REQUEST);
         } catch (JsonParseException e){
-            log.error(String.format("Exception %s", e.toString()));
+            log.debug(String.format("Exception %s", e.toString()));
             response = String.format("Invalid Data: %s", e.getMessage());
             DefaultHandler.sendErrorResponse(ctx, request, response, HttpResponseStatus.BAD_REQUEST);
         } catch (InvalidDataException e) {
-            log.error(String.format("Exception %s", e.toString()));
+            log.debug(String.format("Exception %s", e.toString()));
             response = String.format("Invalid Data: %s", e.getMessage());
             DefaultHandler.sendErrorResponse(ctx, request, response, HttpResponseStatus.BAD_REQUEST);
         } catch (Exception e) {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
@@ -16,36 +16,42 @@
 
 package com.rackspacecloud.blueflood.inputs.handlers;
 
-import com.rackspacecloud.blueflood.exceptions.InvalidDataException;
-import com.rackspacecloud.blueflood.http.DefaultHandler;
 import com.codahale.metrics.Timer;
+import com.rackspacecloud.blueflood.http.DefaultHandler;
 import com.rackspacecloud.blueflood.http.HttpRequestHandler;
 import com.rackspacecloud.blueflood.io.EventsIO;
-import com.rackspacecloud.blueflood.service.Configuration;
-import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
 import com.rackspacecloud.blueflood.types.Event;
+import com.rackspacecloud.blueflood.utils.Metrics;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
-import com.rackspacecloud.blueflood.utils.Metrics;
 import org.codehaus.jackson.map.ObjectMapper;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.*;
-import io.netty.util.CharsetUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 public class HttpEventsIngestionHandler implements HttpRequestHandler {
-
-    private static final long pastDiff = Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
-    private static final long futureDiff = Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
 
     private static final Logger log = LoggerFactory.getLogger(HttpEventsIngestionHandler.class);
 
     private EventsIO searchIO;
     private final com.codahale.metrics.Timer httpEventsIngestTimer = Metrics.timer(HttpEventsIngestionHandler.class,
             "Handle HTTP request for ingesting events");
+
+    private static final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    protected static final Validator validator = factory.getValidator();
 
     public HttpEventsIngestionHandler(EventsIO searchIO) {
         this.searchIO = searchIO;
@@ -55,7 +61,6 @@ public class HttpEventsIngestionHandler implements HttpRequestHandler {
     public void handle(ChannelHandlerContext ctx, FullHttpRequest request) {
 
         final String tenantId = request.headers().get(Event.FieldLabels.tenantId.name());
-        HttpResponseStatus status = HttpResponseStatus.OK;
         String response = "";
         ObjectMapper objectMapper = new ObjectMapper();
         final Timer.Context httpEventsIngestTimerContext = httpEventsIngestTimer.time();
@@ -65,40 +70,34 @@ public class HttpEventsIngestionHandler implements HttpRequestHandler {
                     CharsetUtil.UTF_8);
             Event event = objectMapper.readValue(body, Event.class);
 
-            long timestamp = event.getWhen();
-            long current = System.currentTimeMillis();
+            Set<ConstraintViolation<Event>> constraintViolations = validator.validate(event);
 
-            if (event.getWhat().equals("")) {
-                throw new InvalidDataException(String.format( HttpMetricsIngestionHandler.ERROR_HEADER + System.lineSeparator() + "Event should contain at least '%s' field.", Event.FieldLabels.what.name()));
+            List<ErrorResponse.ErrorData> validationErrors = new ArrayList<ErrorResponse.ErrorData>();
+            for (ConstraintViolation<Event> constraintViolation : constraintViolations) {
+                validationErrors.add(new ErrorResponse.ErrorData(tenantId, "",
+                        constraintViolation.getPropertyPath().toString(), constraintViolation.getMessage()));
             }
 
-            if ( timestamp > current + futureDiff ) {
-                throw new InvalidDataException( HttpMetricsIngestionHandler.ERROR_HEADER + System.lineSeparator() + "'" + event.getWhat() + "': 'when' '" + timestamp + "' is more than '" + futureDiff + "' milliseconds into the future." );
-            }
-
-            if ( timestamp < current - pastDiff ) {
-                throw new InvalidDataException( HttpMetricsIngestionHandler.ERROR_HEADER + System.lineSeparator() + "'" + event.getWhat() + "': 'when' '" + timestamp + "' is more than '" + pastDiff + "' milliseconds into the past." );
+            if (!validationErrors.isEmpty()) {
+                DefaultHandler.sendErrorResponse(ctx, request, validationErrors, HttpResponseStatus.BAD_REQUEST);
+                return;
             }
 
             searchIO.insert(tenantId, Arrays.asList(event.toMap()));
+            DefaultHandler.sendResponse(ctx, request, response, HttpResponseStatus.OK);
         } catch (JsonMappingException e) {
             log.error(String.format("Exception %s", e.toString()));
             response = String.format("Invalid Data: %s", e.getMessage());
-            status = HttpResponseStatus.BAD_REQUEST;
+            DefaultHandler.sendErrorResponse(ctx, request, response, HttpResponseStatus.BAD_REQUEST);
         } catch (JsonParseException e){
             log.error(String.format("Exception %s", e.toString()));
             response = String.format("Invalid Data: %s", e.getMessage());
-            status = HttpResponseStatus.BAD_REQUEST;
-        } catch (InvalidDataException e) {
-            log.error(String.format("InvalidDataException %s", e.toString()));
-            response = String.format("Invalid Data: %s", e.getMessage());
-            status = HttpResponseStatus.BAD_REQUEST;
+            DefaultHandler.sendErrorResponse(ctx, request, response, HttpResponseStatus.BAD_REQUEST);
         } catch (Exception e) {
             log.error(String.format("Exception %s", e.toString()));
             response = String.format("Error: %s", e.getMessage());
-            status = HttpResponseStatus.INTERNAL_SERVER_ERROR;
+            DefaultHandler.sendErrorResponse(ctx, request, response, HttpResponseStatus.INTERNAL_SERVER_ERROR);
         } finally {
-            DefaultHandler.sendResponse(ctx, request, response, status);
             httpEventsIngestTimerContext.stop();
         }
     }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandler.java
@@ -32,7 +32,6 @@ public class HttpEventsQueryHandler implements HttpRequestHandler {
         Tracker.getInstance().track(request);
 
         final String tenantId = request.headers().get("tenantId");
-        HttpResponseStatus status = HttpResponseStatus.OK;
 
         ObjectMapper objectMapper = new ObjectMapper();
         String responseBody = null;
@@ -49,16 +48,16 @@ public class HttpEventsQueryHandler implements HttpRequestHandler {
             parseDateFieldInQuery(params, "until");
             List<Map<String, Object>> searchResult = searchIO.search(tenantId, params);
             responseBody = objectMapper.writeValueAsString(searchResult);
+            DefaultHandler.sendResponse(ctx, request, responseBody, HttpResponseStatus.OK, null);
         } catch (InvalidDataException e) {
             log.error(String.format("Exception %s", e.toString()));
             responseBody = String.format("Error: %s", e.getMessage());
-            status = HttpResponseStatus.BAD_REQUEST;
+            DefaultHandler.sendErrorResponse(ctx, request, responseBody, HttpResponseStatus.BAD_REQUEST);
         } catch (Exception e) {
             log.error(String.format("Exception %s", e.toString()));
             responseBody = String.format("Error: %s", e.getMessage());
-            status = HttpResponseStatus.INTERNAL_SERVER_ERROR;
+            DefaultHandler.sendErrorResponse(ctx, request, responseBody, HttpResponseStatus.INTERNAL_SERVER_ERROR);
         } finally {
-            DefaultHandler.sendResponse(ctx, request, responseBody, status, null);
             httpEventsFetchTimerContext.stop();
         }
     }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricTokensHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricTokensHandler.java
@@ -49,7 +49,7 @@ public class HttpMetricTokensHandler implements HttpRequestHandler {
         // get the query param
         List<String> query = requestWithParams.getQueryParams().get("query");
         if (query == null || query.size() != 1) {
-            sendResponse(ctx, request, "Invalid Query String",
+            DefaultHandler.sendErrorResponse(ctx, request, "Invalid Query String",
                     HttpResponseStatus.BAD_REQUEST);
             return;
         }
@@ -64,7 +64,7 @@ public class HttpMetricTokensHandler implements HttpRequestHandler {
             sendResponse(ctx, request, getSerializedJSON(metricTokens), HttpResponseStatus.OK);
         } catch (Exception e) {
             log.error(String.format("Exception occurred while trying to get metrics index for %s", tenantId), e);
-            sendResponse(ctx, request, "Error getting metrics index", HttpResponseStatus.INTERNAL_SERVER_ERROR);
+            DefaultHandler.sendErrorResponse(ctx, request, "Error getting metrics index", HttpResponseStatus.INTERNAL_SERVER_ERROR);
         } finally {
             httpMetricNameTokensHandlerTimerContext.stop();
         }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
@@ -36,7 +36,7 @@ public class HttpMetricsIndexHandler implements HttpRequestHandler {
         // get the query param
         List<String> query = requestWithParams.getQueryParams().get("query");
         if (query == null || query.size() != 1) {
-            sendResponse(ctx, request, "Invalid Query String",
+            DefaultHandler.sendErrorResponse(ctx, request, "Invalid Query String",
                     HttpResponseStatus.BAD_REQUEST);
             return;
         }
@@ -64,7 +64,7 @@ public class HttpMetricsIndexHandler implements HttpRequestHandler {
             sendResponse(ctx, request, getSerializedJSON(searchResults), HttpResponseStatus.OK);
         } catch (Exception e) {
             log.error(String.format("Exception occurred while trying to get metrics index for %s", tenantId), e);
-            sendResponse(ctx, request, "Error getting metrics index", HttpResponseStatus.INTERNAL_SERVER_ERROR);
+            DefaultHandler.sendErrorResponse(ctx, request, "Error getting metrics index", HttpResponseStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.outputs.handlers;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -56,7 +57,13 @@ public class HttpRollupsQueryHandler extends RollupHandler
             "Handle HTTP request for metrics");
 
     public HttpRollupsQueryHandler() {
-        this.serializer = new JSONBasicRollupsOutputSerializer();
+        this(new JSONBasicRollupsOutputSerializer());
+
+    }
+
+    @VisibleForTesting
+    HttpRollupsQueryHandler(BasicRollupsOutputSerializer<JSONObject> serializer) {
+        this.serializer = serializer;
         this.gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
         this.parser = new JsonParser();
     }
@@ -113,7 +120,7 @@ public class HttpRollupsQueryHandler extends RollupHandler
         final String metricName = request.headers().get("metricName");
 
         if (!(request instanceof HttpRequestWithDecodedQueryParams)) {
-            sendResponse(ctx, request, "Missing query params: from, to, points",
+            DefaultHandler.sendErrorResponse(ctx, request, "Missing query params: from, to, points",
                     HttpResponseStatus.BAD_REQUEST);
             return;
         }
@@ -141,13 +148,13 @@ public class HttpRollupsQueryHandler extends RollupHandler
         } catch (InvalidRequestException e) {
             // let's not log the full exception, just the message.
             log.warn(e.getMessage());
-            sendResponse(ctx, request, e.getMessage(), HttpResponseStatus.BAD_REQUEST);
+            DefaultHandler.sendErrorResponse(ctx, request, e.getMessage(), HttpResponseStatus.BAD_REQUEST);
         } catch (SerializationException e) {
             log.error(e.getMessage(), e);
-            sendResponse(ctx, request, e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR);
+            DefaultHandler.sendErrorResponse(ctx, request, e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
             log.error(e.getMessage(), e);
-            sendResponse(ctx, request, e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR);
+            DefaultHandler.sendErrorResponse(ctx, request, e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR);
         } finally {
             httpMetricsFetchTimerContext.stop();
         }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
@@ -147,7 +147,7 @@ public class HttpRollupsQueryHandler extends RollupHandler
             sendResponse(ctx, request, jsonStringRep, HttpResponseStatus.OK);
         } catch (InvalidRequestException e) {
             // let's not log the full exception, just the message.
-            log.warn(e.getMessage());
+            log.debug(e.getMessage());
             DefaultHandler.sendErrorResponse(ctx, request, e.getMessage(), HttpResponseStatus.BAD_REQUEST);
         } catch (SerializationException e) {
             log.error(e.getMessage(), e);

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayloadTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayloadTest.java
@@ -36,7 +36,7 @@ public class AggregatedPayloadTest {
 
         List<ErrorResponse.ErrorData> errors = payload.getValidationErrors();
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past. " +
-                "Cannot be more than 259200000 milliseconds into the future", errors.get(0).getMessage());
+                "Cannot be more than 600000 milliseconds into the future", errors.get(0).getMessage());
     }
 
     @Test
@@ -50,7 +50,7 @@ public class AggregatedPayloadTest {
 
         List<ErrorResponse.ErrorData> errors = payload.getValidationErrors();
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past. " +
-                "Cannot be more than 259200000 milliseconds into the future", errors.get(0).getMessage());
+                "Cannot be more than 600000 milliseconds into the future", errors.get(0).getMessage());
     }
 
     @Test

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandlerTest.java
@@ -249,7 +249,7 @@ public class HttpAggregatedIngestionHandlerTest extends BaseHandlerTest {
 
         assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past. " +
-                "Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                "Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
         assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());
@@ -275,7 +275,7 @@ public class HttpAggregatedIngestionHandlerTest extends BaseHandlerTest {
 
         assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past. " +
-                "Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                "Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
         assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandlerTest.java
@@ -23,7 +23,7 @@ import com.netflix.astyanax.serializers.AbstractSerializer;
 import com.rackspacecloud.blueflood.inputs.formats.AggregatedPayload;
 import com.rackspacecloud.blueflood.io.serializers.Serializers;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
-import com.rackspacecloud.blueflood.outputs.handlers.BaseHandlerTest;
+import com.rackspacecloud.blueflood.outputs.handlers.HandlerTestsBase;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.*;
@@ -51,7 +51,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 
-public class HttpAggregatedIngestionHandlerTest extends BaseHandlerTest {
+public class HttpAggregatedIngestionHandlerTest extends HandlerTestsBase {
 
     private String payloadJson;
     private HttpAggregatedIngestionHandler handler;

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandlerTest.java
@@ -22,7 +22,7 @@ import com.netflix.astyanax.serializers.AbstractSerializer;
 import com.rackspacecloud.blueflood.inputs.formats.AggregatedPayload;
 import com.rackspacecloud.blueflood.io.serializers.Serializers;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
-import com.rackspacecloud.blueflood.outputs.handlers.BaseHandlerTest;
+import com.rackspacecloud.blueflood.outputs.handlers.HandlerTestsBase;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import io.netty.channel.Channel;
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-public class HttpAggregatedMultiIngestionHandlerTest extends BaseHandlerTest {
+public class HttpAggregatedMultiIngestionHandlerTest extends HandlerTestsBase {
 
     private HttpAggregatedMultiIngestionHandler handler;
     private HttpMetricsIngestionServer.Processor processor;

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandlerTest.java
@@ -19,7 +19,7 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 import com.rackspacecloud.blueflood.http.HttpRequestWithDecodedQueryParams;
 import com.rackspacecloud.blueflood.io.EventsIO;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
-import com.rackspacecloud.blueflood.outputs.handlers.BaseHandlerTest;
+import com.rackspacecloud.blueflood.outputs.handlers.HandlerTestsBase;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.Event;
@@ -38,7 +38,7 @@ import java.util.*;
 import static org.mockito.Mockito.*;
 import static junit.framework.Assert.*;
 
-public class HttpEventsIngestionHandlerTest extends BaseHandlerTest {
+public class HttpEventsIngestionHandlerTest extends HandlerTestsBase {
 
     private EventsIO searchIO;
     private HttpEventsIngestionHandler handler;

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandlerTest.java
@@ -18,7 +18,12 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.rackspacecloud.blueflood.http.HttpRequestWithDecodedQueryParams;
 import com.rackspacecloud.blueflood.io.EventsIO;
+import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
+import com.rackspacecloud.blueflood.outputs.handlers.BaseHandlerTest;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.Event;
+import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
 import io.netty.buffer.Unpooled;
 import org.codehaus.jackson.map.ObjectMapper;
 import io.netty.channel.*;
@@ -33,7 +38,7 @@ import java.util.*;
 import static org.mockito.Mockito.*;
 import static junit.framework.Assert.*;
 
-public class HttpEventsIngestionHandlerTest {
+public class HttpEventsIngestionHandlerTest extends BaseHandlerTest {
 
     private EventsIO searchIO;
     private HttpEventsIngestionHandler handler;
@@ -89,13 +94,118 @@ public class HttpEventsIngestionHandlerTest {
     }
 
     @Test
+    public void testInvalidRequestBody() throws Exception {
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, createRequest(HttpMethod.POST, "", "{\"xxx\": \"yyy\"}"));
+        verify(searchIO, never()).insert(anyString(), anyList());
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
     public void testMalformedEventPut() throws Exception {
-        final String malformedJSON = "{\"when\":, what]}";
+        final String malformedJSON = "{\"when\":, what]}"; //causes JsonParseException
         handler.handle(context, createRequest(HttpMethod.POST, "", malformedJSON));
         ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
         verify(searchIO, never()).insert(anyString(), anyList());
         verify(channel).write(argument.capture());
-        assertNotSame(argument.getValue().content().toString(Charset.defaultCharset()), "");
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void testEmptyPut() throws Exception {
+        Map<String, Object> event = new HashMap<String, Object>();
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, createPutOneEventRequest(event));
+        verify(searchIO, never()).insert(anyString(), anyList());
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        System.out.println(errorResponse);
+        assertEquals("Number of errors invalid", 2, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void testEmptyWhatField() throws Exception {
+        Map<String, Object> event = new HashMap<String, Object>();
+        event.put(Event.FieldLabels.what.name(), "");
+        event.put(Event.FieldLabels.when.name(), System.currentTimeMillis());
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, createPutOneEventRequest(event));
+        verify(searchIO, never()).insert(anyString(), anyList());
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid error message", "may not be empty", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void testWhenFieldInThePast() throws Exception {
+
+        long collectionTimeInPast = new DefaultClockImpl().now().getMillis() - 1000
+                - Configuration.getInstance().getLongProperty( CoreConfig.BEFORE_CURRENT_COLLECTIONTIME_MS );
+
+        Map<String, Object> event = new HashMap<String, Object>();
+        event.put(Event.FieldLabels.what.name(), "xxxx");
+        event.put(Event.FieldLabels.when.name(), collectionTimeInPast);
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, createPutOneEventRequest(event));
+        verify(searchIO, never()).insert(anyString(), anyList());
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void testWhenFieldInTheFuture() throws Exception {
+
+        long collectionTimeInFuture = new DefaultClockImpl().now().getMillis() + 1000
+                + Configuration.getInstance().getLongProperty( CoreConfig.AFTER_CURRENT_COLLECTIONTIME_MS );
+
+        Map<String, Object> event = new HashMap<String, Object>();
+        event.put(Event.FieldLabels.what.name(), "xxxx");
+        event.put(Event.FieldLabels.when.name(), collectionTimeInFuture);
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, createPutOneEventRequest(event));
+        verify(searchIO, never()).insert(anyString(), anyList());
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
     @Test
@@ -107,8 +217,11 @@ public class HttpEventsIngestionHandlerTest {
         verify(searchIO, never()).insert(anyString(), anyList());
         verify(channel).write(argument.capture());
 
-        String error = argument.getValue().content().toString(Charset.defaultCharset());
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
 
-        assertEquals(argument.getValue().content().toString(Charset.defaultCharset()), "Invalid Data: " + HttpMetricsIngestionHandler.ERROR_HEADER + System.lineSeparator() + "Event should contain at least 'what' field.");
+        assertEquals("Number of errors invalid", 2, errorResponse.getErrors().size());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandlerTest.java
@@ -3,7 +3,7 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 import com.rackspacecloud.blueflood.inputs.formats.JSONMetric;
 import com.rackspacecloud.blueflood.inputs.formats.JSONMetricsContainer;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
-import com.rackspacecloud.blueflood.outputs.handlers.BaseHandlerTest;
+import com.rackspacecloud.blueflood.outputs.handlers.HandlerTestsBase;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class HttpMetricsIngestionHandlerTest extends BaseHandlerTest {
+public class HttpMetricsIngestionHandlerTest extends HandlerTestsBase {
 
     private HttpMetricsIngestionHandler handler;
     private HttpMetricsIngestionServer.Processor processor;

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandlerTest.java
@@ -191,7 +191,7 @@ public class HttpMetricsIngestionHandlerTest extends BaseHandlerTest {
         assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
         assertEquals("Invalid error source", "collectionTime", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
     }
 
     @Test
@@ -217,7 +217,7 @@ public class HttpMetricsIngestionHandlerTest extends BaseHandlerTest {
         assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
         assertEquals("Invalid error source", "collectionTime", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
     }
 
     @Test
@@ -299,7 +299,7 @@ public class HttpMetricsIngestionHandlerTest extends BaseHandlerTest {
         assertEquals("Invalid tenant", metricName2, errorResponse.getErrors().get(1).getMetricName());
         assertEquals("Invalid error source", "collectionTime", errorResponse.getErrors().get(1).getSource());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(1).getMessage());
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(1).getMessage());
 
     }
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandlerTest.java
@@ -129,7 +129,7 @@ public class HttpMultitenantMetricsIngestionHandlerTest extends BaseHandlerTest 
         assertEquals("Invalid tenant", metricName2, errorResponse.getErrors().get(1).getMetricName());
         assertEquals("Invalid error source", "collectionTime", errorResponse.getErrors().get(1).getSource());
         assertEquals("Invalid error message", "Out of bounds. Cannot be more than 259200000 milliseconds into the past." +
-                " Cannot be more than 259200000 milliseconds into the future", errorResponse.getErrors().get(1).getMessage());
+                " Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(1).getMessage());
 
     }
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandlerTest.java
@@ -2,7 +2,7 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.rackspacecloud.blueflood.inputs.formats.JSONMetricScoped;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
-import com.rackspacecloud.blueflood.outputs.handlers.BaseHandlerTest;
+import com.rackspacecloud.blueflood.outputs.handlers.HandlerTestsBase;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.utils.DefaultClockImpl;
@@ -25,7 +25,7 @@ import static junit.framework.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
-public class HttpMultitenantMetricsIngestionHandlerTest extends BaseHandlerTest {
+public class HttpMultitenantMetricsIngestionHandlerTest extends HandlerTestsBase {
 
     private HttpMultitenantMetricsIngestionHandler handler;
     private HttpMetricsIngestionServer.Processor processor;

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HandlerTestsBase.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HandlerTestsBase.java
@@ -11,7 +11,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 
-public class BaseHandlerTest {
+public class HandlerTestsBase {
 
     protected static final String TENANT = "tenant";
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerTest.java
@@ -32,7 +32,7 @@ import java.util.*;
 import static junit.framework.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
-public class HttpEventsQueryHandlerTest extends BaseHandlerTest {
+public class HttpEventsQueryHandlerTest extends HandlerTestsBase {
 
     private EventsIO searchIO;
     private HttpEventsQueryHandler handler;

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerTest.java
@@ -17,15 +17,19 @@
 package com.rackspacecloud.blueflood.outputs.handlers;
 
 import com.rackspacecloud.blueflood.io.EventsIO;
+import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
 import com.rackspacecloud.blueflood.types.Event;
 import io.netty.channel.*;
 import io.netty.handler.codec.http.*;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.nio.charset.Charset;
 import java.util.*;
 
+import static junit.framework.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class HttpEventsQueryHandlerTest extends BaseHandlerTest {
@@ -55,8 +59,18 @@ public class HttpEventsQueryHandlerTest extends BaseHandlerTest {
 
     @Test
     public void testElasticSearchSearchNotCalledEmptyQuery() throws Exception {
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
         handler.handle(context, createGetRequest("/v2.0/" + TENANT + "/events/"));
+        verify(channel).write(argument.capture());
         verify(searchIO, never()).search(TENANT, new HashMap<String, List<String>>());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "Error: Query should contain at least one query parameter", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
     private void testQuery(String query, Map<String, List<String>> params) throws Exception {

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricTokensHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricTokensHandlerTest.java
@@ -2,7 +2,10 @@ package com.rackspacecloud.blueflood.outputs.handlers;
 
 import com.rackspacecloud.blueflood.io.DiscoveryIO;
 import com.rackspacecloud.blueflood.io.MetricToken;
+import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
 import io.netty.channel.ChannelFuture;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import junit.framework.Assert;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -12,9 +15,12 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.nio.charset.Charset;
 import java.util.*;
 
+import static junit.framework.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -41,14 +47,34 @@ public class HttpMetricTokensHandlerTest extends BaseHandlerTest {
 
     @Test
     public void emptyPrefix() throws Exception {
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
         handler.handle(context, createGetRequest("/v2.0/" + TENANT + "/metric_name/search"));
+        verify(channel).write(argument.capture());
         verify(mockDiscoveryHandle, never()).getMetricTokens(anyString(), anyString());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "Invalid Query String", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
     @Test
     public void invalidQuerySize() throws Exception {
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
         handler.handle(context, createGetRequest("/v2.0/" + TENANT + "/metric_name/search?query=foo&query=bar"));
+        verify(channel).write(argument.capture());
         verify(mockDiscoveryHandle, never()).getMetricTokens(anyString(), anyString());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "Invalid Query String", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricTokensHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricTokensHandlerTest.java
@@ -24,7 +24,7 @@ import static junit.framework.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
-public class HttpMetricTokensHandlerTest extends BaseHandlerTest {
+public class HttpMetricTokensHandlerTest extends HandlerTestsBase {
 
     private DiscoveryIO mockDiscoveryHandle = mock(DiscoveryIO.class);
     private ChannelHandlerContext context;

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerTest.java
@@ -1,0 +1,59 @@
+package com.rackspacecloud.blueflood.outputs.handlers;
+
+import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class HttpMetricsIndexHandlerTest extends BaseHandlerTest {
+
+    private HttpMetricsIndexHandler handler;
+
+    private static final String TENANT = "tenant";
+
+    private ChannelHandlerContext context;
+    private Channel channel;
+
+    @Before
+    public void setup() {
+        handler = new HttpMetricsIndexHandler();
+
+        channel = mock(Channel.class);
+        context = mock(ChannelHandlerContext.class);
+        when(context.channel()).thenReturn(channel);
+    }
+
+    @Test
+    public void testWithNoQueryParams() throws IOException {
+        FullHttpRequest request = createQueryRequest("");
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "Invalid Query String", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    private FullHttpRequest createQueryRequest(String queryParams) {
+        return super.createGetRequest("/v2.0/" + TENANT + "/search/" + queryParams);
+    }
+}

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class HttpMetricsIndexHandlerTest extends BaseHandlerTest {
+public class HttpMetricsIndexHandlerTest extends HandlerTestsBase {
 
     private HttpMetricsIndexHandler handler;
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerTest.java
@@ -20,7 +20,7 @@ import java.nio.charset.Charset;
 import static junit.framework.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
-public class HttpRollupsQueryHandlerTest extends BaseHandlerTest {
+public class HttpRollupsQueryHandlerTest extends HandlerTestsBase {
 
     private HttpRollupsQueryHandler handler;
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerTest.java
@@ -1,0 +1,100 @@
+package com.rackspacecloud.blueflood.outputs.handlers;
+
+import com.rackspacecloud.blueflood.exceptions.SerializationException;
+import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
+import com.rackspacecloud.blueflood.outputs.formats.MetricData;
+import com.rackspacecloud.blueflood.outputs.serializers.BasicRollupsOutputSerializer;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.json.simple.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class HttpRollupsQueryHandlerTest extends BaseHandlerTest {
+
+    private HttpRollupsQueryHandler handler;
+
+    private static final String TENANT = "tenant";
+
+    private ChannelHandlerContext context;
+    private Channel channel;
+    private BasicRollupsOutputSerializer<JSONObject> serializer;
+
+    @Before
+    public void setup() {
+        serializer = mock(BasicRollupsOutputSerializer.class);
+        handler = new HttpRollupsQueryHandler(serializer);
+
+        channel = mock(Channel.class);
+        context = mock(ChannelHandlerContext.class);
+        when(context.channel()).thenReturn(channel);
+    }
+
+    @Test
+    public void testWithNoQueryParams() throws IOException {
+        FullHttpRequest request = createQueryRequest("");
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "No query parameters present.", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void testMissingRequiredQueryParams() throws IOException {
+        FullHttpRequest request = createQueryRequest("?from=111111");
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", "Either 'points' or 'resolution' is required.", errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void testRequestWithSerializationException() throws IOException {
+        FullHttpRequest request = createQueryRequest("?points=10&from=1&to=2");
+
+        ArgumentCaptor<FullHttpResponse> argument = ArgumentCaptor.forClass(FullHttpResponse.class);
+        String message = "mock exception message";
+        when(serializer.transformRollupData(any(MetricData.class), anySet())).thenThrow(new SerializationException(message));
+        handler.handle(context, request);
+        verify(channel).write(argument.capture());
+
+        String errorResponseBody = argument.getValue().content().toString(Charset.defaultCharset());
+        ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
+
+        assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
+        assertEquals("Invalid error message", message, errorResponse.getErrors().get(0).getMessage());
+        assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
+        assertEquals("Invalid status", HttpResponseStatus.INTERNAL_SERVER_ERROR, argument.getValue().getStatus());
+    }
+
+    private FullHttpRequest createQueryRequest(String queryParams) {
+        return super.createGetRequest("/v2.0/" + TENANT + "/views/" + queryParams);
+    }
+
+}


### PR DESCRIPTION
 - Add java bean validation to some /events and /search endpoints using hibernate validator
 - Made all error responses in consistent format
 - Added validation for /events when we get multiple root elements