### PR TITLE
add response body for partial 207 errors for aggregated payload

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
@@ -113,12 +113,8 @@ public class AggregatedPayload {
                 metricName = ((BluefloodSet) leafBean).getName();
             }
 
-            if ((metricName.isEmpty()) && (payload.getAllMetricNames().size() > 0)) {
-                metricName = payload.getAllMetricNames().get(0);
-            }
-
             payload.validationErrors.add(new ErrorResponse.ErrorData(payload.getTenantId(), metricName,
-                    source, constraintViolation.getMessage()));
+                    source, constraintViolation.getMessage(), payload.getTimestamp()));
         }
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/AggregatedPayload.java
@@ -113,6 +113,10 @@ public class AggregatedPayload {
                 metricName = ((BluefloodSet) leafBean).getName();
             }
 
+            if ((metricName.isEmpty()) && (payload.getAllMetricNames().size() > 0)) {
+                metricName = payload.getAllMetricNames().get(0);
+            }
+
             payload.validationErrors.add(new ErrorResponse.ErrorData(payload.getTenantId(), metricName,
                     source, constraintViolation.getMessage()));
         }
@@ -158,7 +162,7 @@ public class AggregatedPayload {
     /**
      * This method is invoked by the validator automatically
      */
-    @AssertTrue(message="Atleast one of the aggregated metrics(gauges, counters, timers, sets) are expected")
+    @AssertTrue(message="At least one of the aggregated metrics(gauges, counters, timers, sets) are expected")
     private boolean isValid() {
         boolean isGaugePresent = gauges != null && gauges.length > 0;
         boolean isCounterPresent = counters != null && counters.length > 0;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/ErrorResponse.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/outputs/formats/ErrorResponse.java
@@ -31,6 +31,7 @@ public class ErrorResponse {
     public static class ErrorData {
 
         private String tenantId;
+        private Long timestamp;
         private String metricName;
         private String source;
         private String message;
@@ -38,15 +39,28 @@ public class ErrorResponse {
         public ErrorData() {
         }
 
-        public ErrorData(String tenantId, String metricName, String source, String message) {
+        /***
+         * Data class for storing error message for a metric from an ingest validation error
+         * @param tenantId the tenantId of for the metric
+         * @param metricName the name of the metric
+         * @param source the source of the error within the metric, i.e. the field with the violiation
+         * @param message the error message
+         * @param timestamp the collectionTime of a metric, timestamp of an aggregated metric, or when value of an event
+         */
+        public ErrorData(String tenantId, String metricName, String source, String message, Long timestamp) {
             this.tenantId = tenantId == null ? "" : tenantId;
             this.metricName = metricName == null ? "" : metricName;
             this.source = source;
             this.message = message;
+            this.timestamp = timestamp;
         }
 
         public String getTenantId() {
             return tenantId;
+        }
+
+        public Long getTimestamp() {
+            return timestamp;
         }
 
         public String getMetricName() {
@@ -65,6 +79,10 @@ public class ErrorResponse {
             this.tenantId = tenantId;
         }
 
+        public void setTimestamp(long timestamp) {
+            this.timestamp = timestamp;
+        }
+
         public void setMetricName(String metricName) {
             this.metricName = metricName;
         }
@@ -81,6 +99,7 @@ public class ErrorResponse {
         public String toString() {
             return "ErrorData{" +
                     "tenantId='" + tenantId + '\'' +
+                    ", timestamp='" + timestamp + '\'' +
                     ", metricName='" + metricName + '\'' +
                     ", source='" + source + '\'' +
                     ", message='" + message + '\'' +

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/DefaultHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/DefaultHandler.java
@@ -65,7 +65,7 @@ public class DefaultHandler implements HttpRequestHandler {
         final String tenantId = request.headers().get("tenantId");
 
         List<ErrorResponse.ErrorData> errrors = new ArrayList<ErrorResponse.ErrorData>(){{
-            add(new ErrorResponse.ErrorData(tenantId, null, null, message));
+            add(new ErrorResponse.ErrorData(tenantId, null, null, message, null));
         }};
 
         sendErrorResponse(ctx, request, errrors, status);

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
@@ -128,7 +128,7 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
                     return;
                 } else {
                     // has some validation errors, response MULTI_STATUS
-                    DefaultHandler.sendResponse(ctx, request, null, HttpResponseStatus.MULTI_STATUS);
+                    DefaultHandler.sendErrorResponse(ctx, request, errors, HttpResponseStatus.MULTI_STATUS);
                     return;
                 }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpEventsIngestionHandler.java
@@ -82,8 +82,10 @@ public class HttpEventsIngestionHandler implements HttpRequestHandler {
 
             List<ErrorResponse.ErrorData> validationErrors = new ArrayList<ErrorResponse.ErrorData>();
             for (ConstraintViolation<Event> constraintViolation : constraintViolations) {
-                validationErrors.add(new ErrorResponse.ErrorData(tenantId, "",
-                        constraintViolation.getPropertyPath().toString(), constraintViolation.getMessage()));
+                validationErrors.add(
+                        new ErrorResponse.ErrorData(tenantId, "",
+                        constraintViolation.getPropertyPath().toString(), constraintViolation.getMessage(),
+                        event.getWhen()));
             }
 
             if (!validationErrors.isEmpty()) {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandler.java
@@ -111,7 +111,8 @@ public class HttpMetricsIngestionHandler implements HttpRequestHandler {
             } else {
                 for (ConstraintViolation<JSONMetric> constraintViolation : constraintViolations) {
                     validationErrors.add(new ErrorResponse.ErrorData(tenantId, metric.getMetricName(),
-                            constraintViolation.getPropertyPath().toString(), constraintViolation.getMessage()));
+                            constraintViolation.getPropertyPath().toString(), constraintViolation.getMessage(),
+                            metric.getCollectionTime()));
                 }
             }
         }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandler.java
@@ -55,8 +55,10 @@ public class HttpMultitenantMetricsIngestionHandler extends HttpMetricsIngestion
                 validJsonMetrics.add(metric);
             } else {
                 for (ConstraintViolation<JSONMetricScoped> constraintViolation : constraintViolations) {
-                    validationErrors.add(new ErrorResponse.ErrorData(scopedMetric.getTenantId(), metric.getMetricName(),
-                            constraintViolation.getPropertyPath().toString(), constraintViolation.getMessage()));
+                    validationErrors.add(
+                            new ErrorResponse.ErrorData(scopedMetric.getTenantId(), metric.getMetricName(),
+                            constraintViolation.getPropertyPath().toString(), constraintViolation.getMessage(),
+                            metric.getCollectionTime()));
                 }
             }
         }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandlerTest.java
@@ -204,7 +204,7 @@ public class HttpAggregatedIngestionHandlerTest extends HandlerTestsBase {
         assertEquals("Invalid error message", "may not be empty", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "tenantId", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", "", errorResponse.getErrors().get(0).getTenantId());
-        assertEquals("Invalid metric name", "gauge.a.b", errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());
         assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
@@ -226,7 +226,7 @@ public class HttpAggregatedIngestionHandlerTest extends HandlerTestsBase {
         assertEquals("Invalid error message", "must be between 0 and 9223372036854775807", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "flushInterval", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
-        assertEquals("Invalid metric name", "gauge.a.b", errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());
         assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
@@ -252,7 +252,7 @@ public class HttpAggregatedIngestionHandlerTest extends HandlerTestsBase {
                 "Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
-        assertEquals("Invalid metric name", "gauge.a.b", errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());
         assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
@@ -278,7 +278,7 @@ public class HttpAggregatedIngestionHandlerTest extends HandlerTestsBase {
                 "Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
-        assertEquals("Invalid metric name", "gauge.a.b", errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());
         assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandlerTest.java
@@ -204,7 +204,7 @@ public class HttpAggregatedIngestionHandlerTest extends HandlerTestsBase {
         assertEquals("Invalid error message", "may not be empty", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "tenantId", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", "", errorResponse.getErrors().get(0).getTenantId());
-        assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid metric name", "gauge.a.b", errorResponse.getErrors().get(0).getMetricName());
         assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
@@ -226,7 +226,7 @@ public class HttpAggregatedIngestionHandlerTest extends HandlerTestsBase {
         assertEquals("Invalid error message", "must be between 0 and 9223372036854775807", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "flushInterval", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
-        assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid metric name", "gauge.a.b", errorResponse.getErrors().get(0).getMetricName());
         assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
@@ -252,7 +252,7 @@ public class HttpAggregatedIngestionHandlerTest extends HandlerTestsBase {
                 "Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
-        assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid metric name", "gauge.a.b", errorResponse.getErrors().get(0).getMetricName());
         assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
@@ -278,7 +278,7 @@ public class HttpAggregatedIngestionHandlerTest extends HandlerTestsBase {
                 "Cannot be more than 600000 milliseconds into the future", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "timestamp", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());
-        assertEquals("Invalid metric name", "", errorResponse.getErrors().get(0).getMetricName());
+        assertEquals("Invalid metric name", "gauge.a.b", errorResponse.getErrors().get(0).getMetricName());
         assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
@@ -296,7 +296,7 @@ public class HttpAggregatedIngestionHandlerTest extends HandlerTestsBase {
         ErrorResponse errorResponse = getErrorResponse(errorResponseBody);
 
         assertEquals("Number of errors invalid", 1, errorResponse.getErrors().size());
-        assertEquals("Invalid error message", "Atleast one of the aggregated metrics(gauges, counters, timers, sets) " +
+        assertEquals("Invalid error message", "At least one of the aggregated metrics(gauges, counters, timers, sets) " +
                 "are expected", errorResponse.getErrors().get(0).getMessage());
         assertEquals("Invalid source", "", errorResponse.getErrors().get(0).getSource());
         assertEquals("Invalid tenant", TENANT, errorResponse.getErrors().get(0).getTenantId());


### PR DESCRIPTION
# What

Add response body for aggregated/multi payload ingestion with partial invalid metrics (207 response code).
Fix missing metricName for aggregated payload validation response.
Fix and refactor integration tests.

# Why

Currently partial failure during ingestion for aggregated metrics return a 207 response code with an empty body.  A response body is returned to indicate which metrics failed and the reason for the failure.

# How

Use the new sendErrorResponse() method in the HttpAggregatedMultiIngestionHandler.java class.

