### PR TITLE
add instrumentation to count ingested datapoints per tenant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # CHANGES
 
 ## IN PROGRESS
+* Added configuration option ENABLE_PER_TENANT_METRICS to enable recording per-tenant ingest metrics:
+  ** number of datapoints each tenant ingests
+  ** number of delayed datapoints each tenant ingests
 * Updated to using cassandra-maven-plugin v2.1.7-1
 * Removed String and Boolean support
 * Removed caching of metrics Type in metrics_metadata Column Family and MetadataCache

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainer.java
@@ -116,4 +116,18 @@ public class JSONMetricsContainer {
         return delayedMetrics;
     }
 
+    /**
+     * Returns the count of metrics with "delayed" timestamp.
+     *
+     * @return
+     */
+    public int getDelayedMetricsCount() { return delayedMetrics.size(); }
+
+    /**
+     * Returns the count of metrics with non-delayed timestamp.
+     *
+     * @return
+     */
+    public int getNonDelayedMetricsCount() { return validMetrics.size() - delayedMetrics.size();  }
+
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
@@ -19,6 +19,7 @@ package com.rackspacecloud.blueflood.io;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.datastax.shaded.netty.util.internal.StringUtil;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.netflix.astyanax.connectionpool.exceptions.PoolTimeoutException;
 import com.rackspacecloud.blueflood.utils.Metrics;
@@ -38,7 +39,6 @@ public class Instrumentation implements InstrumentationMBean {
     private static final Meter batchReadErrMeter;
 
     // One-off meters
-    private static final Meter scanAllColumnFamiliesMeter;
     private static final Meter allPoolsExhaustedException;
     private static final Meter fullResMetricWritten;
     private static final Meter fullResPreaggregatedMetricWritten;
@@ -50,7 +50,6 @@ public class Instrumentation implements InstrumentationMBean {
         writeErrMeter = Metrics.meter(kls, "writes", "Cassandra Write Errors");
         readErrMeter = Metrics.meter(kls, "reads", "Cassandra Read Errors");
         batchReadErrMeter = Metrics.meter(kls, "reads", "Batch Cassandra Read Errors");
-        scanAllColumnFamiliesMeter = Metrics.meter(kls, "Scan all ColumnFamilies");
         allPoolsExhaustedException = Metrics.meter(kls, "All Pools Exhausted");
         fullResMetricWritten = Metrics.meter(kls, "Full Resolution Metrics Written");
         fullResPreaggregatedMetricWritten = Metrics.meter(kls, "Full Resolution Preaggregated Metrics Written");
@@ -154,10 +153,6 @@ public class Instrumentation implements InstrumentationMBean {
 
     }
 
-    public static void markScanAllColumnFamilies() {
-        scanAllColumnFamiliesMeter.mark();
-    }
-
     public static void markFullResMetricWritten() {
         fullResMetricWritten.mark();
     }
@@ -172,5 +167,19 @@ public class Instrumentation implements InstrumentationMBean {
 
     public static void markMetricsWithLongDelayReceived() {
         metricsWithLongDelayReceived.mark();
+    }
+
+    public static Meter getIngestedMetricsMeter(String tenantId) {
+        if ( StringUtil.isNullOrEmpty(tenantId) ) {
+            return null;
+        }
+        return Metrics.meter(Instrumentation.class, "tenants", tenantId, "Data Points Ingested");
+    }
+
+    public static Meter getIngestedDelayedMetricsMeter(String tenantId) {
+        if ( StringUtil.isNullOrEmpty(tenantId) ) {
+            return null;
+        }
+        return Metrics.meter(Instrumentation.class, "tenants", tenantId, "Delayed Data Points Ingested");
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -182,6 +182,9 @@ public enum CoreConfig implements ConfigDefaults {
     //Feature to improve token search. Enabling this will persist metric name tokens separately.
     ENABLE_TOKEN_SEARCH_IMPROVEMENTS("false"),
 
+    //Count raw metrics ingested per tenant
+    ENABLE_PER_TENANT_METRICS("false"),
+
     // Cross-Origin Resource Sharing
     CORS_ENABLED("false"),
     CORS_ALLOWED_ORIGINS("*"),

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandler.java
@@ -34,6 +34,10 @@ public class HttpMultitenantMetricsIngestionHandler extends HttpMetricsIngestion
         super(processor, timeout);
     }
 
+    public HttpMultitenantMetricsIngestionHandler(HttpMetricsIngestionServer.Processor processor, TimeValue timeout, boolean enablePerTenantMetrics) {
+        super(processor, timeout, enablePerTenantMetrics);
+    }
+
     @Override
     protected JSONMetricsContainer createContainer(String body, String tenantId) throws JsonParseException, JsonMappingException, IOException {
         List<JSONMetric> jsonMetrics =

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/formats/JSONMetricsContainerTest.java
@@ -110,8 +110,10 @@ public class JSONMetricsContainerTest {
         // has a side-effect required by areDelayedMetricsPresent()
         List<Metric> metrics = container.getValidMetrics();
 
-        assertTrue( container.getValidationErrors().isEmpty() );
-        assertTrue(container.areDelayedMetricsPresent());
+        assertTrue("no metrics validation errors", container.getValidationErrors().isEmpty() );
+        assertTrue("delayed metrics are present", container.areDelayedMetricsPresent());
+        assertEquals("delayed metric count", 1, container.getDelayedMetricsCount());
+        assertEquals("non delayed metric count", 0, container.getNonDelayedMetricsCount());
     }
 
     @Test


### PR DESCRIPTION
This PR adds DropWizard Meters to count the number of ingested datapoints per tenant. There will be two meters for each tenant to count:
* number of normal (on time) metrics ingested
* number of delayed metrics ingested

The metrics are collected only if the configuration property ENABLE_PER_TENANT_METRICS is set to true (by default it's false).