### PR TITLE
add logic to send back Keep-Alive header if httpConnectionIdleTimeout is non zero

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/DefaultHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/DefaultHandler.java
@@ -43,9 +43,11 @@ public class DefaultHandler implements HttpRequestHandler {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultHandler.class);
 
+    private static final HttpResponder responder = HttpResponder.getInstance();
+
     @Override
     public void handle(ChannelHandlerContext ctx, FullHttpRequest request) {
-        HttpResponder.respond(ctx, request, HttpResponseStatus.OK);
+        responder.respond(ctx, request, HttpResponseStatus.OK);
     }
 
     public static void sendErrorResponse(ChannelHandlerContext ctx, FullHttpRequest request,
@@ -98,7 +100,7 @@ public class DefaultHandler implements HttpRequestHandler {
                 response.content().writeBytes(Unpooled.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
             }
 
-            HttpResponder.respond(channel, request, response);
+            responder.respond(channel, request, response);
             Tracker.getInstance().trackResponse(request, response);
         } finally {
             sendResponseTimerContext.stop();

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/HttpResponder.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/HttpResponder.java
@@ -37,6 +37,7 @@ public class HttpResponder {
 
     private static final boolean CORS_ENABLED = Configuration.getInstance().getBooleanProperty(CoreConfig.CORS_ENABLED);
     private static final String CORS_ALLOWED_ORIGINS = Configuration.getInstance().getStringProperty(CoreConfig.CORS_ALLOWED_ORIGINS);
+    private static final String KEEP_ALIVE_TIMEOUT_STR = "timeout=";
 
     private static final Logger log = LoggerFactory.getLogger(HttpResponder.class);
 
@@ -70,17 +71,15 @@ public class HttpResponder {
             setContentLength(res, res.content().readableBytes());
         }
 
-        boolean isKeepAlive = false;
-        // if this config is set to non zero, it means we intend
-        // to close this connection after x seconds. We need to
-        // respond back with the right header to indicate this
-        if ( httpConnIdleTimeout >0 ) {
-            res.headers().add(CONNECTION, CLOSE);
-            res.headers().add(KEEP_ALIVE, "timeout="+httpConnIdleTimeout);
-        } else {
-            isKeepAlive = isKeepAlive(req);
-            if (isKeepAlive) {
-                res.headers().add(CONNECTION, KEEP_ALIVE);
+        boolean isKeepAlive = isKeepAlive(req);
+        if (isKeepAlive) {
+            res.headers().add(CONNECTION, KEEP_ALIVE);
+
+            // if this config is set to non zero, it means we intend
+            // to close this connection after x seconds. We need to
+            // respond back with the right headers to indicate this
+            if ( httpConnIdleTimeout > 0 ) {
+                res.headers().add(KEEP_ALIVE, KEEP_ALIVE_TIMEOUT_STR + httpConnIdleTimeout);
             }
         }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/HttpResponder.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/HttpResponder.java
@@ -16,15 +16,14 @@
 
 package com.rackspacecloud.blueflood.http;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.service.HttpConfig;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +40,26 @@ public class HttpResponder {
 
     private static final Logger log = LoggerFactory.getLogger(HttpResponder.class);
 
-    public static void respond(ChannelHandlerContext ctx, FullHttpRequest req, HttpResponseStatus status) {
+    private static HttpResponder INSTANCE = new HttpResponder();
+
+    public static HttpResponder getInstance() { return INSTANCE; }
+
+    private int httpConnIdleTimeout =
+            Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_CONNECTION_READ_IDLE_TIME_SECONDS);
+
+    @VisibleForTesting
+    HttpResponder() {}
+
+    @VisibleForTesting
+    HttpResponder(int httpConnIdleTimeout) {
+        this.httpConnIdleTimeout = httpConnIdleTimeout;
+    }
+
+    public void respond(ChannelHandlerContext ctx, FullHttpRequest req, HttpResponseStatus status) {
         respond(ctx, req, new DefaultFullHttpResponse(HTTP_1_1, status));
     }
 
-    public static void respond(ChannelHandlerContext ctx, FullHttpRequest req, FullHttpResponse res) {
+    public void respond(ChannelHandlerContext ctx, FullHttpRequest req, FullHttpResponse res) {
 
         // set response headers
         if (CORS_ENABLED) {
@@ -56,9 +70,18 @@ public class HttpResponder {
             setContentLength(res, res.content().readableBytes());
         }
 
-        boolean isKeepAlive = isKeepAlive(req);
-        if (isKeepAlive) {
-            res.headers().add(CONNECTION, KEEP_ALIVE);
+        boolean isKeepAlive = false;
+        // if this config is set to non zero, it means we intend
+        // to close this connection after x seconds. We need to
+        // respond back with the right header to indicate this
+        if ( httpConnIdleTimeout >0 ) {
+            res.headers().add(CONNECTION, CLOSE);
+            res.headers().add(KEEP_ALIVE, "timeout="+httpConnIdleTimeout);
+        } else {
+            isKeepAlive = isKeepAlive(req);
+            if (isKeepAlive) {
+                res.headers().add(CONNECTION, KEEP_ALIVE);
+            }
         }
 
         // Send the response and close the connection if necessary.

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/NoRouteHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/NoRouteHandler.java
@@ -24,6 +24,6 @@ public class NoRouteHandler implements HttpRequestHandler {
 
     @Override
     public void handle(ChannelHandlerContext context, FullHttpRequest request) {
-        HttpResponder.respond(context, request, HttpResponseStatus.NOT_FOUND);
+        HttpResponder.getInstance().respond(context, request, HttpResponseStatus.NOT_FOUND);
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/QueryStringDecoderAndRouter.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/QueryStringDecoderAndRouter.java
@@ -79,7 +79,7 @@ public class QueryStringDecoderAndRouter extends SimpleChannelInboundHandler<Ful
         if (thr.getCause() instanceof TooLongFrameException) {
             // todo: meter these so we observe DOS conditions.
             log.warn(String.format("Long frame from %s", ctx.channel().remoteAddress()));
-            HttpResponder.respond(ctx, null, HttpResponseStatus.BAD_REQUEST);
+            HttpResponder.getInstance().respond(ctx, null, HttpResponseStatus.BAD_REQUEST);
         } else {
             log.warn(String.format("Exception event received from %s: ", ctx.channel().remoteAddress()), thr);
         }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/UnsupportedMethodHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/UnsupportedMethodHandler.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http.*;
 import java.util.Set;
 
 public class UnsupportedMethodHandler implements HttpRequestHandler {
+
     private final RouteMatcher routeMatcher;
     private final FullHttpResponse response;
 
@@ -41,6 +42,6 @@ public class UnsupportedMethodHandler implements HttpRequestHandler {
         }
         final String methodsAllowed =  result.length() > 0 ? result.substring(0, result.length() - 1): "";
         response.headers().add("Allow", methodsAllowed);
-        HttpResponder.respond(context, request, response);
+        HttpResponder.getInstance().respond(context, request, response);
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/UnsupportedVerbsHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/http/UnsupportedVerbsHandler.java
@@ -24,6 +24,6 @@ public class UnsupportedVerbsHandler implements HttpRequestHandler {
 
     @Override
     public void handle(ChannelHandlerContext ctx, FullHttpRequest request) {
-        HttpResponder.respond(ctx, request, HttpResponseStatus.NOT_IMPLEMENTED);
+        HttpResponder.getInstance().respond(ctx, request, HttpResponseStatus.NOT_IMPLEMENTED);
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricTokensHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricTokensHandler.java
@@ -79,7 +79,7 @@ public class HttpMetricTokensHandler implements HttpRequestHandler {
             response.content().writeBytes(Unpooled.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
 
-        HttpResponder.respond(channel, request, response);
+        HttpResponder.getInstance().respond(channel, request, response);
         Tracker.getInstance().trackResponse(request, response);
     }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
@@ -67,7 +67,7 @@ public class HttpMetricsIndexHandler implements HttpRequestHandler {
             response.content().writeBytes(Unpooled.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
 
-        HttpResponder.respond(channel, request, response);
+        HttpResponder.getInstance().respond(channel, request, response);
         Tracker.getInstance().trackResponse(request, response);
     }
 

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandler.java
@@ -159,7 +159,7 @@ public class HttpMultiRollupsQueryHandler extends RollupHandler implements HttpR
             response.content().writeBytes(Unpooled.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
 
-        HttpResponder.respond(channel, request, response);
+        HttpResponder.getInstance().respond(channel, request, response);
         Tracker.getInstance().trackResponse(request, response);
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandler.java
@@ -169,7 +169,7 @@ public class HttpRollupsQueryHandler extends RollupHandler
             response.content().writeBytes(Unpooled.copiedBuffer(messageBody, Constants.DEFAULT_CHARSET));
         }
 
-        HttpResponder.respond(channel, request, response);
+        HttpResponder.getInstance().respond(channel, request, response);
         Tracker.getInstance().trackResponse(request, response);
     }
 }

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpConfig.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpConfig.java
@@ -62,7 +62,7 @@ public enum HttpConfig implements ConfigDefaults {
     HTTP_MAX_TYPE_UNIT_PROCESSOR_THREADS("10"),
 
     // Idle time allowed on a connection, with no inbound traffic, before closing the connection. Specify 0 to disable.
-    HTTP_CONNECTION_READ_IDLE_TIME_SECONDS("120");
+    HTTP_CONNECTION_READ_IDLE_TIME_SECONDS("0");
 
     static {
         Configuration.getInstance().loadDefaults(HttpConfig.values());

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/http/HttpResponderTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/http/HttpResponderTest.java
@@ -1,0 +1,69 @@
+package com.rackspacecloud.blueflood.http;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ *
+ */
+public class HttpResponderTest {
+
+    @Test
+    public void testDefaultHttpConnIdleTimeout_RequestKeepAlive_ShouldHaveResponseKeepAlive() {
+        HttpResponder responder = new HttpResponder();
+
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        FullHttpRequest request = mock(FullHttpRequest.class);
+        FullHttpResponse response = mock(FullHttpResponse.class);
+        HttpHeaders headers = mock(HttpHeaders.class);
+        Channel channel = mock(Channel.class);
+
+        when(ctx.channel()).thenReturn(channel);
+
+        when(request.content()).thenReturn(null);
+        when(request.headers()).thenReturn(headers);
+        when(headers.get(HttpHeaders.Names.CONNECTION)).thenReturn(HttpHeaders.Values.KEEP_ALIVE);
+        when(request.getProtocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
+
+        HttpHeaders responseHeaders = new DefaultHttpHeaders();
+        when(response.headers()).thenReturn(responseHeaders);
+
+        responder.respond(ctx, request, response);
+
+        assertEquals("Connection: response header", HttpHeaders.Values.KEEP_ALIVE, responseHeaders.get(HttpHeaders.Names.CONNECTION));
+    }
+
+    @Test
+    public void testNonZeroHttpConnIdleTimeout_RequestKeepAlive_ShouldHaveResponseKeepAliveTimeout() {
+        int idleTimeout = 300;
+        HttpResponder responder = new HttpResponder(idleTimeout);
+
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        FullHttpRequest request = mock(FullHttpRequest.class);
+        FullHttpResponse response = mock(FullHttpResponse.class);
+        HttpHeaders headers = mock(HttpHeaders.class);
+        Channel channel = mock(Channel.class);
+        ChannelFuture future = mock(ChannelFuture.class);
+
+        when(ctx.channel()).thenReturn(channel);
+        when(ctx.writeAndFlush(any())).thenReturn(future);
+
+        when(request.content()).thenReturn(null);
+        when(request.headers()).thenReturn(headers);
+        when(headers.get(HttpHeaders.Names.CONNECTION)).thenReturn(HttpHeaders.Values.KEEP_ALIVE);
+        when(request.getProtocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
+
+        HttpHeaders responseHeaders = new DefaultHttpHeaders();
+        when(response.headers()).thenReturn(responseHeaders);
+
+        responder.respond(ctx, request, response);
+
+        assertEquals("Connection: response header", HttpHeaders.Values.KEEP_ALIVE, responseHeaders.get(HttpHeaders.Names.CONNECTION));
+        assertEquals("Keep-Alive: response header", "timeout="+idleTimeout, responseHeaders.get("Keep-Alive"));
+    }
+}


### PR DESCRIPTION
Blueflood introduced a configuration setting HTTP_CONNECTION_READ_IDLE_TIME_SECONDS that controls how long Blueflood waits before closing idle connections. Setting this to zero effectively disables it.

When this property is set to non zero value x, however, Blueflood sends back ```Connection: keep-alive``` header if the request has that same header sent. But we close the connections after x seconds.

This PR changes that behavior. If the property is set to non zero value x, the new behavior is now to send back additional ```Keep-Alive: timeout=x``` header.

Other changes are
* refactored HttpResponder so I can add unit tests
* added unit tests
* changed the default value of HTTP_CONNECTION_READ_IDLE_TIME_SECONDS to 0 (essentially disable it)

Reference:
https://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#Connection