### PR TITLE
prevent travis from running mvn install twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   directories:
     - $HOME/.m2
 
-script: 
+install: 
   - mvn clean install -Pcassandra-2.0 -Dmaven.javadoc.skip --quiet
 
 after_success:


### PR DESCRIPTION
I noticed from Travis logs that for each build we are actually running ```mvn install``` twice, which means running unit and integration tests twice. Which is why it takes so darn long to build.

I googled around and found some ppl suggesting to replace the ```install``` step in .travis.yml:
https://github.com/travis-ci/travis-ci/issues/1400

I am making this changes for blueflood.