### PR TITLE
docker: allow keyspace name override

### DIFF
--- a/contrib/blueflood-docker/docker-entrypoint.sh
+++ b/contrib/blueflood-docker/docker-entrypoint.sh
@@ -40,6 +40,11 @@ done
 export CASSANDRA_HOSTS="$CASSANDRA_HOST:9160"
 export CASSANDRA_BINXPORT_HOSTS="$CASSANDRA_HOST:9042"
 
+if [ $ROLLUP_KEYSPACE != "DATA" ]
+then
+    sed -i "s/\"DATA\"/\"$ROLLUP_KEYSPACE\"/g" blueflood.cdl
+fi
+
 cqlsh $CASSANDRA_HOST -f blueflood.cdl
 
 ######## Connecting to Elasticsearch #######


### PR DESCRIPTION
Currently Blueflood allows overriding the name of the Cassandra keyspace with the 'ROLLUP_KEYSPACE' variable (which defaults to 'DATA'). While the Docker container currently also accepts this environment variable and it gets provided to Blueflood itself, it isn't taken into account when initially creating the Cassandra keyspace and tables, therefore Cassandra still gets initialized with a keyspace called 'DATA' even when providing a different keyspace name.

This PR solves this issue by modifying the CQL script at startup time when it detects a different keyspace name.