### PR TITLE
Delayed metrics reroll config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## IN PROGRESS
 * Upgraded datastax driver to 3.1.2
+* Added new configuration option DELAYED_METRICS_REROLL_GRANULARITY
 
 ## blueflood-2.0.0
 * Switched to officially building with JDK 8. **NOTE**: after this release, JDK 7 will no longer be supported.

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/rollup/SlotKey.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/rollup/SlotKey.java
@@ -149,7 +149,7 @@ public final class SlotKey {
     public Collection<SlotKey> getChildrenKeys(Granularity destGranularity) {
 
         if (!getGranularity().isCoarser(destGranularity)) {
-            throw new IllegalArgumentException("Current granularity must be coarser than the destination granularity");
+            throw new IllegalArgumentException(String.format("Current granularity [%s] must be coarser than the destination granularity [%s]", getGranularity(), destGranularity));
         }
 
         List<SlotKey> result = new ArrayList<SlotKey>();

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/rollup/SlotKey.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/rollup/SlotKey.java
@@ -23,6 +23,7 @@ import com.rackspacecloud.blueflood.io.Constants;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -132,6 +133,33 @@ public final class SlotKey {
             result.addAll(child.getChildrenKeys());
         }
         return result;
+    }
+
+    /**
+     * Same as the method {@link #getChildrenKeys()} except this method returns only
+     * the children corresponding to the destination granularity.
+     *
+     * For example, a slot key of granularity
+     * {@link Granularity#MIN_1440 MIN_1440}, for destination granularity of
+     * {@link Granularity#MIN_60 MIN_60}, will have 6*4=24 children.
+     *
+     * @param destGranularity
+     * @return
+     */
+    public Collection<SlotKey> getChildrenKeys(Granularity destGranularity) {
+
+        if (!getGranularity().isCoarser(destGranularity)) {
+            throw new IllegalArgumentException("Current granularity must be coarser than the destination granularity");
+        }
+
+        List<SlotKey> result = new ArrayList<SlotKey>();
+        for(SlotKey slotKey: this.getChildrenKeys()) {
+            if (slotKey.getGranularity().equals(destGranularity)) {
+                result.add(slotKey);
+            }
+        }
+
+        return Collections.unmodifiableList(result);
     }
 
     /**

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -158,6 +158,8 @@ public enum CoreConfig implements ConfigDefaults {
 
     //the granularity for which we store delayed metrics. Allowed values are 5m, 20m, 60m, 240m, 1440m
     DELAYED_METRICS_STORAGE_GRANULARITY("20m"),
+    //the granularity upto which we re-roll only the delayed metrics instead of the entire shard
+    DELAYED_METRICS_REROLL_GRANULARITY("60m"),
     RECORD_DELAYED_METRICS("true"),
 
     SHOULD_STORE_UNITS("true"),

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/rollup/SlotKeyTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/rollup/SlotKeyTest.java
@@ -51,6 +51,35 @@ public class SlotKeyTest {
     }
 
     @Test
+    public void test_getChildrenKeys_with_destinationGranularity() {
+        // the relationship between slots plays out here.
+        int shard = 0;
+        int slot = 0;
+
+        // min5 slots contain only their full res counterpart.
+        assertEquals("Incorrect number of children - scenario 0", 1, SlotKey.of(Granularity.MIN_5, slot, shard).getChildrenKeys(Granularity.FULL).size());
+
+        //1 level
+        assertEquals("Incorrect number of children - scenario 1", 4, SlotKey.of(Granularity.MIN_20, slot, shard).getChildrenKeys(Granularity.MIN_5).size());
+
+        //2 levels
+        assertEquals("Incorrect number of children - scenario 2", 3 * 4, SlotKey.of(Granularity.MIN_60, slot, shard).getChildrenKeys(Granularity.MIN_5).size());
+
+        //4 levels
+        assertEquals("Incorrect number of children - scenario 3", 6 * 4 * 3 * 4, SlotKey.of(Granularity.MIN_1440, slot, shard).getChildrenKeys(Granularity.MIN_5).size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetChildrenKeysWithSameDestGranularity() {
+        SlotKey.of(Granularity.MIN_20, 1, 1).getChildrenKeys(Granularity.MIN_20);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetChildrenKeysWithInvalidDestGranularity() {
+        SlotKey.of(Granularity.MIN_20, 1, 1).getChildrenKeys(Granularity.MIN_60);
+    }
+
+    @Test
     public void testExtrapolate() {
         int shard = 1;
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnableIntegrationTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnableIntegrationTest.java
@@ -63,6 +63,9 @@ public class LocatorFetchRunnableIntegrationTest extends IntegrationTestBase {
     private static Granularity DELAYED_METRICS_STORAGE_GRANULARITY =
             Granularity.getRollupGranularity(Configuration.getInstance().getStringProperty(CoreConfig.DELAYED_METRICS_STORAGE_GRANULARITY));
 
+    private static Granularity DELAYED_METRICS_REROLL_GRANULARITY =
+            Granularity.getRollupGranularity(Configuration.getInstance().getStringProperty(CoreConfig.DELAYED_METRICS_REROLL_GRANULARITY));
+
     private final List<String> shard1Locators = Arrays.asList(
             "-1.int.perf01.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.131",
             "-100.int.perf01.abcdefg.hijklmnop.qrstuvw.xyz.ABCDEFG.HIJKLMNOP.QRSTUVW.XYZ.abcdefg.hijklmnop.qrstuvw.xyz.met.119");
@@ -225,7 +228,7 @@ public class LocatorFetchRunnableIntegrationTest extends IntegrationTestBase {
 
             locatorFetchRunnable.run();
 
-            if (slotKey.getGranularity().isCoarser(DELAYED_METRICS_STORAGE_GRANULARITY)) {
+            if (slotKey.getGranularity().isCoarser(DELAYED_METRICS_REROLL_GRANULARITY)) {
                 //verifying number of locators read and rollups written are same as the number of delayed locators during re-roll.
                 verify(rollupExecutionContext, times(generatedMetrics.get(slotKey.getShard()).size())).incrementReadCounter();
                 verify(rollupBatchWriter, times(generatedMetrics.get(slotKey.getShard()).size()))

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnableRunTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/LocatorFetchRunnableRunTest.java
@@ -113,7 +113,8 @@ public class LocatorFetchRunnableRunTest {
         lfr.initialize(scheduleCtx, destSlotKey,
                 rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor);
         doReturn(generateLocators(0)).when(lfr).getLocators(
-                Matchers.<RollupExecutionContext>any());
+                Matchers.<RollupExecutionContext>any(),
+                anyBoolean(), any(Granularity.class), any(Granularity.class));
 
         // when
         lfr.run();
@@ -139,7 +140,8 @@ public class LocatorFetchRunnableRunTest {
         verify(lfr, times(1)).getParentSlot();
         verify(lfr).createRollupExecutionContext();
         verify(lfr).createRollupBatchWriter(Matchers.<RollupExecutionContext>any());
-        verify(lfr).getLocators(Matchers.<RollupExecutionContext>any());
+        verify(lfr).getLocators(Matchers.<RollupExecutionContext>any(),
+                anyBoolean(), any(Granularity.class), any(Granularity.class));
 
         verify(lfr, never()).processLocator(anyInt(),
                 Matchers.<RollupExecutionContext>any(),
@@ -160,7 +162,8 @@ public class LocatorFetchRunnableRunTest {
         lfr.initialize(scheduleCtx, destSlotKey,
                 rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor);
         doReturn(generateLocators(1)).when(lfr).getLocators(
-                Matchers.<RollupExecutionContext>any());
+                Matchers.<RollupExecutionContext>any(),
+                anyBoolean(), any(Granularity.class), any(Granularity.class));
 
         // when
         lfr.run();
@@ -186,7 +189,8 @@ public class LocatorFetchRunnableRunTest {
         verify(lfr, times(1)).getParentSlot();
         verify(lfr).createRollupExecutionContext();
         verify(lfr).createRollupBatchWriter(Matchers.<RollupExecutionContext>any());
-        verify(lfr).getLocators(Matchers.<RollupExecutionContext>any());
+        verify(lfr).getLocators(Matchers.<RollupExecutionContext>any(),
+                anyBoolean(), any(Granularity.class), any(Granularity.class));
 
         verify(lfr, times(1)).processLocator(anyInt(),
                 Matchers.<RollupExecutionContext>any(),
@@ -207,7 +211,8 @@ public class LocatorFetchRunnableRunTest {
         lfr.initialize(scheduleCtx, destSlotKey,
                 rollupReadExecutor, rollupWriteExecutor, enumValidatorExecutor);
         doReturn(generateLocators(3)).when(lfr).getLocators(
-                Matchers.<RollupExecutionContext>any());
+                Matchers.<RollupExecutionContext>any(),
+                anyBoolean(), any(Granularity.class), any(Granularity.class));
 
         // when
         lfr.run();
@@ -233,7 +238,8 @@ public class LocatorFetchRunnableRunTest {
         verify(lfr, times(1)).getParentSlot();
         verify(lfr).createRollupExecutionContext();
         verify(lfr).createRollupBatchWriter(Matchers.<RollupExecutionContext>any());
-        verify(lfr).getLocators(Matchers.<RollupExecutionContext>any());
+        verify(lfr).getLocators(Matchers.<RollupExecutionContext>any(),
+                anyBoolean(), any(Granularity.class), any(Granularity.class));
 
         verify(lfr, times(3)).processLocator(anyInt(),
                 Matchers.<RollupExecutionContext>any(),


### PR DESCRIPTION
Introducing a new configuration, DELAYED_METRICS_REROLL_GRANULARITY, using which we control the granularity upto which we re-roll only the delayed metrics instead of entire slot. 

