### PR TITLE
change response to BAD_REQUEST for empty aggregated metrics request

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
@@ -134,7 +134,7 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
 
             } else {
                 // no aggregated metric bundles in body, response OK
-                DefaultHandler.sendResponse(ctx, request, null, HttpResponseStatus.OK);
+                DefaultHandler.sendResponse(ctx, request, "No valid metrics", HttpResponseStatus.BAD_REQUEST);
                 return;
             }
         } catch (JsonParseException ex) {

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandlerTest.java
@@ -210,8 +210,8 @@ public class HttpAggregatedMultiIngestionHandlerTest extends HandlerTestsBase {
 
         String responseBody = argument.getValue().content().toString(Charset.defaultCharset());
 
-        assertEquals("Invalid response", "", responseBody);
-        assertEquals("Invalid status", HttpResponseStatus.OK, argument.getValue().getStatus());
+        assertEquals("Invalid response", "No valid metrics", responseBody);
+        assertEquals("Invalid status", HttpResponseStatus.BAD_REQUEST, argument.getValue().getStatus());
     }
 
     private String createRequestBody(String tenantId, long collectionTime, long flushInterval, BluefloodGauge[] gauges,


### PR DESCRIPTION
# WHAT

change response to BAD_REQUEST for empty array of aggregated metrics request

# WHY

empty array should return BAD_REQUEST (400) instead of OK (200).

# HOW

Change response in class HttpMetricsIngestionHandler.

# TEST

Run cloudmetrics-system-tests with empty array test unignored against system with this change.
