### PR TITLE
Code fix for a bug to handle leaf queries with no regex.

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticTokensIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticTokensIO.java
@@ -219,7 +219,7 @@ public class ElasticTokensIO implements TokenDiscoveryIO {
             if (pattern.hasWildcard()) {
                 tokenQB = regexpQuery(ESFieldLabel.token.name(), pattern.compiled().toString());
             } else {
-                tokenQB = termQuery(ESFieldLabel.token.name(), query);
+                tokenQB = termQuery(ESFieldLabel.token.name(), lastToken);
             }
 
             bqb.must(tokenQB);

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticIOIntegrationTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticIOIntegrationTest.java
@@ -414,6 +414,26 @@ public class ElasticIOIntegrationTest extends BaseElasticTest {
     }
 
     @Test
+    @Parameters({"elasticIO", "elasticTokensIO"})
+    public void testGetMetricNamesWithoutWildCard(String type) throws Exception {
+        String tenantId = TENANT_A;
+        String query = "one.foo.three00.bar.baz";
+
+        createTestMetrics(tenantId, new HashSet<String>() {{
+            add("one.foo.three00.bar.baz");
+        }});
+
+        List<MetricName> results = getDiscoveryIO(type).getMetricNames(tenantId, query);
+
+        Set<String> expectedResults = new HashSet<String>() {{
+            add("one.foo.three00.bar.baz|true");
+        }};
+
+        assertEquals("Invalid total number of results", expectedResults.size(), results.size());
+        verifyResults(results, expectedResults);
+    }
+
+    @Test
     public void testRegexLevel0() {
         List<String> terms = Arrays.asList("foo", "bar", "baz", "foo.bar", "foo.bar.baz", "foo.bar.baz.aux");
 


### PR DESCRIPTION
For metric name foo.bar.baz.qux, if a metric_name/search API is used with query=foo.bar.baz.qux, I am forming the wrong ES query inside. This code is to fix that. I also added a test case to cover that scenario.

