### PR TITLE
prepare blueflood-2.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 jdk:
-  - oraclejdk7
-  - openjdk7
   - oraclejdk8
 
 sudo: false
@@ -39,7 +37,7 @@ deploy:
     repo: rackerlabs/blueflood
     tags: false
     branch: rax-release
-    jdk: oraclejdk7
+    jdk: oraclejdk8
 
 after_deploy:
   # change pom.xml files to the next dev version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,13 @@
 # CHANGES
 
 ## IN PROGRESS
-* Added response body for 207 errors listing the rejected metrics and why
+
+## blueflood-2.0.0
+* Switched to officially building with JDK 8
+  NOTE: after this release, JDK 7 will no longer be supported.
+* Added response body for 207 errors listing the rejected metrics and the reasons
+* Fixed Issue #748, avoided missing rollups due to metrics_locator not updated because
+  metrics never expired from cache
 * Improved handling of delayed metrics by re-rolling only those metrics (not the whole shard)
 
 ## rax-release-v1.0.2981

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,7 @@
 ## IN PROGRESS
 
 ## blueflood-2.0.0
-* Switched to officially building with JDK 8
-  NOTE: after this release, JDK 7 will no longer be supported.
+* Switched to officially building with JDK 8. **NOTE**: after this release, JDK 7 will no longer be supported.
 * Added response body for 207 errors listing the rejected metrics and the reasons
 * Fixed Issue #748, avoided missing rollups due to metrics_locator not updated because
   metrics never expired from cache


### PR DESCRIPTION
Changes are:
* update release notes to say we are only supporting JDK 8 after this release
* change Travis to no longer build with JDK 7