### PR TITLE
allowing to configure the Cassandra datacenter name

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IOConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IOConfig.java
@@ -62,6 +62,14 @@ public class IOConfig {
     }
 
     /**
+     * Retrieves the datacenter location as known by Cassandra.
+     * @return name of the datacenter
+     */
+    public String getDatacenterName() {
+        return config.getStringProperty(CoreConfig.CASSANDRA_LOCAL_DATACENTER_NAME);
+    }
+
+    /**
      * Retrieves a set of unique Cassandra hosts with Binary Transport protocol
      * enabled from configuration file as a set of {@link java.net.InetSocketAddress}
      * objects.

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxIO.java
@@ -57,7 +57,7 @@ public class DatastaxIO {
         CodecRegistry codecRegistry = new CodecRegistry();
 
         cluster = Cluster.builder()
-                .withLoadBalancingPolicy(new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().withLocalDc("datacenter1").build(), false))
+                .withLoadBalancingPolicy(new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().withLocalDc(ioconfig.getDatacenterName()).build(), false))
                 .withPoolingOptions(getPoolingOptions(dbHosts.size()))
                 .withCodecRegistry(codecRegistry)
                 .withSocketOptions(getSocketOptions())

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -24,6 +24,7 @@ public enum CoreConfig implements ConfigDefaults {
     DEFAULT_CASSANDRA_PORT("19180"),
     CASSANDRA_BINXPORT_HOSTS("localhost:9042"),
     CASSANDRA_BINXPORT_PORT("9042"),
+    CASSANDRA_LOCAL_DATACENTER_NAME("datacenter1"),
 
     // This number is only accurate if MAX_CASSANDRA_CONNECTIONS
     // is evenly divisible by number of hosts. For its connection


### PR DESCRIPTION
Currently the Cassandra datacenter name is hardcoded with no option to change this. This PR changes this by adding an overridable "CASSANDRA_LOCAL_DATACENTER_NAME" variable.