### PR TITLE
update cassandra-maven-plugin to v 2.1.7-1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 install: true
 
 script: 
-  - mvn clean install -Pcassandra-2.0 -Dmaven.javadoc.skip --quiet
+  - mvn clean install -Dmaven.javadoc.skip --quiet
 
 after_success:
   - mvn package -P all-modules dependency:resolve -Dmaven.test.skip -Dmaven.javadoc.skip -Dcassandra.skip

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # CHANGES
 
 ## IN PROGRESS
+* Updated to using cassandra-maven-plugin v2.1.7-1
 * Removed String and Boolean support
 * Removed caching of metrics Type in metrics_metadata Column Family and MetadataCache
 * Closed idle connection with no inbound traffic after HTTP_CONNECTION_READ_IDLE_TIME_SECONDS  

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <!-- Used to locate the profile specific configuration file. -->
     <build.profile.id>dev</build.profile.id>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cassandra.plugin.version>2.0.0-1</cassandra.plugin.version>
+    <cassandra.plugin.version>2.1.7-1</cassandra.plugin.version>
     <cassandra.listenAddress>127.0.0.1</cassandra.listenAddress>
     <cassandra.skip>true</cassandra.skip>
     <skip.integration.tests>false</skip.integration.tests>
@@ -270,6 +270,8 @@
           <cassandraDir>/tmp/bf-cassandra-${cassandra.plugin.version}-${maven.build.timestamp}/</cassandraDir>
           <loadFailureIgnore>false</loadFailureIgnore>
           <startNativeTransport>true</startNativeTransport>
+          <script>${project.basedir}/src/cassandra/cli/load.cdl</script>
+          <cqlVersion>3.0.0</cqlVersion>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
This updates the integration tests to use cassandra-maven-plugin 2.1.7, thus running the tests under Cassandra 2.1.7