### PR TITLE
allowing hyphens and underscores in cassandra hostnames

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/BluefloodServiceStarter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/BluefloodServiceStarter.java
@@ -46,7 +46,7 @@ public class BluefloodServiceStarter {
             throw new BluefloodServiceStarterException(-1, "No cassandra hosts found in configuration option 'CASSANDRA_HOSTS'");
         }
         for (String host : hosts.split(",")) {
-            if (!host.matches("[\\d\\w\\.]+:\\d+")) {
+            if (!host.matches("[\\d\\w\\.\\-_]+:\\d+")) {
                 log.error("Invalid Cassandra host found in Configuration option 'CASSANDRA_HOSTS' -- Should be of the form <hostname>:<port>");
                 throw new BluefloodServiceStarterException(-1, "Invalid Cassandra host found in Configuration option 'CASSANDRA_HOSTS' -- Should be of the form <hostname>:<port>");
             }

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/BluefloodServiceStarterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/service/BluefloodServiceStarterTest.java
@@ -95,6 +95,34 @@ public class BluefloodServiceStarterTest {
         // exception was thrown
     }
 
+    @Test
+    public void testCassandraHostWithHyphenSucceedsValidation() {
+
+        // given
+        Configuration config = Configuration.getInstance();
+        config.setProperty(CoreConfig.CASSANDRA_HOSTS, "my-hostname:9160");
+
+        // when
+        BluefloodServiceStarter.validateCassandraHosts();
+
+        // then
+        // no exception was thrown
+    }
+
+    @Test
+    public void testCassandraHostWithUnderscoreSucceedsValidation() {
+
+        // given
+        Configuration config = Configuration.getInstance();
+        config.setProperty(CoreConfig.CASSANDRA_HOSTS, "my_hostname:9160");
+
+        // when
+        BluefloodServiceStarter.validateCassandraHosts();
+
+        // then
+        // no exception was thrown
+    }
+
     @Test(expected = BluefloodServiceStarterException.class)
     public void testIngestModeEnabledWithoutModules() {
 


### PR DESCRIPTION
Currently Cassandra hostnames with hyphens or underscores in them are not supported because the validation mechanism uses the following regex: "[\\d\\w\\.]+:\\d+"

This PR solves this by also including these characters in the regex.