### PR TITLE
fix cassandra integration tests so multiple jenkins jobs can run on the same box

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <skip.unit.tests>false</skip.unit.tests>
     <slf4j.version>1.7.6</slf4j.version>
     <jodatime.version>2.9</jodatime.version>
+    <maven.build.timestamp.format>yyyyMMdd-HHmmss</maven.build.timestamp.format>
   </properties>
 
   <dependencyManagement>
@@ -244,14 +245,14 @@
         <version>${cassandra.plugin.version}</version>
         <configuration>
           <!--There are issues when running tests inside vmware fusion on a filesystem mounted from the host machine-->
-          <cassandraDir>/tmp/bf-cassandra-${cassandra.plugin.version}/</cassandraDir>
+          <cassandraDir>/tmp/bf-cassandra-${cassandra.plugin.version}-${maven.build.timestamp}/</cassandraDir>
           <loadFailureIgnore>false</loadFailureIgnore>
           <startNativeTransport>true</startNativeTransport>
         </configuration>
         <executions>
           <execution>
             <id>delete-cassandra</id>
-            <phase>pre-integration-test</phase>
+            <phase>post-integration-test</phase>
             <goals>
               <goal>delete</goal>
             </goals>


### PR DESCRIPTION
We have recently changed some of our Jenkins blueflood-bundle-* jobs to run ```mvn clean install``` which essentially run our integration tests.

When we run integration tests, we configure ```cassandra-maven-plugin``` to use directory ```/tmp/bf-cassandra-2.0.0-1``` as the Cassandra directory. This means that multiple blueflood-bundle-* Jenkins job can't run at the same time on the Jenkins box.

This PR modifies the ```/tmp/bf-cassandra-2.0.0-1``` so that it contains timestamp, allowing multiple Jenkins jobs to use different Cassandra directory (hopefully no 2 Jenkins jobs are kicked of at the same second). 