### PR TITLE
create properties for the datastax connection pool settings

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IOConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IOConfig.java
@@ -105,8 +105,16 @@ public class IOConfig {
         return maxConns / numHosts + (maxConns % numHosts == 0 ? 0 : 1);
     }
 
-    public int getInitialConn() {
-        return config.getIntegerProperty(CoreConfig.INITIAL_CASSANDRA_CONNECTIONS);
+    public int getDatastaxInitialConnectionPerHost() {
+        return config.getIntegerProperty(CoreConfig.DATASTAX_CORE_CONNECTIONS_PER_HOST);
+    }
+
+    public int getDatastaxMaxConnectionPerHost() {
+        return config.getIntegerProperty(CoreConfig.DATASTAX_MAX_CONNECTIONS_PER_HOST);
+    }
+
+    public int getDatastaxMaxRequestsPerConnection() {
+        return config.getIntegerProperty(CoreConfig.DATASTAX_MAX_REQUESTS_PER_CONNECTION);
     }
 
     /**

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IOConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/IOConfig.java
@@ -105,11 +105,11 @@ public class IOConfig {
         return maxConns / numHosts + (maxConns % numHosts == 0 ? 0 : 1);
     }
 
-    public int getDatastaxInitialConnectionPerHost() {
+    public int getDatastaxCoreConnectionsPerHost() {
         return config.getIntegerProperty(CoreConfig.DATASTAX_CORE_CONNECTIONS_PER_HOST);
     }
 
-    public int getDatastaxMaxConnectionPerHost() {
+    public int getDatastaxMaxConnectionsPerHost() {
         return config.getIntegerProperty(CoreConfig.DATASTAX_MAX_CONNECTIONS_PER_HOST);
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
@@ -39,8 +39,6 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
     private static final Granularity DELAYED_METRICS_STORAGE_GRANULARITY =
             Granularity.getRollupGranularity(Configuration.getInstance().getStringProperty(CoreConfig.DELAYED_METRICS_STORAGE_GRANULARITY));
 
-    private static final Meter metricsFullQueryResultSize = Metrics.meter(DAbstractMetricsRW.class, "reads", "metricsFullQueryResultSize");
-
     protected final DLocatorIO locatorIO;
     protected final DDelayedLocatorIO delayedLocatorIO;
     protected final boolean isBatchIngestEnabled;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxIO.java
@@ -58,7 +58,7 @@ public class DatastaxIO {
 
         cluster = Cluster.builder()
                 .withLoadBalancingPolicy(new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().withLocalDc(ioconfig.getDatacenterName()).build(), false))
-                .withPoolingOptions(getPoolingOptions(dbHosts.size()))
+                .withPoolingOptions(getPoolingOptions())
                 .withCodecRegistry(codecRegistry)
                 .withSocketOptions(getSocketOptions())
                 .addContactPointsWithPorts(dbHosts)
@@ -102,12 +102,13 @@ public class DatastaxIO {
         return socketOptions;
     }
 
-    private static PoolingOptions getPoolingOptions(int numHosts){
+    private static PoolingOptions getPoolingOptions(){
 
         final PoolingOptions poolingOptions = new PoolingOptions();
         poolingOptions
-                .setCoreConnectionsPerHost(HostDistance.LOCAL, ioconfig.getInitialConn())
-                .setMaxConnectionsPerHost(HostDistance.LOCAL, ioconfig.getMaxConnPerHost(numHosts));
+                .setCoreConnectionsPerHost(HostDistance.LOCAL, ioconfig.getDatastaxInitialConnectionPerHost())
+                .setMaxConnectionsPerHost(HostDistance.LOCAL, ioconfig.getDatastaxMaxConnectionPerHost())
+                .setMaxRequestsPerConnection(HostDistance.LOCAL, ioconfig.getDatastaxMaxRequestsPerConnection());
         return poolingOptions;
     }
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DatastaxIO.java
@@ -106,8 +106,8 @@ public class DatastaxIO {
 
         final PoolingOptions poolingOptions = new PoolingOptions();
         poolingOptions
-                .setCoreConnectionsPerHost(HostDistance.LOCAL, ioconfig.getDatastaxInitialConnectionPerHost())
-                .setMaxConnectionsPerHost(HostDistance.LOCAL, ioconfig.getDatastaxMaxConnectionPerHost())
+                .setCoreConnectionsPerHost(HostDistance.LOCAL, ioconfig.getDatastaxCoreConnectionsPerHost())
+                .setMaxConnectionsPerHost(HostDistance.LOCAL, ioconfig.getDatastaxMaxConnectionsPerHost())
                 .setMaxRequestsPerConnection(HostDistance.LOCAL, ioconfig.getDatastaxMaxRequestsPerConnection());
         return poolingOptions;
     }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -30,15 +30,17 @@ public enum CoreConfig implements ConfigDefaults {
     // is evenly divisible by number of hosts. For its connection
     // pool, the driver class calculate the max number of
     // connections per host, by dividing this number with
-    // the number of hosts.
+    // the number of hosts. This is only being used by Astyanax
+    // driver.
     MAX_CASSANDRA_CONNECTIONS("75"),
 
-    // This is the number of initial connections
-    // to be created by the connection pool of the
-    // datastax driver
-    INITIAL_CASSANDRA_CONNECTIONS("15"),
-
     CASSANDRA_DRIVER("astyanax"),
+
+    // Datastax related connection pool settings
+    // http://docs.datastax.com/en/developer/java-driver/3.2/manual/pooling/
+    DATASTAX_CORE_CONNECTIONS_PER_HOST("5"),
+    DATASTAX_MAX_CONNECTIONS_PER_HOST("10"),
+    DATASTAX_MAX_REQUESTS_PER_CONNECTION("1024"),
 
     ROLLUP_KEYSPACE("DATA"),
     CLUSTER_NAME("Test Cluster"),


### PR DESCRIPTION
This PR changes the way we configure Datastax's Connection Pool settings. Before this PR, we:
* call setCoreConnectionsPerHost() to the value of INITIAL_CASSANDRA_CONNECTIONS
* call setMaxConnectionsPerHost() to the value we calculate based on MAX_CASSANDRA_CONNECTIONS and number of DB/C* nodes

The MAX_CASSANDRA_CONNECTIONS is also used when configuring Astyanax connection pool.

With this PR, we:
* call setCoreConnectionsPerHost() to the value of DATASTAX_CORE_CONNECTIONS_PER_HOST
* call setMaxConnectionsPerHost() to the value of DATASTAX_MAX_CONNECTIONS_PER_HOST
* call setMaxRequestsPerConnection() to the value of DATASTAX_MAX_REQUESTS_PER_CONNECTION, with a default value of 1024.

MAX_CASSANDRA_CONNECTION is now only for configuring Astyanax connection pool.