### PR TITLE
add querylogger, locator metric, minor log changes

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/ALocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/ALocatorIO.java
@@ -46,12 +46,17 @@ public class ALocatorIO implements LocatorIO {
      */
     @Override
     public void insertLocator(Locator locator) throws IOException {
+        Timer.Context timer = Instrumentation.getWriteTimerContext(CassandraModel.CF_METRICS_LOCATOR_NAME);
         try {
             MutationBatch mutationBatch = AstyanaxIO.getKeyspace().prepareMutationBatch();
             AstyanaxWriter.getInstance().insertLocator(locator, mutationBatch);
             mutationBatch.execute();
         } catch (Exception e) {
             throw new IOException(e);
+        } finally {
+            if ( timer != null ) {
+                timer.stop();
+            }
         }
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/ALocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/ALocatorIO.java
@@ -54,9 +54,7 @@ public class ALocatorIO implements LocatorIO {
         } catch (Exception e) {
             throw new IOException(e);
         } finally {
-            if ( timer != null ) {
-                timer.stop();
-            }
+            timer.stop();
         }
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
@@ -82,7 +82,7 @@ public class DLocatorIO implements LocatorIO {
                 .value(VALUE, bindMarker());
         putValue = DatastaxIO.getSession()
                 .prepare(insert)
-                .setConsistencyLevel( ConsistencyLevel.LOCAL_ONE );  // TODO: remove later; required by the cassandra-maven-plugin 2.0.0-1
+                .setConsistencyLevel( ConsistencyLevel.ONE );  // TODO: remove later; required by the cassandra-maven-plugin 2.0.0-1
                                                               // (see https://issues.apache.org/jira/browse/CASSANDRA-6238)
 
     }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
@@ -99,10 +99,10 @@ public class DLocatorIO implements LocatorIO {
         // get shard this locator would belong to
         long shard = (long) Util.getShard(locator.toString());
 
-        // bound values and execute
-        BoundStatement bs = putValue.bind(shard, locator.toString(), "");
         Timer.Context timer = Instrumentation.getWriteTimerContext(CassandraModel.CF_METRICS_LOCATOR_NAME);
         try {
+            // bound values and execute
+            BoundStatement bs = putValue.bind(shard, locator.toString(), "");
             session.execute(bs);
         } finally {
             timer.stop();

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
@@ -25,7 +25,7 @@ import com.rackspacecloud.blueflood.io.CassandraModel;
 import com.rackspacecloud.blueflood.io.Instrumentation;
 import com.rackspacecloud.blueflood.io.LocatorIO;
 import com.rackspacecloud.blueflood.types.Locator;
-import com.rackspacecloud.blueflood.utils.Util;
+import com.rackspacecloud.blueflood.utils.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +82,7 @@ public class DLocatorIO implements LocatorIO {
                 .value(VALUE, bindMarker());
         putValue = DatastaxIO.getSession()
                 .prepare(insert)
-                .setConsistencyLevel( ConsistencyLevel.ONE);  // TODO: remove later; required by the cassandra-maven-plugin 2.0.0-1
+                .setConsistencyLevel( ConsistencyLevel.LOCAL_ONE );  // TODO: remove later; required by the cassandra-maven-plugin 2.0.0-1
                                                               // (see https://issues.apache.org/jira/browse/CASSANDRA-6238)
 
     }
@@ -101,7 +101,12 @@ public class DLocatorIO implements LocatorIO {
 
         // bound values and execute
         BoundStatement bs = putValue.bind(shard, locator.toString(), "");
-        session.execute(bs);
+        Timer.Context timer = Instrumentation.getWriteTimerContext(CassandraModel.CF_METRICS_LOCATOR_NAME);
+        try {
+            session.execute(bs);
+        } finally {
+            timer.stop();
+        }
     }
 
     /**

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxIO.java
@@ -57,12 +57,18 @@ public class DatastaxIO {
         CodecRegistry codecRegistry = new CodecRegistry();
 
         cluster = Cluster.builder()
-                .withLoadBalancingPolicy(new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().withLocalDc("datacenter1").build()))
+                .withLoadBalancingPolicy(new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().withLocalDc("datacenter1").build(), false))
                 .withPoolingOptions(getPoolingOptions(dbHosts.size()))
                 .withCodecRegistry(codecRegistry)
                 .withSocketOptions(getSocketOptions())
                 .addContactPointsWithPorts(dbHosts)
                 .build();
+
+        QueryLogger queryLogger = QueryLogger.builder()
+                .withConstantThreshold(5000)
+                .build();
+
+        cluster.register(queryLogger);
 
         if ( LOG.isDebugEnabled() ) {
             logDebugConnectionInfo();

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -162,8 +162,8 @@ public class RollupRunnable implements Runnable {
         } catch (Exception e) {
             LOG.error("Rollup failed; Locator: {}, Source Granularity: {}, For period: {}", new Object[]{
                     singleRollupReadContext.getLocator(),
-                    singleRollupReadContext.getRange().toString(),
                     srcGran.name(),
+                    singleRollupReadContext.getRange().toString(),
                     e});
         } finally {
             executionContext.decrementReadCounter();


### PR DESCRIPTION
A few minor changes I'd like to add, as a result of the latest performance testing:
* add metrics to track the rate and timing of locator inserts
We currently do not track this. As I found in the performance tests, how many locators we are inserting impacts the throughput. This will be a useful metric to track
* add QueryLogger (which is not the same thing as QueryTrace). See also https://datastax.github.io/java-driver/3.0.3/manual/logging/
This will enable us to turn on logging at client/driver side, which queries/statements are in ERROR, SLOW, or NORMAL. These 3 categories of logging can be turned on independently from log4j, by having this in your log4j.properties:

```
log4j.logger.com.datastax.driver.core.QueryLogger.ERROR=DEBUG
log4j.logger.com.datastax.driver.core.QueryLogger.SLOW=DEBUG
```

* fix minor out of order logging statement (in RollupRunnable.java)