### PR TITLE
use LOCAL_ONE consistency

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
@@ -57,14 +57,14 @@ public class Instrumentation implements InstrumentationMBean {
         metricsWithShortDelayReceived = Metrics.meter(kls, "Metrics with short delay received");
         metricsWithLongDelayReceived = Metrics.meter(kls, "Metrics with long delay received");
 
-            try {
-                final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-                final String name = String.format("com.rackspacecloud.blueflood.io:type=%s", Instrumentation.class.getSimpleName());
-                final ObjectName nameObj = new ObjectName(name);
-                mbs.registerMBean(new Instrumentation() { }, nameObj);
-            } catch (Exception exc) {
-                log.error("Unable to register mbean for " + Instrumentation.class.getSimpleName(), exc);
-            }
+        try {
+            final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            final String name = String.format("com.rackspacecloud.blueflood.io:type=%s", Instrumentation.class.getSimpleName());
+            final ObjectName nameObj = new ObjectName(name);
+            mbs.registerMBean(new Instrumentation() { }, nameObj);
+        } catch (Exception exc) {
+            log.error("Unable to register mbean for " + Instrumentation.class.getSimpleName(), exc);
+        }
     }
 
     private Instrumentation() {/* Used for JMX exposure */}

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
@@ -83,7 +83,6 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
         }
 
         Timer.Context ctx = Instrumentation.getWriteTimerContext( writeContexts.get( 0 ).getDestinationCF().getName() );
-
         try {
 
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicNumericIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DBasicNumericIO.java
@@ -1,6 +1,5 @@
 package com.rackspacecloud.blueflood.io.datastax;
 
-
 import com.rackspacecloud.blueflood.io.serializers.metrics.BasicRollupSerDes;
 import com.rackspacecloud.blueflood.types.*;
 
@@ -8,8 +7,8 @@ import java.nio.ByteBuffer;
 
 
 /**
- * This class holds the utility methods to read/write rolled up basic numeric values using
- * {@link com.rackspacecloud.blueflood.types.BasicRollup}.
+ * This class holds the utility methods to read/write rolled up basic numeric values in
+ * {@link com.rackspacecloud.blueflood.types.BasicRollup} using {@link BasicRollupSerDes}
  */
 public class DBasicNumericIO extends DAbstractMetricIO {
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DDelayedLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DDelayedLocatorIO.java
@@ -53,8 +53,7 @@ public class DDelayedLocatorIO implements DelayedLocatorIO {
                 .value(VALUE, bindMarker());
         putValue = DatastaxIO.getSession()
                 .prepare(insert)
-                .setConsistencyLevel( ConsistencyLevel.ONE );  // TODO: remove later; required by the cassandra-maven-plugin 2.0.0-1
-        // (see https://issues.apache.org/jira/browse/CASSANDRA-6238)
+                .setConsistencyLevel( ConsistencyLevel.LOCAL_ONE );
     }
 
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
@@ -82,9 +82,7 @@ public class DLocatorIO implements LocatorIO {
                 .value(VALUE, bindMarker());
         putValue = DatastaxIO.getSession()
                 .prepare(insert)
-                .setConsistencyLevel( ConsistencyLevel.ONE );  // TODO: remove later; required by the cassandra-maven-plugin 2.0.0-1
-                                                              // (see https://issues.apache.org/jira/browse/CASSANDRA-6238)
-
+                .setConsistencyLevel( ConsistencyLevel.LOCAL_ONE );
     }
 
     /**

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetadataIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetadataIO.java
@@ -55,10 +55,7 @@ public class DMetadataIO implements MetadataIO {
                 .value( VALUE, bindMarker() );
 
         putValue = DatastaxIO.getSession().prepare( insert );
-
-        // TODO: This is required by the cassandra-maven-plugin 2.0.0-1, but not by cassandra 2.0.11, which we run.
-        // I believe its due to the bug https://issues.apache.org/jira/browse/CASSANDRA-6238
-        putValue.setConsistencyLevel( ConsistencyLevel.ONE );
+        putValue.setConsistencyLevel( ConsistencyLevel.LOCAL_ONE );
     }
 
     @Override

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetricsCFPreparedStatements.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetricsCFPreparedStatements.java
@@ -94,33 +94,30 @@ public class DMetricsCFPreparedStatements {
         //
         // Preaggr insert statements
         //
-        // TODO: The call to setConsistency(ONE) is required by
-        // the cassandra-maven-plugin 2.0.0-1, but not by cassandra 2.0.11, which we run.
-        // I believe its due to the bug https://issues.apache.org/jira/browse/CASSANDRA-6238
         insertToMetricsPreaggrFullStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_PREAGGREGATED_FULL_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
         insertToMetricsPreaggr5MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_PREAGGREGATED_5M_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
         insertToMetricsPreaggr20MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_PREAGGREGATED_20M_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
         insertToMetricsPreaggr60MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_PREAGGREGATED_60M_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
         insertToMetricsPreaggr240MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_PREAGGREGATED_240M_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
         insertToMetricsPreaggr1440MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_PREAGGREGATED_1440M_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
 
         //
         // Preaggr select statements
@@ -165,33 +162,30 @@ public class DMetricsCFPreparedStatements {
         //
         // Basic insert statements
         //
-        // TODO: The call to setConsistency(ONE) is required by
-        // the cassandra-maven-plugin 2.0.0-1, but not by cassandra 2.0.11, which we run.
-        // I believe its due to the bug https://issues.apache.org/jira/browse/CASSANDRA-6238
         insertToMetricsBasicFullStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_FULL_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
         insertToMetricsBasic5MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_5M_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
         insertToMetricsBasic20MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_20M_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
         insertToMetricsBasic60MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_60M_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
         insertToMetricsBasic240MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_240M_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
         insertToMetricsBasic1440MStatement = session.prepare(
                 String.format(INSERT_KEY_COLUMN_VALUE_TTL_FORMAT,
                         CassandraModel.CF_METRICS_1440M_NAME))
-                .setConsistencyLevel(ConsistencyLevel.ONE); // needed by maven cassandra plugin
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
 
         //
         // Basic select statements

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DRawIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DRawIO.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
 /**
- * This class deals with writing boolean, numeric and string values to the metrics_full & metrics_string column
+ * This class deals with writing boolean, numeric and string values to the metrics_full column
  * families using the Datastax driver.
  *
  * This class does not subclass the {@link com.rackspacecloud.blueflood.io.datastax.DAbstractMetricIO} as serializes
@@ -42,10 +42,7 @@ public class DRawIO {
                 .using( ttl( bindMarker() ) );
 
         putNumeric = session.prepare( insertNumeric );
-
-        // TODO: This is required by the cassandra-maven-plugin 2.0.0-1, but not by cassandra 2.0.11, which we run.
-        // I believe its due to the bug https://issues.apache.org/jira/browse/CASSANDRA-6238
-        putNumeric.setConsistencyLevel( ConsistencyLevel.ONE );
+        putNumeric.setConsistencyLevel( ConsistencyLevel.LOCAL_ONE );
     }
 
     public ResultSetFuture insertAsync( IMetric metric ) {
@@ -57,5 +54,4 @@ public class DRawIO {
 
         return DatastaxIO.getSession().executeAsync( bound );
     }
-
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DShardStateIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DShardStateIO.java
@@ -74,9 +74,7 @@ public class DShardStateIO implements ShardStateIO {
                 .value( VALUE, bindMarker() );
 
         putShardState = DatastaxIO.getSession().prepare( insert );
-        // TODO: This is required by the cassandra-maven-plugin 2.0.0-1, but not by cassandra 2.0.11, which we run.
-        // I believe its due to the bug https://issues.apache.org/jira/browse/CASSANDRA-6238
-        putShardState.setConsistencyLevel( ConsistencyLevel.ONE );
+        putShardState.setConsistencyLevel( ConsistencyLevel.LOCAL_ONE );
     }
 
     @Override

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -35,8 +35,6 @@ import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.*;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -88,8 +86,8 @@ public class HttpMetricsIngestionServer {
 
         int acceptThreads = Configuration.getInstance().getIntegerProperty(HttpConfig.MAX_WRITE_ACCEPT_THREADS);
         int workerThreads = Configuration.getInstance().getIntegerProperty(HttpConfig.MAX_WRITE_WORKER_THREADS);
-        acceptorGroup = new EpollEventLoopGroup(acceptThreads); // acceptor threads
-        workerGroup = new EpollEventLoopGroup(workerThreads);   // client connections threads
+        acceptorGroup = new NioEventLoopGroup(acceptThreads); // acceptor threads
+        workerGroup = new NioEventLoopGroup(workerThreads);   // client connections threads
     }
 
     /**
@@ -116,7 +114,7 @@ public class HttpMetricsIngestionServer {
         log.info("Starting metrics listener HTTP server on port {}", httpIngestPort);
         ServerBootstrap server = new ServerBootstrap();
         server.group(acceptorGroup, workerGroup)
-                .channel(EpollServerSocketChannel.class)
+                .channel(NioServerSocketChannel.class)
                 .childHandler(new ChannelInitializer<SocketChannel>() {
                     @Override
                     public void initChannel(SocketChannel channel) throws Exception {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServer.java
@@ -35,6 +35,8 @@ import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.*;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -86,8 +88,8 @@ public class HttpMetricsIngestionServer {
 
         int acceptThreads = Configuration.getInstance().getIntegerProperty(HttpConfig.MAX_WRITE_ACCEPT_THREADS);
         int workerThreads = Configuration.getInstance().getIntegerProperty(HttpConfig.MAX_WRITE_WORKER_THREADS);
-        acceptorGroup = new NioEventLoopGroup(acceptThreads); // acceptor threads
-        workerGroup = new NioEventLoopGroup(workerThreads);   // client connections threads
+        acceptorGroup = new EpollEventLoopGroup(acceptThreads); // acceptor threads
+        workerGroup = new EpollEventLoopGroup(workerThreads);   // client connections threads
     }
 
     /**
@@ -114,7 +116,7 @@ public class HttpMetricsIngestionServer {
         log.info("Starting metrics listener HTTP server on port {}", httpIngestPort);
         ServerBootstrap server = new ServerBootstrap();
         server.group(acceptorGroup, workerGroup)
-                .channel(NioServerSocketChannel.class)
+                .channel(EpollServerSocketChannel.class)
                 .childHandler(new ChannelInitializer<SocketChannel>() {
                     @Override
                     public void initChannel(SocketChannel channel) throws Exception {


### PR DESCRIPTION
Since have upgraded to newer version of cassandra-maven-plugin, we are not limited to setting our consistency to ONE due to this bug: https://issues.apache.org/jira/browse/CASSANDRA-6238.

Should not impact performance that much. This is just cleaning up work.