### PR TITLE
Integrated docker maven build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Build an ['uber jar'](http://stackoverflow.com/questions/11947037/what-is-an-ube
 The uber jar will be found in ${BLUEFLOOD_DIR}/blueflood-all/target/blueflood-all-${VERSION}-jar-with-dependencies.jar.
 This jar contains all the dependencies necessary to run Blueflood with a very simple classpath.
 
+Build a docker image:
+
+    mvn clean package  docker:build -Pall-modules
+
 ### Running
 
 The best place to start is the [10 minute guide](https://github.com/rackerlabs/blueflood/wiki/10-Minute-Guide).

--- a/blueflood-all/pom.xml
+++ b/blueflood-all/pom.xml
@@ -15,6 +15,10 @@
   <artifactId>blueflood-all</artifactId>
   <packaging>jar</packaging>
 
+  <properties>
+    <main.basedir>${project.parent.basedir}</main.basedir>
+  </properties>
+
 
   <build>
     <plugins>
@@ -41,6 +45,38 @@
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
+        </configuration>
+      </plugin>
+
+      <!-- docker build -->
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <skipDocker>false</skipDocker>
+          <imageName>rackerlabs/blueflood</imageName>
+          <dockerDirectory>${main.basedir}/contrib/blueflood-docker</dockerDirectory>
+          <resources>
+            <resource>
+              <targetPath>/artifacts</targetPath>
+              <directory>${project.build.directory}</directory>
+              <include>${project.build.finalName}-jar-with-dependencies.jar</include>
+            </resource>
+            <resource>
+              <targetPath>/ES-Setup</targetPath>
+              <directory>${main.basedir}/blueflood-elasticsearch/src/main/resources</directory>
+              <include>*</include>
+            </resource>
+            <resource>
+              <targetPath>/</targetPath>
+              <directory>${main.basedir}/src/cassandra/cli</directory>
+              <include>load.cdl</include>
+            </resource>
+          </resources>
+          <imageTags>
+            <imageTag>${project.version}</imageTag>
+            <imageTag>latest</imageTag>
+          </imageTags>
         </configuration>
       </plugin>
     </plugins>

--- a/contrib/blueflood-docker/Dockerfile
+++ b/contrib/blueflood-docker/Dockerfile
@@ -13,8 +13,7 @@ COPY ES-Setup /ES-Setup
 COPY load.cdl /blueflood.cdl
 
 COPY artifacts /
-RUN (ls blueflood-all-*.jar | sed "s|blueflood-all-\(.*\)-jar-with-dependencies.jar|\1|") >> BLUEFLOOD_VERSION
-RUN mv blueflood-all-*-jar-with-dependencies.jar blueflood-all-jar-with-dependencies.jar
+RUN ln -s blueflood-all-*-jar-with-dependencies.jar blueflood-all-jar-with-dependencies.jar
 
 ENV MAX_ROLLUP_THREADS=20
 ENV MAX_TIMEOUT_WHEN_EXHAUSTED=2000

--- a/contrib/blueflood-docker/Dockerfile
+++ b/contrib/blueflood-docker/Dockerfile
@@ -9,12 +9,12 @@ RUN apt-get install -y python python-dev python-pip python-virtualenv && \
     rm -rf /var/lib/apt/lists/*
 RUN pip install cqlsh==4.1.1
 
-RUN git clone https://github.com/rackerlabs/blueflood.git
-RUN mv ./blueflood/blueflood-elasticsearch/src/main/resources ./ES-Setup
-RUN mv ./blueflood/src/cassandra/cli/load.cdl ./blueflood.cdl
-RUN rm -r ./blueflood
+COPY ES-Setup /ES-Setup
+COPY load.cdl /blueflood.cdl
 
-RUN curl -s -L https://github.com/rackerlabs/blueflood/releases/latest | egrep -o 'rackerlabs/blueflood/releases/download/rax-release-.*/blueflood-all-.*-jar-with-dependencies.jar' |  xargs -I % curl -C - -L https://github.com/% --create-dirs -o ./blueflood-all-2.0.0-SNAPSHOT-jar-with-dependencies.jar
+COPY artifacts /
+RUN (ls blueflood-all-*.jar | sed "s|blueflood-all-\(.*\)-jar-with-dependencies.jar|\1|") >> BLUEFLOOD_VERSION
+RUN mv blueflood-all-*-jar-with-dependencies.jar blueflood-all-jar-with-dependencies.jar
 
 ENV MAX_ROLLUP_THREADS=20
 ENV MAX_TIMEOUT_WHEN_EXHAUSTED=2000

--- a/contrib/blueflood-docker/docker-entrypoint.sh
+++ b/contrib/blueflood-docker/docker-entrypoint.sh
@@ -93,4 +93,4 @@ EOL
         -Dcom.sun.management.jmxremote.ssl=false \
         -Djava.rmi.server.hostname=localhost \
         -Dcom.sun.management.jmxremote.port=9180 \
-        -classpath blueflood-all-2.0.0-SNAPSHOT-jar-with-dependencies.jar com.rackspacecloud.blueflood.service.BluefloodServiceStarter 2>&1
+        -classpath blueflood-all-jar-with-dependencies.jar com.rackspacecloud.blueflood.service.BluefloodServiceStarter 2>&1

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
   <url>http://blueflood.io</url>
 
   <properties>
+    <main.basedir>${project.basedir}</main.basedir>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <!-- Used to locate the profile specific configuration file. -->
     <build.profile.id>dev</build.profile.id>
@@ -105,6 +106,14 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.19.1</version>
+        </plugin>
+        <plugin>
+          <groupId>com.spotify</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>0.4.13</version>
+          <configuration>
+            <skipDocker>true</skipDocker>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
The current Docker build has several problems:
- it depends on a blueflood release jar hosted on github to make a docker image. This makes it impossible to checkout any blueflood branch/tag and create a docker image out of it.
- it downloads the latest version of the Blueflood code from github. Because of this you can't have a reliable reproducible build.
- version numbers/urls need to be updated for every release in the Dockerfile and docker-entrypoint.sh, which is prone to mistakes.

This PR solves these issues by integrating the docker build into the Maven build. Basically it allows you to build a docker image of any branch/tag by executing the following command:
```
mvn clean package  docker:build -Pall-modules
```

This results in a docker image with two tags: 'latest' and the version of the maven project

The Dockerfile copies the jar which is the result of the package command into the Docker image, together with the other required files (such as ES-Setup, load.cdl). These changes make it independent from any outside resources such as github.