### PR TITLE
Removing check for empty tokens

### DIFF
--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/TokenTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/types/TokenTest.java
@@ -69,7 +69,6 @@ public class TokenTest {
                 tenantID + ":" + "a.b.c.d:$"};
 
         List<Token> tokens = Token.getTokens(locator);
-        tokens.forEach(System.out::println);
 
         verifyTokenInfos(tenantID, expectedTokens, expectedParents, expectedIds, tokens);
     }
@@ -86,6 +85,37 @@ public class TokenTest {
         String[] expectedIds = new String[] {tenantID + ":" + "a:$"};
 
         List<Token> tokens = Token.getTokens(locator);
+        verifyTokenInfos(tenantID, expectedTokens, expectedParents, expectedIds, tokens);
+    }
+
+    @Test
+    public void testGetTokensWithEmptyTokenInBetween() {
+
+        String tenantID = "111111";
+        String metricName = "ingest00.HeaderNormalization.header-normalization..*_GET.count";
+        Locator locator = Locator.createLocatorFromPathComponents(tenantID, metricName);
+
+
+        String[] expectedTokens = new String[] {"ingest00", "HeaderNormalization", "header-normalization", "", "*_GET", "count"};
+
+        String[] expectedParents = new String[] {
+                "",
+                "ingest00",
+                "ingest00.HeaderNormalization",
+                "ingest00.HeaderNormalization.header-normalization",
+                "ingest00.HeaderNormalization.header-normalization.",
+                "ingest00.HeaderNormalization.header-normalization..*_GET"};
+
+        String[] expectedIds = new String[] {
+                tenantID + ":" + "ingest00",
+                tenantID + ":" + "ingest00.HeaderNormalization",
+                tenantID + ":" + "ingest00.HeaderNormalization.header-normalization",
+                tenantID + ":" + "ingest00.HeaderNormalization.header-normalization.",
+                tenantID + ":" + "ingest00.HeaderNormalization.header-normalization..*_GET",
+                tenantID + ":" + "ingest00.HeaderNormalization.header-normalization..*_GET.count:$"};
+
+        List<Token> tokens = Token.getTokens(locator);
+
         verifyTokenInfos(tenantID, expectedTokens, expectedParents, expectedIds, tokens);
     }
 

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticTokensIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticTokensIO.java
@@ -100,10 +100,6 @@ public class ElasticTokensIO implements TokenDiscoveryIO {
 
     IndexRequestBuilder createSingleRequest(Token token) throws IOException {
 
-        if (StringUtils.isEmpty(token.getToken())) {
-            throw new IllegalArgumentException("trying to insert token discovery without a token: " + token.getLocator());
-        }
-
         return client.prepareIndex(ELASTICSEARCH_TOKEN_INDEX_NAME_WRITE, ES_DOCUMENT_TYPE)
                 .setId(token.getId())
                 .setSource(createSourceContent(token))


### PR DESCRIPTION
I have noticed that we are getting locators like this

ingest00.iad.prod.bf.k1k.me-org.openrepose.core.filters.HeaderNormalization.header-normalization..*_GET.count

Notice how the metric name as tokens which are empty. We had a condition to check if token is not empty before inserting data. As there is a possibility of empty token, I removed that check and made sure we still index documents appropriately. 