### PR TITLE
add histogram to track how many datapoints per metric we try to rollup raw to 5Min

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AbstractMetricsRW.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.io;
 
+import com.codahale.metrics.Meter;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 import com.rackspacecloud.blueflood.cache.CombinedTtlProvider;
@@ -23,6 +24,7 @@ import com.rackspacecloud.blueflood.cache.TenantTtlProvider;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.Clock;
+import com.rackspacecloud.blueflood.utils.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
@@ -16,6 +16,7 @@
 
 package com.rackspacecloud.blueflood.io;
 
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
@@ -44,6 +45,7 @@ public class Instrumentation implements InstrumentationMBean {
     private static final Meter fullResPreaggregatedMetricWritten;
     private static final Meter metricsWithShortDelayReceived;
     private static final Meter metricsWithLongDelayReceived;
+    private static final Histogram rawPointsIn5Min;
 
     static {
         Class kls = Instrumentation.class;
@@ -55,6 +57,7 @@ public class Instrumentation implements InstrumentationMBean {
         fullResPreaggregatedMetricWritten = Metrics.meter(kls, "Full Resolution Preaggregated Metrics Written");
         metricsWithShortDelayReceived = Metrics.meter(kls, "Metrics with short delay received");
         metricsWithLongDelayReceived = Metrics.meter(kls, "Metrics with long delay received");
+        rawPointsIn5Min = Metrics.histogram(kls, "Raw points in 5 min");
 
         try {
             final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
@@ -181,5 +184,9 @@ public class Instrumentation implements InstrumentationMBean {
             return null;
         }
         return Metrics.meter(Instrumentation.class, "tenants", tenantId, "Delayed Data Points Ingested");
+    }
+
+    public static Histogram getRawPointsIn5MinHistogram() {
+        return rawPointsIn5Min;
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxReader.java
@@ -200,7 +200,8 @@ public class AstyanaxReader extends AstyanaxIO {
 
             // we only want to count the number of points we
             // get when we're querying the metrics_full
-            if ( cf == CassandraModel.CF_METRICS_FULL || cf == CassandraModel.CF_METRICS_PREAGGREGATED_FULL ) {
+            // we don't do for aggregated or other granularities
+            if ( cf == CassandraModel.CF_METRICS_FULL ) {
                 Instrumentation.getRawPointsIn5MinHistogram().update(points.getPoints().size());
             }
         } catch (RuntimeException ex) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxReader.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/astyanax/AstyanaxReader.java
@@ -29,7 +29,6 @@ import com.netflix.astyanax.serializers.AbstractSerializer;
 import com.netflix.astyanax.shallows.EmptyColumnList;
 import com.netflix.astyanax.util.RangeBuilder;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
-import com.rackspacecloud.blueflood.exceptions.CacheException;
 import com.rackspacecloud.blueflood.io.CassandraModel;
 import com.rackspacecloud.blueflood.io.Instrumentation;
 import com.rackspacecloud.blueflood.io.serializers.Serializers;
@@ -197,6 +196,12 @@ public class AstyanaxReader extends AstyanaxIO {
         try {
             for (Column<Long> col : cols) {
                 points.add(new Points.Point<T>(col.getName(), (T)col.getValue(serializer)));
+            }
+
+            // we only want to count the number of points we
+            // get when we're querying the metrics_full
+            if ( cf == CassandraModel.CF_METRICS_FULL || cf == CassandraModel.CF_METRICS_PREAGGREGATED_FULL ) {
+                Instrumentation.getRawPointsIn5MinHistogram().update(points.getPoints().size());
             }
         } catch (RuntimeException ex) {
             log.error("Problem deserializing data for " + locator + " (" + range + ") from " + cf.getName(), ex);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
@@ -23,6 +23,7 @@ import com.rackspacecloud.blueflood.io.CassandraModel;
 import com.rackspacecloud.blueflood.io.Instrumentation;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.types.*;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,7 +142,7 @@ public abstract class DAbstractMetricIO {
             List<ResultSetFuture> futures = entry.getValue();
 
             Table<Locator, Long, T> result = toLocatorTimestampValue(futures, locator,
-                                                    CassandraModel.getGranularity(columnFamily),
+                                                    columnFamily,
                                                     range);
             locatorTimestampRollup.putAll(result);
         }
@@ -237,7 +238,7 @@ public abstract class DAbstractMetricIO {
      */
     public <T extends Object> Table<Locator, Long, T> toLocatorTimestampValue( List<ResultSetFuture> futures,
                                                                                Locator locator,
-                                                                               Granularity granularity,
+                                                                               String columnFamily,
                                                                                Range range) {
         Table<Locator, Long, T> locatorTimestampRollup = HashBasedTable.create();
         for ( ResultSetFuture future : futures ) {
@@ -246,7 +247,7 @@ public abstract class DAbstractMetricIO {
 
                 // we only want to count the number of points we
                 // get when we're querying the metrics_full
-                if ( granularity == Granularity.FULL ) {
+                if ( StringUtils.isNotEmpty(columnFamily) && columnFamily.equals(CassandraModel.CF_METRICS_FULL_NAME) ) {
                     Instrumentation.getRawPointsIn5MinHistogram().update(rows.size());
                 }
 
@@ -258,8 +259,8 @@ public abstract class DAbstractMetricIO {
                 }
             } catch (Exception ex) {
                 Instrumentation.markReadError();
-                LOG.error(String.format("error reading metric for locator %s, granularity %s, range %s",
-                        locator, granularity, range.toString()), ex);
+                LOG.error(String.format("error reading metric for locator %s, column family '%s', range %s",
+                        locator, columnFamily, range.toString()), ex);
             }
         }
         return locatorTimestampRollup;

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricIO.java
@@ -244,6 +244,12 @@ public abstract class DAbstractMetricIO {
             try {
                 List<Row> rows = future.getUninterruptibly().all();
 
+                // we only want to count the number of points we
+                // get when we're querying the metrics_full
+                if ( granularity == Granularity.FULL ) {
+                    Instrumentation.getRawPointsIn5MinHistogram().update(rows.size());
+                }
+
                 for (Row row : rows) {
                     String key = row.getString(DMetricsCFPreparedStatements.KEY);
                     Locator loc = Locator.createLocatorFromDbKey(key);

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DAbstractMetricsRW.java
@@ -212,7 +212,7 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
                     LOG.error(String.format("Error looking up locator %s in cache", locator), ex);
                 }
             }
-            return resultSetsToMetricData(locatorToFuturesMap, locatorIOMap, granularity, range);
+            return resultSetsToMetricData(locatorToFuturesMap, locatorIOMap, columnFamily, range);
         }
         finally {
 
@@ -268,12 +268,12 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
      *
      * @param resultSets
      * @param locatorIO
-     * @param granularity
+     * @param columnFamily
      * @return
      */
     protected Map<Locator, MetricData> resultSetsToMetricData(Map<Locator, List<ResultSetFuture>> resultSets,
                                                               Map<Locator, DAbstractMetricIO> locatorIO,
-                                                              Granularity granularity,
+                                                              String columnFamily,
                                                               Range range) {
 
         MetadataCache metadataCache = MetadataCache.getInstance();
@@ -287,7 +287,7 @@ public abstract class DAbstractMetricsRW extends AbstractMetricsRW {
             DAbstractMetricIO io = locatorIO.get(locator);
 
             // get ResultSets to a Table of locator, timestamp, rollup
-            Table<Locator, Long, Object> locatorTimestampRollup = io.toLocatorTimestampValue(futures, locator, granularity, range);
+            Table<Locator, Long, Object> locatorTimestampRollup = io.toLocatorTimestampValue(futures, locator, columnFamily, range);
 
             Map<Long, Object> tsRollupMap = locatorTimestampRollup.row( locator );
 


### PR DESCRIPTION
We would like to know how many points we are fetching/reading when we are trying to rollup raw points from metrics_full to 5Min granularity. This would be useful in generating the right kind of load for performance testing.
