### PR TITLE
elasticsearch init script: add mechanism to avoid a reset of the indexes

### DIFF
--- a/contrib/blueflood-docker/docker-entrypoint.sh
+++ b/contrib/blueflood-docker/docker-entrypoint.sh
@@ -71,7 +71,7 @@ done
 export ELASTICSEARCH_HOSTS="$ELASTICSEARCH_HOST:9300"
 
 cd ES-Setup
-./init-es.sh -u $ELASTICSEARCH_HOST:9200
+./init-es.sh -u $ELASTICSEARCH_HOST:9200 -r false
 cd ..
 
 printenv > blueflood.conf


### PR DESCRIPTION
Currently the init-es.sh script always deletes old indexes before setting up the new elasticsearch configuration. This is problematic when running Blueflood in a Docker container, because the container runs this script on startup. So on a container restart or when upscaling the cluster, it resets all the data in ES.

This PR solves this issue by adding a new -r (reset) command line option to the init-es.sh script, which by default is true (to keep the current default behaviour). When a value of 'false' is provided to the reset option, it will skip (instead of reset and re-initialise) the initialisation process when Blueflood has already been initialised in ES.
A 'marker' index is created in ES to indicate the Blueflood configuration has been initialised.

This new '-r false' option is provided to the init-es.sh script when starting up the Docker container.