### PR TITLE
Code changes to avoid return duplicates from metric_name search

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticTokensIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticTokensIO.java
@@ -143,6 +143,7 @@ public class ElasticTokensIO implements TokenDiscoveryIO {
 
         return Arrays.stream(response.getHits().getHits())
                      .map(this::convertHitToMetricNameResult)
+                     .distinct()
                      .collect(toList());
     }
 
@@ -254,7 +255,7 @@ public class ElasticTokensIO implements TokenDiscoveryIO {
             return queryRegex.replaceAll("\\.\\*", "[^.]*");
     }
 
-    private static XContentBuilder createSourceContent(Token token) throws IOException {
+    protected static XContentBuilder createSourceContent(Token token) throws IOException {
         XContentBuilder json;
 
         json = XContentFactory.jsonBuilder().startObject()


### PR DESCRIPTION
The metric_name/search API, sometimes returns duplicate data. This happens esp when the data is present in multiple indexes. Since we query from an alias in prod which points to multiple indexes this returns duplicate data as shown below. This is causing issues with grafana + blueflood integration. This PR addresses this issue by eliminating duplicates.

```
curl -XGET 'http://localhost:2500/v2.0/<tenantid>/metric_name/search?query=ord.instance_metrics.ord.a0001.xxxx.vif_0_rx'| python -m json.tool

[ 
    { "ord.instance_metrics.ord.a0001.xxxx.vif_0_rx": true },
    { "ord.instance_metrics.ord.a0001.xxxx.vif_0_rx": true }
]
```