### PR TITLE
MAX_ROLLUP_THREADS cleanup

### DIFF
--- a/blueflood-core/src/main/resources/configDefaults/blueflood.properties
+++ b/blueflood-core/src/main/resources/configDefaults/blueflood.properties
@@ -10,7 +10,8 @@ INGESTION_MODULES=
 QUERY_MODULES=
 DISCOVERY_MODULES=
 
-MAX_ROLLUP_THREADS=20
+MAX_ROLLUP_READ_THREADS=20
+MAX_ROLLUP_WRITE_THREADS=5
 # Maximum timeout waiting on exhausted connection pools in milliseconds.
 # Maps directly to Astyanax's ConnectionPoolConfiguration.setMaxTimeoutWhenExhausted
 MAX_TIMEOUT_WHEN_EXHAUSTED=2000

--- a/contrib/blueflood-docker/Dockerfile
+++ b/contrib/blueflood-docker/Dockerfile
@@ -15,7 +15,8 @@ COPY load.cdl /blueflood.cdl
 COPY artifacts /
 RUN ln -s blueflood-all-*-jar-with-dependencies.jar blueflood-all-jar-with-dependencies.jar
 
-ENV MAX_ROLLUP_THREADS=20
+ENV MAX_ROLLUP_READ_THREADS=20
+ENV MAX_ROLLUP_WRITE_THREADS=5
 ENV MAX_TIMEOUT_WHEN_EXHAUSTED=2000
 ENV SCHEDULE_POLL_PERIOD=60000
 ENV CONFIG_REFRESH_PERIOD=10000

--- a/contrib/blueflood-docker/README.md
+++ b/contrib/blueflood-docker/README.md
@@ -18,7 +18,8 @@ Here's the list of ENV variables and their description.
 | ----- | ------- | --------- |
 | CASSANDRA_HOST | IP address of Cassandra seed. (Required) | null |
 | ELASTICSEARCH_HOST | IP address of Elasticsearch node. (Required) | null |
-| MAX_ROLLUP_THREADS | Maximum number of threads participating in rolling up the metrics | 20 |
+| MAX_ROLLUP_READ_THREADS | Maximum number of read threads participating in rolling up the metrics | 20 |
+| MAX_ROLLUP_WRITE_THREADS | Maximum number of write threads participating in rolling up the metrics | 5 |
 | MAX_CASSANDRA_CONNECTIONS | Maximum number of connections with each Cassandra node | 70 |
 | INGEST_MODE | Whether to start the Ingest service | true |
 | ROLLUP_MODE | Whether to start the Rollup service | true |

--- a/demo/docker/config/blueflood.conf
+++ b/demo/docker/config/blueflood.conf
@@ -7,7 +7,8 @@ CLUSTER_NAME=TEST\u0020CLUSTER
 
 # limits the maximum number of concurrent rollups that can be taking place. This number will vary, but should be
 # kept reasonable. (values as high as 200 are not unreasonable, given suitable hardware.)
-MAX_ROLLUP_THREADS=100
+MAX_ROLLUP_READ_THREADS=100
+MAX_ROLLUP_WRITE_THREADS=25
 MAX_CASSANDRA_CONNECTIONS=128
 MAX_TIMEOUT_WHEN_EXHAUSTED=1
 
@@ -15,7 +16,7 @@ MAX_TIMEOUT_WHEN_EXHAUSTED=1
 SCHEDULE_POLL_PERIOD=5000
 
 # if you find your system getting behind, but cores are not being fully utilized, follow this procedure:
-# 1. if RollupServiceMBean.getQueuedRollupCount() is big, you need to increase MAX_ROLLUP_THREADS.
+# 1. if RollupServiceMBean.getQueuedRollupCount() is big, you need to increase MAX_ROLLUP_READ_THREADS and/or MAX_ROLLUP_WRITE_THREADS.
 
 # identifies which data shards this node is responsible for. Value values are:
 # 1. "ALL" indicates this node is responsible for rolling up all shards.

--- a/demo/local/config/blueflood.conf
+++ b/demo/local/config/blueflood.conf
@@ -13,7 +13,8 @@ INGESTION_MODULES=com.rackspacecloud.blueflood.service.HttpIngestionService
 DISCOVERY_MODULES=com.rackspacecloud.blueflood.io.ElasticIO
 EVENTS_MODULES=com.rackspacecloud.blueflood.io.EventElasticSearchIO
 
-MAX_ROLLUP_THREADS=20
+MAX_ROLLUP_READ_THREADS=20
+MAX_ROLLUP_WRITE_THREADS=5
 # Maximum timeout waiting on exhausted connection pools in milliseconds.
 # Maps directly to Astyanax's ConnectionPoolConfiguration.setMaxTimeoutWhenExhausted
 MAX_TIMEOUT_WHEN_EXHAUSTED=2000


### PR DESCRIPTION
I noticed that the MAX_ROLLUP_THREADS configuration variable is still present in several places, even though it has been replaced with MAX_ROLLUP_READ_THREADS and MAX_ROLLUP_WRITE_THREADS since rax-release-v1.0.1956.
Therefore I've changed these occurrences with the new variants. You might want to verify the default values though as I don't have much experience with them, I've used the same values as in CoreConfig.java