### PR TITLE
remove log.error() on cases where it's not really system error

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedIngestionHandler.java
@@ -108,11 +108,9 @@ public class HttpAggregatedIngestionHandler implements HttpRequestHandler {
             }
         } catch (JsonParseException ex) {
             log.debug(String.format("BAD JSON: %s", body));
-            log.error(ex.getMessage(), ex);
             DefaultHandler.sendErrorResponse(ctx, request, ex.getMessage(), HttpResponseStatus.BAD_REQUEST);
         } catch (InvalidDataException ex) {
             log.debug(String.format("Invalid request body: %s", body));
-            log.error(ex.getMessage(), ex);
             DefaultHandler.sendErrorResponse(ctx, request, ex.getMessage(), HttpResponseStatus.BAD_REQUEST);
         } catch (TimeoutException ex) {
             DefaultHandler.sendErrorResponse(ctx, request, "Timed out persisting metrics", HttpResponseStatus.ACCEPTED);

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAggregatedMultiIngestionHandler.java
@@ -139,16 +139,14 @@ public class HttpAggregatedMultiIngestionHandler implements HttpRequestHandler {
             }
         } catch (JsonParseException ex) {
             log.debug(String.format("BAD JSON: %s", body));
-            log.error(ex.getMessage(), ex);
             DefaultHandler.sendErrorResponse(ctx, request, ex.getMessage(), HttpResponseStatus.BAD_REQUEST);
         } catch (InvalidDataException ex) {
             log.debug(String.format("Invalid request body: %s", body));
-            log.error(ex.getMessage(), ex);
             DefaultHandler.sendErrorResponse(ctx, request, ex.getMessage(), HttpResponseStatus.BAD_REQUEST);
         } catch (TimeoutException ex) {
             DefaultHandler.sendErrorResponse(ctx, request, "Timed out persisting metrics", HttpResponseStatus.ACCEPTED);
         } catch (Exception ex) {
-            log.debug(String.format("BAD JSON: %s", body));
+            log.debug(String.format("Exception processing: %s", body));
             log.error("Other exception while trying to parse content", ex);
             DefaultHandler.sendErrorResponse(ctx, request, "Internal error saving data", HttpResponseStatus.INTERNAL_SERVER_ERROR);
         } finally {


### PR DESCRIPTION
remove calls to log.error() as an invalid user input should not be considered an error 