### PR TITLE
ES upgrade to 2.4.4

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -122,6 +122,7 @@
               <!-- do not require zookeeper for these tests. -->
               <argLine>-DZOOKEEPER_CLUSTER=NONE</argLine>
               <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties ${jacoco.agent.it.argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
+              <argLine>-Duser.language=en</argLine>
               <!-- Skips integration tests if the value of skip.integration.tests property is true -->
               <skipTests>${skip.integration.tests}</skipTests>
               <includes>

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/io/IntegrationTestBase.java
@@ -37,7 +37,7 @@ public class IntegrationTestBase {
 
     private static final char[] STRING_SEEDS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_".toCharArray();
     protected static final Random RAND = new Random(System.currentTimeMillis());
-    protected static final ConcurrentHashMap<Locator, String> locatorToUnitMap = new ConcurrentHashMap<Locator, String>();
+    public static final ConcurrentHashMap<Locator, String> locatorToUnitMap = new ConcurrentHashMap<Locator, String>();
 
     @Before
     public void setUp() throws Exception {
@@ -106,7 +106,7 @@ public class IntegrationTestBase {
         return metric;
     }
 
-    protected PreaggregatedMetric getGaugeMetric(String name, String tenantid, long timestamp) {
+    public PreaggregatedMetric getGaugeMetric(String name, String tenantid, long timestamp) {
         final Locator locator = Locator.createLocatorFromPathComponents(tenantid, name);
         return getGaugeMetric(locator, timestamp);
     }
@@ -130,14 +130,14 @@ public class IntegrationTestBase {
         return metrics;
     }
 
-    protected static String randString(int length) {
+    public static String randString(int length) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < length; i++)
             sb.append( STRING_SEEDS[ RAND.nextInt( STRING_SEEDS.length ) ] );
         return sb.toString();
     }
 
-    protected int getRandomIntMetricValue() {
+    public int getRandomIntMetricValue() {
         return RAND.nextInt();
     }
 
@@ -145,7 +145,7 @@ public class IntegrationTestBase {
         return "str" + String.valueOf(getRandomIntMetricValue());
     }
 
-    protected Metric getRandomIntMetric(final Locator locator, long timestamp) {
+    public Metric getRandomIntMetric(final Locator locator, long timestamp) {
         locatorToUnitMap.putIfAbsent(locator, UNIT_ENUM.values()[new Random().nextInt(UNIT_ENUM.values().length)].unit);
         return new Metric(locator, getRandomIntMetricValue(), timestamp, new TimeValue(1, TimeUnit.DAYS), locatorToUnitMap.get(locator));
     }
@@ -182,7 +182,7 @@ public class IntegrationTestBase {
         }
     }
 
-    protected void generateRollups(Locator locator, long from, long to, Granularity destGranularity) throws Exception {
+    public void generateRollups(Locator locator, long from, long to, Granularity destGranularity) throws Exception {
         if (destGranularity == Granularity.FULL) {
             throw new Exception("Can't roll up to FULL");
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -62,6 +62,8 @@ public enum CoreConfig implements ConfigDefaults {
     TOKEN_DISCOVERY_WRITER_MIN_THREADS("5"),
     TOKEN_DISCOVERY_WRITER_MAX_THREADS("10"),
 
+    MAX_DISCOVERY_RESULT_SIZE("10000"),
+
     // Maximum threads that would access the cache concurrently
     META_CACHE_MAX_CONCURRENCY("50"),
 

--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -33,7 +33,100 @@
 
 
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/integration-test/java</directory>
+      </testResource>
+    </testResources>
+
     <plugins>
+
+      <!-- Used to add source directories to our build. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <!-- States that the plugin's add-test-source goal is executed at generate-test-sources phase. -->
+          <execution>
+            <id>add-integration-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <!-- Configures the source directory of integration tests. -->
+              <sources>
+                <source>src/integration-test/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.6</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Skips unit tests if the value of skip.unit.tests property is true -->
+          <skipTests>${skip.unit.tests}</skipTests>
+          <!-- Excludes integration tests when unit tests are run. -->
+          <excludes>
+            <exclude>**/*Integration*.java</exclude>
+          </excludes>
+          <!-- configuration values are static, and tests interfere with each
+               other when run in parallel. -->
+          <!--<parallel>classes</parallel>-->
+          <!--<threadCount>5</threadCount>-->
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <!-- States that both integration-test and verify goals of the Failsafe Maven plugin are executed. -->
+          <execution>
+            <id>integration-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <tests.jarhell.check>false</tests.jarhell.check>
+                <tests.security.manager>false</tests.security.manager>
+                <tests.locale>en-US</tests.locale>
+              </systemPropertyVariables>
+              <testSourceDirectory>src/integration-test/java</testSourceDirectory>
+              <argLine>-Duser.language=en</argLine>
+              <!-- Skips integration tests if the value of skip.integration.tests property is true -->
+              <skipTests>${skip.integration.tests}</skipTests>
+              <includes>
+                <include>**/*Integration*.java</include>
+              </includes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
     </plugins>
   </build>
@@ -49,7 +142,7 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>1.7.1</version>
+      <version>${elasticsearch.version}</version>
     </dependency>
 
     <dependency>
@@ -79,12 +172,35 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.tlrx</groupId>
       <artifactId>elasticsearch-test</artifactId>
       <version>1.2.1</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-test-framework</artifactId>
+      <version>${lucene.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>${elasticsearch.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -35,7 +35,7 @@
   <build>
     <testResources>
       <testResource>
-        <directory>src/integration-test/java</directory>
+        <directory>src/integration-test/resources</directory>
       </testResource>
     </testResources>
 

--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -179,14 +179,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.tlrx</groupId>
-      <artifactId>elasticsearch-test</artifactId>
-      <version>1.2.1</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-test-framework</artifactId>
       <version>${lucene.version}</version>

--- a/blueflood-elasticsearch/src/integration-test/java/com/rackspacecloud/blueflood/io/BaseElasticTest.java
+++ b/blueflood-elasticsearch/src/integration-test/java/com/rackspacecloud/blueflood/io/BaseElasticTest.java
@@ -1,17 +1,17 @@
 package com.rackspacecloud.blueflood.io;
 
-import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.TimeValue;
-import junit.framework.Assert;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.Assert.assertTrue;
-
-public abstract class BaseElasticTest {
+public abstract class BaseElasticTest extends ESIntegTestCase {
 
     protected static final int NUM_PARENT_ELEMENTS = 30;
     protected static final List<String> CHILD_ELEMENTS = Arrays.asList("A", "B", "C");
@@ -23,8 +23,6 @@ public abstract class BaseElasticTest {
     protected static final String UNIT = "horse length";
 
     protected static final Map<String, List<Locator>> locatorMap = new HashMap<String, List<Locator>>();
-
-    protected EsSetup esSetup;
 
     protected SearchResult createExpectedResult(String tenantId, int x, String y, int z, String unit) {
         Locator locator = createTestLocator(tenantId, x, y, z);
@@ -78,7 +76,7 @@ public abstract class BaseElasticTest {
 
     protected void createTestMetrics(List<IMetric> metrics) throws IOException {
         insertDiscovery(metrics);
-        esSetup.client().admin().indices().prepareRefresh().execute().actionGet();
+        refreshChanges();
     }
 
 
@@ -112,7 +110,7 @@ public abstract class BaseElasticTest {
         Set<String> formattedResults = formatForComparision(results);
         assertTrue("Expected results does not contain all of api results", expectedResults.containsAll(formattedResults));
         assertTrue("API results does not contain all of expected results", formattedResults.containsAll(expectedResults));
-        Assert.assertEquals("Invalid total number of results", expectedResults.size(), results.size());
+        assertEquals("Invalid total number of results", expectedResults.size(), results.size());
     }
 
     protected Set<String> formatForComparision(List<MetricName> results) {
@@ -124,5 +122,61 @@ public abstract class BaseElasticTest {
         }
 
         return formattedResults;
+    }
+
+    private static String convertStreamToString(java.io.InputStream is) {
+        Scanner s = new Scanner(is).useDelimiter("\\A");
+        return s.hasNext() ? s.next() : "";
+    }
+
+    private static String getDataAsString(String fileName) {
+        return convertStreamToString(BaseElasticTest.class
+                                             .getClassLoader()
+                                             .getResourceAsStream(fileName));
+    }
+
+    protected static String getIndexSettings() {
+        return getDataAsString("index_settings.json");
+    }
+
+    protected static String getMetricsMapping() {
+        return getDataAsString("metrics_mapping.json");
+    }
+
+    protected static String getTokensMapping() {
+        return getDataAsString("tokens_mapping.json");
+    }
+
+    protected static String getEventsMapping() {
+        return getDataAsString("events_mapping.json");
+    }
+
+    protected void createIndexAndMapping(String indexName, String indexType, String fieldMappings)
+            throws ExecutionException, InterruptedException {
+
+        client().admin()
+                .indices()
+                .prepareCreate(indexName)
+                .setSettings(Settings.settingsBuilder().loadFromSource(getIndexSettings()))
+                .addMapping(indexType, fieldMappings)
+                .execute()
+                .get();
+    }
+
+    protected void addAlias(String indexName, String aliasName) throws ExecutionException, InterruptedException {
+        client().admin()
+                .indices()
+                .prepareAliases()
+                .addAlias(indexName, aliasName)
+                .execute()
+                .get();
+    }
+
+    protected void refreshChanges() {
+        flushAndRefresh();
+    }
+
+    protected Client getClient() {
+        return client();
     }
 }

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/AbstractElasticIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/AbstractElasticIO.java
@@ -4,12 +4,13 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.ElasticIOConfig;
 import com.rackspacecloud.blueflood.utils.GlobPattern;
 import com.rackspacecloud.blueflood.utils.Metrics;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.index.query.*;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -40,7 +41,7 @@ public abstract class AbstractElasticIO implements DiscoveryIO {
     public static String ELASTICSEARCH_INDEX_NAME_WRITE = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_WRITE);
     public static String ELASTICSEARCH_INDEX_NAME_READ = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_INDEX_NAME_READ);
 
-    public static int MAX_RESULT_LIMIT = 100000;
+    public static int MAX_DISCOVERY_RESULT_SIZE = Configuration.getInstance().getIntegerProperty(CoreConfig.MAX_DISCOVERY_RESULT_SIZE);
 
     //grabs chars until the next "." which is basically a token
     protected static final String REGEX_TO_GRAB_SINGLE_TOKEN = "[^.]*";
@@ -82,7 +83,7 @@ public abstract class AbstractElasticIO implements DiscoveryIO {
 
             response = client.prepareSearch(indexes)
                     .setRouting(tenant)
-                    .setSize(MAX_RESULT_LIMIT)
+                    .setSize(MAX_DISCOVERY_RESULT_SIZE)
                     .setVersion(true)
                     .setQuery(bqb)
                     .execute()
@@ -229,7 +230,7 @@ public abstract class AbstractElasticIO implements DiscoveryIO {
         Terms aggregateTerms = response.getAggregations().get(METRICS_TOKENS_AGGREGATE);
 
         for (Terms.Bucket bucket: aggregateTerms.getBuckets()) {
-            metricIndexData.add(bucket.getKey(), bucket.getDocCount());
+            metricIndexData.add(bucket.getKeyAsString(), bucket.getDocCount());
         }
 
         return metricIndexData;

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticTokensIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticTokensIO.java
@@ -3,10 +3,8 @@ package com.rackspacecloud.blueflood.io;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
-import com.rackspacecloud.blueflood.service.Configuration;
-import com.rackspacecloud.blueflood.service.ElasticClientManager;
-import com.rackspacecloud.blueflood.service.ElasticIOConfig;
-import com.rackspacecloud.blueflood.service.RemoteElasticSearchServer;
+import com.google.common.annotations.VisibleForTesting;
+import com.rackspacecloud.blueflood.service.*;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Token;
 import com.rackspacecloud.blueflood.utils.GlobPattern;
@@ -51,6 +49,7 @@ public class ElasticTokensIO implements TokenDiscoveryIO {
 
     public static String ELASTICSEARCH_TOKEN_INDEX_NAME_WRITE = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_TOKEN_INDEX_NAME_WRITE);
     public static String ELASTICSEARCH_TOKEN_INDEX_NAME_READ = Configuration.getInstance().getStringProperty(ElasticIOConfig.ELASTICSEARCH_TOKEN_INDEX_NAME_READ);
+    public static int MAX_DISCOVERY_RESULT_SIZE = Configuration.getInstance().getIntegerProperty(CoreConfig.MAX_DISCOVERY_RESULT_SIZE);
 
     private Client client;
 
@@ -132,7 +131,7 @@ public class ElasticTokensIO implements TokenDiscoveryIO {
         try {
             response = client.prepareSearch(indexes)
                              .setRouting(tenantId)
-                             .setSize(AbstractElasticIO.MAX_RESULT_LIMIT)
+                             .setSize(MAX_DISCOVERY_RESULT_SIZE)
                              .setVersion(true)
                              .setQuery(bqb)
                              .execute()
@@ -285,5 +284,10 @@ public class ElasticTokensIO implements TokenDiscoveryIO {
 
     protected String[] getIndexesToSearch() {
         return new String[] {ELASTICSEARCH_TOKEN_INDEX_NAME_READ};
+    }
+
+    @VisibleForTesting
+    public void setClient(Client client) {
+        this.client = client;
     }
 }

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/EventElasticSearchIO.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/EventElasticSearchIO.java
@@ -17,6 +17,7 @@
 package com.rackspacecloud.blueflood.io;
 
 import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
 import com.rackspacecloud.blueflood.service.ElasticClientManager;
 import com.rackspacecloud.blueflood.service.RemoteElasticSearchServer;
 import com.rackspacecloud.blueflood.types.Event;
@@ -41,7 +42,7 @@ public class EventElasticSearchIO implements EventsIO {
             "Insertion time for events");
     public static final String EVENT_INDEX = "events";
     public static final String ES_TYPE = "graphite_event";
-    private final Client client;
+    private Client client;
 
     public EventElasticSearchIO() {
         this(RemoteElasticSearchServer.getInstance());
@@ -81,7 +82,7 @@ public class EventElasticSearchIO implements EventsIO {
 
         SearchResponse response = client.prepareSearch(EVENT_INDEX)
                 .setRouting(tenant)
-                .setSize(100000)
+                .setSize(10000)
                 .setVersion(true)
                 .setQuery(qb)
                 .execute()
@@ -129,5 +130,10 @@ public class EventElasticSearchIO implements EventsIO {
             }
         }
         return result;
+    }
+
+    @VisibleForTesting
+    public void setClient(Client client) {
+        this.client = client;
     }
 }

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/RemoteElasticSearchServer.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/service/RemoteElasticSearchServer.java
@@ -18,10 +18,10 @@ package com.rackspacecloud.blueflood.service;
 
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 
 
@@ -38,15 +38,14 @@ public class RemoteElasticSearchServer implements ElasticClientManager {
         Configuration config = Configuration.getInstance();
         List<String> hosts = config.getListProperty(ElasticIOConfig.ELASTICSEARCH_HOSTS);
         String clusterName = config.getStringProperty(ElasticIOConfig.ELASTICSEARCH_CLUSTERNAME);
-        Settings settings = ImmutableSettings.settingsBuilder()
-                .put("cluster.name", clusterName)
-                .build();
-        TransportClient tc = new TransportClient(settings);
+        Settings settings = Settings.settingsBuilder()
+                                    .put("cluster.name", clusterName).build();
+        TransportClient tc = TransportClient.builder().settings(settings).build();
         for (String host : hosts) {
             String[] parts = host.split(":");
             String address = parts[0];
             Integer port = Integer.parseInt(parts[1]);
-            tc.addTransportAddress(new InetSocketTransportAddress(address, port));
+            tc.addTransportAddress(new InetSocketTransportAddress(new InetSocketAddress(address, port)));
         }
         client = tc;
     }

--- a/blueflood-elasticsearch/src/main/resources/metrics_mapping.json
+++ b/blueflood-elasticsearch/src/main/resources/metrics_mapping.json
@@ -13,7 +13,7 @@
                 "index": "not_analyzed"
             },
             "metric_name": {
-                "index_analyzer": "prefix-test-analyzer",
+                "analyzer": "prefix-test-analyzer",
                 "search_analyzer": "keyword",
                 "type": "string"
             }

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticTokensIOIntegrationTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticTokensIOIntegrationTest.java
@@ -1,0 +1,248 @@
+package com.rackspacecloud.blueflood.io;
+
+import com.github.tlrx.elasticsearch.test.EsSetup;
+import com.rackspacecloud.blueflood.types.IMetric;
+import com.rackspacecloud.blueflood.types.Locator;
+import com.rackspacecloud.blueflood.types.Token;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+
+public class ElasticTokensIOIntegrationTest extends BaseElasticTest {
+
+    protected ElasticTokensIO elasticTokensIO;
+
+    @Before
+    public void setup() throws IOException {
+        esSetup = new EsSetup();
+        esSetup.execute(EsSetup.deleteAll());
+
+        esSetup.execute(EsSetup.createIndex(ElasticTokensIO.ELASTICSEARCH_TOKEN_INDEX_NAME_WRITE)
+                               .withMapping("tokens", EsSetup.fromClassPath("tokens_mapping.json")));
+
+        String TOKEN_INDEX_NAME_OLD = ElasticTokensIO.ELASTICSEARCH_TOKEN_INDEX_NAME_WRITE + "_v1";
+        esSetup.execute(EsSetup.createIndex(TOKEN_INDEX_NAME_OLD)
+                               .withMapping("tokens", EsSetup.fromClassPath("tokens_mapping.json")));
+
+        elasticTokensIO = new ElasticTokensIO(esSetup.client()) {
+            @Override
+            protected String[] getIndexesToSearch() {
+                return new String[] {ElasticTokensIO.ELASTICSEARCH_TOKEN_INDEX_NAME_READ,
+                        TOKEN_INDEX_NAME_OLD};
+            }
+        };
+
+        //inserting to metric_tokens
+        elasticTokensIO.insertDiscovery(createTestTokens(TENANT_A));
+        elasticTokensIO.insertDiscovery(createTestTokens(TENANT_B));
+        elasticTokensIO.insertDiscovery(createTestTokens(TENANT_C));
+
+        //inserting same tokens to old version of metric_tokens
+        this.insertTokenDiscovery(createTestTokens(TENANT_A), TOKEN_INDEX_NAME_OLD, esSetup.client());
+        this.insertTokenDiscovery(createTestTokens(TENANT_B), TOKEN_INDEX_NAME_OLD, esSetup.client());
+        this.insertTokenDiscovery(createTestTokens(TENANT_C), TOKEN_INDEX_NAME_OLD, esSetup.client());
+
+        esSetup.client().admin().indices().prepareRefresh().execute().actionGet();
+    }
+
+    private List<Token> createTestTokens(String tenantId) {
+        return Token.getUniqueTokens(createComplexTestLocators(tenantId).stream())
+                    .collect(toList());
+    }
+
+    public void insertTokenDiscovery(List<Token> tokens, String indexName, Client esClient) throws IOException {
+        if (tokens.size() == 0) return;
+
+        BulkRequestBuilder bulk = esClient.prepareBulk();
+
+        for (Token token : tokens) {
+            bulk.add(createSingleRequest(token, indexName, esClient));
+        }
+
+        bulk.execute().actionGet();
+    }
+
+
+    IndexRequestBuilder createSingleRequest(Token token, String indexName, Client esClient) throws IOException {
+
+        return esClient.prepareIndex(indexName, ElasticTokensIO.ES_DOCUMENT_TYPE)
+                       .setId(token.getId())
+                       .setSource(ElasticTokensIO.createSourceContent(token))
+                       .setCreate(true)
+                       .setRouting(token.getLocator().getTenantId());
+    }
+
+
+    @After
+    public void tearDown() {
+        esSetup.terminate();
+    }
+
+    @Override
+    protected void insertDiscovery(List<IMetric> metrics) throws IOException {
+
+        Stream<Locator> locators = metrics.stream().map(IMetric::getLocator);
+        elasticTokensIO.insertDiscovery(Token.getUniqueTokens(locators)
+                                             .collect(toList()));
+    }
+
+    @Test
+    public void testGetMetricNames() throws Exception {
+        String tenantId = TENANT_A;
+        String query = "*";
+
+
+        List<MetricName> results = elasticTokensIO.getMetricNames(tenantId, query);
+
+        assertEquals("Invalid total number of results", 1, results.size());
+        assertEquals("Next token mismatch", "one", results.get(0).getName());
+        assertEquals("isCompleteName for token", false, results.get(0).isCompleteName());
+    }
+
+    @Test
+    public void testGetMetricNamesMultipleMetrics() throws Exception {
+        String tenantId = TENANT_A;
+        String query = "*";
+
+        createTestMetrics(tenantId, new HashSet<String>() {{
+            add("foo.bar.baz");
+        }});
+
+        List<MetricName> results = elasticTokensIO.getMetricNames(tenantId, query);
+
+        Set<String> expectedResults = new HashSet<String>() {{
+            add("one|false");
+            add("foo|false");
+        }};
+
+        assertEquals("Invalid total number of results", 2, results.size());
+        verifyResults(results, expectedResults);
+    }
+
+    @Test
+    public void testGetMetricNamesSingleLevelPrefix() throws Exception {
+        String tenantId = TENANT_A;
+        String query = "one.*";
+
+        List<MetricName> results = elasticTokensIO.getMetricNames(tenantId, query);
+
+        assertEquals("Invalid total number of results", 1, results.size());
+        assertEquals("Next token mismatch", "one.two", results.get(0).getName());
+        assertEquals("Next level indicator wrong for token", false, results.get(0).isCompleteName());
+    }
+
+    @Test
+    public void testGetMetricNamesWithWildCardPrefixMultipleLevels() throws Exception {
+        String tenantId = TENANT_A;
+        String query = "*.*";
+
+        createTestMetrics(tenantId, new HashSet<String>() {{
+            add("foo.bar.baz");
+        }});
+
+        List<MetricName> results = elasticTokensIO.getMetricNames(tenantId, query);
+
+        Set<String> expectedResults = new HashSet<String>() {{
+            add("one.two|false");
+            add("foo.bar|false");
+        }};
+
+        assertEquals("Invalid total number of results", 2, results.size());
+        verifyResults(results, expectedResults);
+    }
+
+    @Test
+    public void testGetMetricNamesWithMultiLevelPrefix() throws Exception {
+        String tenantId = TENANT_A;
+        String query = "one.two.*";
+
+        List<MetricName> results = elasticTokensIO.getMetricNames(tenantId, query);
+
+        assertEquals("Invalid total number of results", NUM_PARENT_ELEMENTS, results.size());
+        for (MetricName metricName : results) {
+            Assert.assertFalse("isCompleteName value", metricName.isCompleteName());
+        }
+    }
+
+    @Test
+    public void testGetMetricNamesWithWildCardPrefixAtTheEnd() throws Exception {
+        String tenantId = TENANT_A;
+        String query = "one.two.three*.*";
+
+        List<MetricName> results = elasticTokensIO.getMetricNames(tenantId, query);
+
+        assertEquals("Invalid total number of results", NUM_PARENT_ELEMENTS * CHILD_ELEMENTS.size(), results.size());
+        for (MetricName metricName : results) {
+            Assert.assertFalse("isCompleteName value", metricName.isCompleteName());;
+        }
+    }
+
+    @Test
+    public void testGetMetricNamesWithWildCardAndBracketsPrefix() throws Exception {
+        String tenantId = TENANT_A;
+        String query = "one.{two,foo}.[ta]hree00.*";
+
+        createTestMetrics(tenantId, new HashSet<String>() {{
+            add("one.foo.three00.bar.baz");
+        }});
+
+        List<MetricName> results = elasticTokensIO.getMetricNames(tenantId, query);
+
+        Set<String> expectedResults = new HashSet<String>() {{
+            add("one.two.three00.fourA|false");
+            add("one.two.three00.fourB|false");
+            add("one.two.three00.fourC|false");
+            add("one.foo.three00.bar|false");
+        }};
+
+        assertEquals("Invalid total number of results", CHILD_ELEMENTS.size() + 1, results.size());
+        verifyResults(results, expectedResults);
+    }
+
+    @Test
+    public void testGetMetricNamesWithMultiWildCardPrefix() throws Exception {
+        String tenantId = TENANT_A;
+        String query = "*.*.*";
+
+        List<MetricName> results = elasticTokensIO.getMetricNames(tenantId, query);
+
+        assertEquals("Invalid total number of results", NUM_PARENT_ELEMENTS, results.size());
+        for (MetricName metricName : results) {
+            Assert.assertFalse("isCompleteName value", metricName.isCompleteName());;
+        }
+    }
+
+    @Test
+    public void testGetMetricNamesWithoutWildCard() throws Exception {
+        String tenantId = TENANT_A;
+        String query = "one.foo.three00.bar.baz";
+
+        createTestMetrics(tenantId, new HashSet<String>() {{
+            add("one.foo.three00.bar.baz");
+        }});
+
+        List<MetricName> results = elasticTokensIO.getMetricNames(tenantId, query);
+
+        Set<String> expectedResults = new HashSet<String>() {{
+            add("one.foo.three00.bar.baz|true");
+        }};
+
+        assertEquals("Invalid total number of results", expectedResults.size(), results.size());
+        verifyResults(results, expectedResults);
+    }
+
+
+}

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/MetricIndexDataTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/MetricIndexDataTest.java
@@ -1,7 +1,7 @@
 package com.rackspacecloud.blueflood.io;
 
 import com.rackspacecloud.blueflood.types.Locator;
-import org.elasticsearch.common.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 
 import java.util.*;

--- a/blueflood-elasticsearch/src/test/resources/log4j-test.properties
+++ b/blueflood-elasticsearch/src/test/resources/log4j-test.properties
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+log4j.appender.F=org.apache.log4j.RollingFileAppender
+log4j.appender.F.File=tests.log
+log4j.appender.F.MaxFileSize=8048KB
+log4j.appender.F.MaxBackupIndex=2
+
+log4j.appender.F.layout=org.apache.log4j.PatternLayout
+log4j.appender.F.layout.ConversionPattern=%p %t %c - %m%n
+
+log4j.logger.httpclient.wire.header=WARN
+log4j.logger.httpclient.wire.content=WARN
+
+-log4j.category.org.apache.zookeeper.ClientCnxn=WARN
+-log4j.category.org.apache.zookeeper.client.ZooKeeperSaslClient=ERROR
+
+log4j.logger.org.apache.http.client.protocol=INFO
+log4j.logger.org.apache.http.wire=INFO
+log4j.logger.org.apache.http.impl=INFO
+log4j.logger.org.apache.http.headers=INFO
+
+log4j.rootLogger=INFO, F

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -230,14 +230,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.tlrx</groupId>
-      <artifactId>elasticsearch-test</artifactId>
-      <version>1.2.1</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-test-framework</artifactId>
       <version>${lucene.version}</version>

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -103,11 +103,17 @@
                 <CASSANDRA_BINXPORT_PORT>${cassandra.nativeTransportPort}</CASSANDRA_BINXPORT_PORT>
                 <CASSANDRA_BINXPORT_HOSTS>${cassandra.listenAddress}:${cassandra.nativeTransportPort}</CASSANDRA_BINXPORT_HOSTS>
                 <CASSANDRA_DRIVER>datastax</CASSANDRA_DRIVER>
+                <tests.jarhell.check>false</tests.jarhell.check>
+                <tests.security.manager>false</tests.security.manager>
+                <tests.locale>en-US</tests.locale>
               </systemPropertyVariables>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
               <testSourceDirectory>src/integration-test/java</testSourceDirectory>
               <!-- do not require zookeeper for these tests. -->
               <argLine>-DZOOKEEPER_CLUSTER=NONE</argLine>
               <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties ${jacoco.agent.it.argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
+              <argLine>-Duser.language=en</argLine>
               <!-- Skips integration tests if the value of skip.integration.tests property is true -->
               <skipTests>${skip.integration.tests}</skipTests>
               <includes>
@@ -198,7 +204,8 @@
 
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
 
@@ -229,6 +236,22 @@
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-test-framework</artifactId>
+      <version>${lucene.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>${elasticsearch.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpESIntegrationBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpESIntegrationBase.java
@@ -1,0 +1,72 @@
+package com.rackspacecloud.blueflood.http;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.http.annotation.NotThreadSafe;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Scanner;
+import java.util.concurrent.ExecutionException;
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE) //https://github.com/elastic/elasticsearch/issues/8642
+@NotThreadSafe
+public class HttpESIntegrationBase extends ESIntegTestCase {
+
+    private String convertStreamToString(java.io.InputStream is) {
+        Scanner s = new Scanner(is).useDelimiter("\\A");
+        return s.hasNext() ? s.next() : "";
+    }
+
+    private String getDataAsString(String fileName) {
+        return convertStreamToString(HttpESIntegrationBase.class
+                                             .getClassLoader()
+                                             .getResourceAsStream(fileName));
+    }
+
+    private String getIndexSettings() {
+        return getDataAsString("index_settings.json");
+    }
+
+    protected String getMetricsMapping() {
+        return getDataAsString("metrics_mapping.json");
+    }
+
+    protected String getTokensMapping() {
+        return getDataAsString("tokens_mapping.json");
+    }
+
+    protected String getEventsMapping() {
+        return getDataAsString("events_mapping.json");
+    }
+
+    protected void createIndexAndMapping(String indexName, String indexType, String fieldMappings)
+            throws ExecutionException, InterruptedException {
+
+        client().admin()
+                .indices()
+                .prepareCreate(indexName)
+                .setSettings(Settings.settingsBuilder().loadFromSource(getIndexSettings()))
+                .addMapping(indexType, fieldMappings)
+                .execute()
+                .get();
+    }
+
+    protected void addAlias(String indexName, String aliasName) throws ExecutionException, InterruptedException {
+        client().admin()
+                .indices()
+                .prepareAliases()
+                .addAlias(indexName, aliasName)
+                .execute()
+                .get();
+    }
+
+    protected void refreshChanges() {
+        flushAndRefresh();
+    }
+
+    protected Client getClient() {
+        return client();
+    }
+
+}

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpESIntegrationBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpESIntegrationBase.java
@@ -1,6 +1,9 @@
 package com.rackspacecloud.blueflood.http;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import org.apache.http.annotation.NotThreadSafe;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
@@ -67,6 +70,29 @@ public class HttpESIntegrationBase extends ESIntegTestCase {
 
     protected Client getClient() {
         return client();
+    }
+
+    protected void esSetup() throws ExecutionException, InterruptedException {
+        // setup elasticsearch test clusters with blueflood mappings for events
+        createIndexAndMapping(EventElasticSearchIO.EVENT_INDEX,
+                              "graphite_event",
+                              getEventsMapping());
+
+        // setup elasticsearch test clusters with blueflood mappings for metric discovery
+        createIndexAndMapping(ElasticIO.ELASTICSEARCH_INDEX_NAME_WRITE,
+                              ElasticIO.ES_DOCUMENT_TYPE,
+                              getMetricsMapping());
+
+        // setup elasticsearch test clusters with blueflood mappings for metric tokens discovery
+        createIndexAndMapping(ElasticTokensIO.ELASTICSEARCH_TOKEN_INDEX_NAME_WRITE,
+                              ElasticTokensIO.ES_DOCUMENT_TYPE,
+                              getTokensMapping());
+
+        refreshChanges();
+
+        //setting ES client back in ElasticIO and ElasticTokensIO so that ingestion service can interact with ES test cluster.
+        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(getClient());
+        ((ElasticTokensIO) ModuleLoader.getInstance(TokenDiscoveryIO.class, CoreConfig.TOKEN_DISCOVERY_MODULES)).setClient(getClient());
     }
 
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
@@ -16,7 +16,6 @@
 
 package com.rackspacecloud.blueflood.http;
 
-import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpEventsIngestionHandler;
 import com.rackspacecloud.blueflood.inputs.handlers.HttpMetricsIngestionServer;
 import com.rackspacecloud.blueflood.io.*;
@@ -25,10 +24,7 @@ import com.rackspacecloud.blueflood.outputs.handlers.HttpMetricDataQueryServer;
 import com.rackspacecloud.blueflood.outputs.handlers.HttpRollupsQueryHandler;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.*;
-import com.rackspacecloud.blueflood.types.Event;
-import com.rackspacecloud.blueflood.types.Locator;
-import com.rackspacecloud.blueflood.types.Resolution;
-import com.rackspacecloud.blueflood.utils.ModuleLoader;
+import com.rackspacecloud.blueflood.types.*;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -41,17 +37,21 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 
+import static com.rackspacecloud.blueflood.TestUtils.generateJSONMetricsData;
+import static com.rackspacecloud.blueflood.TestUtils.getJsonFromFile;
 import static org.mockito.Mockito.spy;
-import static com.rackspacecloud.blueflood.TestUtils.*;
 
-public class HttpIntegrationTestBase extends IntegrationTestBase {
+public class HttpIntegrationTestBase extends HttpESIntegrationBase {
 
     protected static final long TIME_DIFF_MS = 40000;
 
@@ -62,15 +62,15 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
     protected static ScheduleContext context;
     protected static  Map <String, String> parameterMap;
     protected static ElasticIO elasticIO;
+    protected static ElasticTokensIO elasticTokensIO;
     protected static EventsIO eventsSearchIO;
-    protected static EsSetup esSetup;
 
     protected static String configAllowedOrigins = "test.domain1.com, test.domain2.com, test.domain3.com";
     protected static String configAllowedHeaders = "XYZ, ABC";
     protected static String configAllowedMethods = "GET, POST, PUT";
     protected static String configAllowedMaxAge = "6000";
 
-    private static HttpIngestionService httpIngestionService;
+    protected static HttpIngestionService httpIngestionService;
     private static HttpQueryService httpQueryService;
     private static HttpClientVendor vendor;
     private static Collection<Integer> manageShards = new HashSet<Integer>();
@@ -89,6 +89,35 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
     public final String getViewsPath = "/v2.0/%s/views";
 
     private Random random = new Random( System.currentTimeMillis() );
+    private IntegrationTestBase integrationTestBase;
+
+    public HttpIntegrationTestBase() {
+        this.integrationTestBase = new IntegrationTestBase();
+    }
+
+    protected String randString(int length) {
+        return IntegrationTestBase.randString(length);
+    }
+
+    protected int getRandomIntMetricValue() {
+        return integrationTestBase.getRandomIntMetricValue();
+    }
+
+    protected Map<Locator, String> getLocatorToUnitMap() {
+        return IntegrationTestBase.locatorToUnitMap;
+    }
+
+    protected Metric getRandomIntMetric(final Locator locator, long timestamp) {
+        return integrationTestBase.getRandomIntMetric(locator, timestamp);
+    }
+
+    protected void generateRollups(Locator locator, long from, long to, Granularity destGranularity) throws Exception {
+        integrationTestBase.generateRollups(locator, from, to, destGranularity);
+    }
+
+    protected PreaggregatedMetric getGaugeMetric(String name, String tenantid, long timestamp) {
+        return integrationTestBase.getGaugeMetric(name, tenantid, timestamp);
+    }
 
     @BeforeClass
     public static void setUpHttp() throws Exception {
@@ -106,11 +135,16 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
         // RollupHandler is instantiated.
         Configuration.getInstance().setProperty(CoreConfig.ROLLUP_ON_READ_TIMEOUT_IN_SECONDS, "20");
 
-        setupElasticSearch();
+        // setup config for elastic search
+        Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.ElasticIO");
+        Configuration.getInstance().setProperty(CoreConfig.EVENTS_MODULES.name(), "com.rackspacecloud.blueflood.io.EventElasticSearchIO");
+        Configuration.getInstance().setProperty(CoreConfig.TOKEN_DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.ElasticTokensIO");
+        Configuration.getInstance().setProperty(CoreConfig.ENABLE_TOKEN_SEARCH_IMPROVEMENTS.name(), "true");
 
         setupIngestionServer();
 
         setupQueryServer();
+
 
         // setup vendor and client
         vendor = new HttpClientVendor();
@@ -133,33 +167,6 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
         if (httpIngestionService != null) {
             httpIngestionService.shutdownService();
         }
-
-        if (esSetup != null) {
-            esSetup.terminate();
-        }
-    }
-
-    private static void setupElasticSearch() {
-        // setup elasticsearch
-
-        // setup config
-        System.setProperty(CoreConfig.DISCOVERY_MODULES.name(), "com.rackspacecloud.blueflood.io.ElasticIO");
-        System.setProperty(CoreConfig.EVENTS_MODULES.name(), "com.rackspacecloud.blueflood.io.EventElasticSearchIO");
-
-        // setup elasticsearch test clusters with blueflood mappings
-        esSetup = new EsSetup();
-        esSetup.execute(EsSetup.deleteAll());
-        esSetup.execute(EsSetup.createIndex(ElasticIO.ELASTICSEARCH_INDEX_NAME_WRITE)
-                .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
-        esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
-                .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
-
-        // create elaticsearch client and link it to ModuleLoader
-        elasticIO = new ElasticIO(esSetup.client());
-        eventsSearchIO = new EventElasticSearchIO(esSetup.client());
-        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(esSetup.client());
     }
 
     private static void setupIngestionServer() throws Exception {
@@ -168,6 +175,7 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
         context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
         httpPortIngest = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_INGESTION_PORT);
         HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context);
+        eventsSearchIO = new EventElasticSearchIO();
         server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
         httpIngestionService = new HttpIngestionService();
         httpIngestionService.setMetricsIngestionServer(server);
@@ -187,7 +195,7 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
     public URI getQueryURI(String queryPath) throws URISyntaxException {
         // build and return a query path with query port and parameters set from the parameters
         URIBuilder builder = new URIBuilder().setScheme("http").setHost("127.0.0.1")
-                .setPort(httpPortQuery).setPath(queryPath);
+                                             .setPort(httpPortQuery).setPath(queryPath);
 
         Set<String> parameters = parameterMap.keySet();
         Iterator<String> setIterator = parameters.iterator();
@@ -331,20 +339,20 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
 
     public URIBuilder getMetricsURIBuilder() throws URISyntaxException {
         return new URIBuilder().setScheme("http").setHost("127.0.0.1")
-                .setPort(httpPortIngest).setPath("/v2.0/tenantId/ingest");
+                               .setPort(httpPortIngest).setPath("/v2.0/tenantId/ingest");
     }
 
     public URIBuilder getMetricDataQueryURIBuilder() throws URISyntaxException {
         return new URIBuilder().setScheme("http").setHost("127.0.0.1")
-                .setPort(httpPortQuery).setPath(getSearchPath)
-                .setParameter("query", "call*");
+                               .setPort(httpPortQuery).setPath(getSearchPath)
+                               .setParameter("query", "call*");
     }
 
     public URIBuilder getRollupsQueryURIBuilder() throws URISyntaxException {
         return new URIBuilder().setScheme("http").setHost("127.0.0.1")
-                .setPort(httpPortQuery).setPath("/v2.0/tenantId/views")
-                .setParameter("from", "100000000")
-                .setParameter("to", "200000000");
+                               .setPort(httpPortQuery).setPath("/v2.0/tenantId/views")
+                               .setParameter("from", "100000000")
+                               .setParameter("to", "200000000");
     }
 
     protected String[] getBodyArray( HttpResponse response ) throws IOException {
@@ -387,7 +395,7 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
             for (Resolution resolution : Resolution.values()) {
                 Granularity g = Granularity.granularities()[resolution.getValue()];
                 checkHttpHandlersGetByResolution(locator, resolution, baseMillis, baseMillis + 86400000,
-                        answers.get(locator).get(g), httpHandler);
+                                                 answers.get(locator).get(g), httpHandler);
             }
         }
     }
@@ -395,18 +403,18 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
     protected void checkHttpHandlersGetByResolution(Locator locator, Resolution resolution, long from, long to,
                                                     int expectedPoints, HttpRollupsQueryHandler handler) throws Exception {
         int currentPoints = getNumberOfPointsViaHTTPHandler(handler, locator,
-                from, to, resolution);
+                                                            from, to, resolution);
 
         Assert.assertEquals(String.format("locator=%s, resolution=%s, from=%d, to=%d, expectedPoints=%d and currentPoints=%d should be the same",
-                locator, resolution.toString(), from, to, expectedPoints, currentPoints),
-                expectedPoints, currentPoints);
+                                          locator, resolution.toString(), from, to, expectedPoints, currentPoints),
+                            expectedPoints, currentPoints);
     }
 
     protected int getNumberOfPointsViaHTTPHandler(HttpRollupsQueryHandler handler,
                                                   Locator locator, long from, long to,
                                                   Resolution resolution) throws Exception {
         final MetricData values = handler.GetDataByResolution(locator.getTenantId(),
-                locator.getMetricName(), from, to, resolution);
+                                                              locator.getMetricName(), from, to, resolution);
         return values.getData().getPoints().size();
     }
 
@@ -421,8 +429,8 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
                         to,
                         points.get(g2));
                 Assert.assertEquals(String.format("locator=%s, from=%d, to=%d, expectedPoints=%d and currentPoints=%d should be the same",
-                        locator, from, to, answers.get(locator).get(g2), data.getData().getPoints().size()),
-                        (int)answers.get(locator).get(g2), data.getData().getPoints().size());
+                                                  locator, from, to, answers.get(locator).get(g2), data.getData().getPoints().size()),
+                                    (int)answers.get(locator).get(g2), data.getData().getPoints().size());
                 // Disabling test that fail on ES
                 // Assert.assertEquals(locatorToUnitMap.get(locator), data.getUnit());
             }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndIntegrationTest.java
@@ -15,8 +15,8 @@
  */
 package com.rackspacecloud.blueflood.inputs.handlers;
 
-import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
+import com.rackspacecloud.blueflood.http.HttpESIntegrationBase;
 import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
 import com.rackspacecloud.blueflood.io.EventsIO;
 import com.rackspacecloud.blueflood.outputs.handlers.HttpMetricDataQueryServer;
@@ -35,7 +35,7 @@ import org.apache.http.util.EntityUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.net.URI;
@@ -44,7 +44,17 @@ import java.util.*;
 
 import static org.mockito.Mockito.spy;
 
-public class HttpAnnotationsEndToEndTest {
+
+/**
+ * The current scope gives us one cluster for all test methods in the test.
+ * All indices and templates are deleted between each test.
+ *
+ * The following flags have to be set while running this test
+ * -Dtests.jarhell.check=false (to handle some bug in intellij https://github.com/elastic/elasticsearch/issues/14348)
+ * -Dtests.security.manager=false (https://github.com/elastic/elasticsearch/issues/16459)
+ *
+ */
+public class HttpAnnotationsEndToEndIntegrationTest extends HttpESIntegrationBase {
     private static HttpIngestionService httpIngestionService;
     private static HttpClientVendor vendor;
     private static DefaultHttpClient client;
@@ -55,12 +65,11 @@ public class HttpAnnotationsEndToEndTest {
     private static EventsIO eventsSearchIO;
     private static HttpQueryService httpQueryService;
     private final String tenant_id = "333333";
-    private static EsSetup esSetup;
     //A time stamp 2 days ago
     private final long baseMillis = Calendar.getInstance().getTimeInMillis() - 172800000;
 
-    @BeforeClass
-    public static void setUp() throws Exception {
+    @Before
+    public void setup() throws Exception {
         System.setProperty(CoreConfig.EVENTS_MODULES.name(), "com.rackspacecloud.blueflood.io.EventElasticSearchIO");
         Configuration.getInstance().init();
         httpPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_INGESTION_PORT);
@@ -68,12 +77,11 @@ public class HttpAnnotationsEndToEndTest {
         manageShards.add(1); manageShards.add(5); manageShards.add(6);
         context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
 
-        esSetup = new EsSetup();
-        esSetup.execute(EsSetup.deleteAll());
-        esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
-                .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
-        eventsSearchIO = new EventElasticSearchIO(esSetup.client());
+        createIndexAndMapping(EventElasticSearchIO.EVENT_INDEX,
+                              "graphite_event",
+                              getEventsMapping());
+
+        eventsSearchIO = new EventElasticSearchIO(getClient());
         HttpMetricsIngestionServer server = new HttpMetricsIngestionServer(context);
         server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
 
@@ -154,10 +162,6 @@ public class HttpAnnotationsEndToEndTest {
     public static void tearDownClass() throws Exception{
         Configuration.getInstance().setProperty(CoreConfig.EVENTS_MODULES.name(), "");
         System.clearProperty(CoreConfig.EVENTS_MODULES.name());
-        if (esSetup != null) {
-            esSetup.terminate();
-        }
-
         if (vendor != null) {
             vendor.shutdown();
         }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerAnnotationIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerAnnotationIntegrationTest.java
@@ -1,13 +1,11 @@
 package com.rackspacecloud.blueflood.inputs.handlers;
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.Event;
-import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
@@ -38,10 +36,7 @@ public class HttpHandlerAnnotationIntegrationTest extends HttpIntegrationTestBas
 
     @Before
     public void setup() throws ExecutionException, InterruptedException {
-        createIndexAndMapping(EventElasticSearchIO.EVENT_INDEX,
-                              "graphite_event",
-                              getEventsMapping());
-
+        super.esSetup();
         ((EventElasticSearchIO) eventsSearchIO).setClient(getClient());
     }
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerIntegrationTest.java
@@ -18,14 +18,15 @@ package com.rackspacecloud.blueflood.inputs.handlers;
 
 import com.google.common.net.HttpHeaders;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
-import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.io.CassandraModel;
+import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
+import com.rackspacecloud.blueflood.io.IOContainer;
+import com.rackspacecloud.blueflood.io.MetricsRW;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
 import com.rackspacecloud.blueflood.rollup.Granularity;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.*;
-import com.rackspacecloud.blueflood.utils.ModuleLoader;
-import com.rackspacecloud.blueflood.utils.TimeValue;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -41,17 +42,11 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
 import static com.rackspacecloud.blueflood.TestUtils.*;
-import static java.util.stream.Collectors.toList;
 import static org.mockito.Mockito.*;
 
 /**
@@ -71,24 +66,7 @@ public class HttpHandlerIntegrationTest extends HttpIntegrationTestBase {
 
     @Before
     public void setup() throws Exception {
-        // setup elasticsearch test clusters with blueflood mappings
-        createIndexAndMapping(EventElasticSearchIO.EVENT_INDEX,
-                              "graphite_event",
-                              getEventsMapping());
-
-        // setup elasticsearch test clusters with blueflood mappings
-        createIndexAndMapping(ElasticIO.ELASTICSEARCH_INDEX_NAME_WRITE,
-                              ElasticIO.ES_DOCUMENT_TYPE,
-                              getMetricsMapping());
-
-        createIndexAndMapping(ElasticTokensIO.ELASTICSEARCH_TOKEN_INDEX_NAME_WRITE,
-                              ElasticTokensIO.ES_DOCUMENT_TYPE,
-                              getTokensMapping());
-
-        refreshChanges();
-
-        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(getClient());
-        ((ElasticTokensIO) ModuleLoader.getInstance(TokenDiscoveryIO.class, CoreConfig.TOKEN_DISCOVERY_MODULES)).setClient(getClient());
+        super.esSetup();
         ((EventElasticSearchIO) eventsSearchIO).setClient(getClient());
     }
 

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionServerShutdownIntegrationTest.java
@@ -17,13 +17,16 @@
 package com.rackspacecloud.blueflood.inputs.handlers;
 
 
-import com.github.tlrx.elasticsearch.test.EsSetup;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.rackspacecloud.blueflood.http.HttpClientVendor;
-import com.rackspacecloud.blueflood.io.*;
+import com.rackspacecloud.blueflood.http.HttpESIntegrationBase;
+import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
+import com.rackspacecloud.blueflood.io.EventsIO;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.HttpConfig;
 import com.rackspacecloud.blueflood.service.ScheduleContext;
+import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -40,10 +43,20 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashSet;
 
-import static org.mockito.Mockito.*;
-import static com.rackspacecloud.blueflood.TestUtils.*;
+import static com.rackspacecloud.blueflood.TestUtils.generateJSONMetricsData;
+import static org.mockito.Mockito.spy;
 
-public class HttpMetricsIngestionServerShutdownIntegrationTest {
+/**
+ *
+ * The current scope gives us one cluster for all test methods in the test.
+ * All indices and templates are deleted between each test.
+ *
+ * The following flags have to be set while running this test
+ * -Dtests.jarhell.check=false (to handle some bug in intellij https://github.com/elastic/elasticsearch/issues/14348)
+ * -Dtests.security.manager=false (https://github.com/elastic/elasticsearch/issues/16459)
+ *
+ */
+public class HttpMetricsIngestionServerShutdownIntegrationTest extends HttpESIntegrationBase {
 
     private static HttpMetricsIngestionServer server;
     private static HttpClientVendor vendor;
@@ -52,32 +65,37 @@ public class HttpMetricsIngestionServerShutdownIntegrationTest {
     private static int httpPort;
     private static ScheduleContext context;
     private static EventsIO eventsSearchIO;
-    private static EsSetup esSetup;
     //A time stamp 2 days ago
     private final long baseMillis = Calendar.getInstance().getTimeInMillis() - 172800000;
 
 
     @BeforeClass
-    public static void setUp() throws Exception{
+    public static void setUpHttpService() throws Exception{
         System.setProperty(CoreConfig.EVENTS_MODULES.name(), "com.rackspacecloud.blueflood.io.EventElasticSearchIO");
         Configuration.getInstance().init();
         httpPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_INGESTION_PORT);
         manageShards.add(1); manageShards.add(5); manageShards.add(6);
         context = spy(new ScheduleContext(System.currentTimeMillis(), manageShards));
 
-        esSetup = new EsSetup();
-        esSetup.execute(EsSetup.deleteAll());
-        esSetup.execute(EsSetup.createIndex(EventElasticSearchIO.EVENT_INDEX)
-                .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("graphite_event", EsSetup.fromClassPath("events_mapping.json")));
-        eventsSearchIO = new EventElasticSearchIO(esSetup.client());
-        server = new HttpMetricsIngestionServer(context);
-        server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
-
-        server.startServer();
-
         vendor = new HttpClientVendor();
         client = vendor.getClient();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        // setup elasticsearch test clusters with blueflood mappings
+        createIndexAndMapping(EventElasticSearchIO.EVENT_INDEX,
+                              "graphite_event",
+                              getEventsMapping());
+
+        eventsSearchIO = new EventElasticSearchIO(getClient());
+        ((EventElasticSearchIO) ModuleLoader.getInstance(EventElasticSearchIO.class, CoreConfig.EVENTS_MODULES)).setClient(getClient());
+
+        server = new HttpMetricsIngestionServer(context);
+        server.setHttpEventsIngestionHandler(new HttpEventsIngestionHandler(eventsSearchIO));
+        server.startServer();
+
+        refreshChanges();
     }
 
     @Test
@@ -112,7 +130,7 @@ public class HttpMetricsIngestionServerShutdownIntegrationTest {
             // the port is no longer open) is to catch the exception object and
             // check its message. Hence, this try/catch.
 
-            Assert.assertEquals("Connection refused", ex.getMessage());
+            Assert.assertTrue(ex.getMessage().contains("Connection refused"));
         }
     }
 
@@ -129,9 +147,6 @@ public class HttpMetricsIngestionServerShutdownIntegrationTest {
     public static void shutdown() {
         Configuration.getInstance().setProperty(CoreConfig.EVENTS_MODULES.name(), "");
         System.clearProperty(CoreConfig.EVENTS_MODULES.name());
-        if (esSetup != null) {
-            esSetup.terminate();
-        }
 
         if (vendor != null) {
             vendor.shutdown();

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerIntegrationTest.java
@@ -17,16 +17,37 @@
 package com.rackspacecloud.blueflood.outputs.handlers;
 
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
+import com.rackspacecloud.blueflood.inputs.handlers.HttpEventsIngestionHandler;
+import com.rackspacecloud.blueflood.io.DiscoveryIO;
+import com.rackspacecloud.blueflood.io.ElasticIO;
+import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
+import com.rackspacecloud.blueflood.io.EventsIO;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.service.HttpIngestionService;
 import com.rackspacecloud.blueflood.types.Event;
-import org.apache.http.util.EntityUtils;
-import org.junit.*;
+import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Integration Tests for GET .../events/getEvents
+ *
+ * The current scope gives us one cluster for all test methods in the test.
+ * All indices and templates are deleted between each test.
+ *
+ * The following flags have to be set while running this test
+ * -Dtests.jarhell.check=false (to handle some bug in intellij https://github.com/elastic/elasticsearch/issues/14348)
+ * -Dtests.security.manager=false (https://github.com/elastic/elasticsearch/issues/16459)
+ *
  */
 public class HttpEventsQueryHandlerIntegrationTest extends HttpIntegrationTestBase {
 
@@ -34,8 +55,15 @@ public class HttpEventsQueryHandlerIntegrationTest extends HttpIntegrationTestBa
 
     @Before
     public void setup() throws Exception {
+        // setup elasticsearch test clusters with blueflood mappings
+        createIndexAndMapping(EventElasticSearchIO.EVENT_INDEX,
+                              "graphite_event",
+                              getEventsMapping());
+
+        ((EventElasticSearchIO) eventsSearchIO).setClient(getClient());
+
         createAndInsertTestEvents(tenantId, 5);
-        esSetup.client().admin().indices().prepareRefresh().execute().actionGet();
+        refreshChanges();
     }
 
     @Test

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerIntegrationTest.java
@@ -17,15 +17,8 @@
 package com.rackspacecloud.blueflood.outputs.handlers;
 
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
-import com.rackspacecloud.blueflood.inputs.handlers.HttpEventsIngestionHandler;
-import com.rackspacecloud.blueflood.io.DiscoveryIO;
-import com.rackspacecloud.blueflood.io.ElasticIO;
 import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
-import com.rackspacecloud.blueflood.io.EventsIO;
-import com.rackspacecloud.blueflood.service.CoreConfig;
-import com.rackspacecloud.blueflood.service.HttpIngestionService;
 import com.rackspacecloud.blueflood.types.Event;
-import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
@@ -55,11 +48,7 @@ public class HttpEventsQueryHandlerIntegrationTest extends HttpIntegrationTestBa
 
     @Before
     public void setup() throws Exception {
-        // setup elasticsearch test clusters with blueflood mappings
-        createIndexAndMapping(EventElasticSearchIO.EVENT_INDEX,
-                              "graphite_event",
-                              getEventsMapping());
-
+        super.esSetup();
         ((EventElasticSearchIO) eventsSearchIO).setClient(getClient());
 
         createAndInsertTestEvents(tenantId, 5);

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricNamesHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricNamesHandlerIntegrationTest.java
@@ -19,12 +19,10 @@ package com.rackspacecloud.blueflood.outputs.handlers;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
-import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Metric;
 import com.rackspacecloud.blueflood.types.Token;
-import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.http.HttpResponse;
@@ -65,21 +63,12 @@ public class HttpMetricNamesHandlerIntegrationTest extends HttpIntegrationTestBa
     @Before
     public void setup() throws Exception {
 
-        // setup elasticsearch test clusters with blueflood mappings
-        createIndexAndMapping(ElasticIO.ELASTICSEARCH_INDEX_NAME_WRITE,
-                              ElasticIO.ES_DOCUMENT_TYPE,
-                              getMetricsMapping());
-
-        createIndexAndMapping(ElasticTokensIO.ELASTICSEARCH_TOKEN_INDEX_NAME_WRITE,
-                              ElasticTokensIO.ES_DOCUMENT_TYPE,
-                              getTokensMapping());
+        super.esSetup();
+        ((EventElasticSearchIO) eventsSearchIO).setClient(getClient());
 
         // create elasticsearch client and link it to ModuleLoader
         elasticIO = new ElasticIO(getClient());
         elasticTokensIO = new ElasticTokensIO(getClient());
-
-        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(getClient());
-        ((ElasticTokensIO) ModuleLoader.getInstance(TokenDiscoveryIO.class, CoreConfig.TOKEN_DISCOVERY_MODULES)).setClient(getClient());
 
         // setup metrics to be searchable
         MetricsRW metricsRW = IOContainer.fromConfig().getBasicMetricsRW();

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricNamesHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricNamesHandlerIntegrationTest.java
@@ -17,12 +17,14 @@
 package com.rackspacecloud.blueflood.outputs.handlers;
 
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
-import com.rackspacecloud.blueflood.io.IOContainer;
-import com.rackspacecloud.blueflood.io.MetricsRW;
+import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Metric;
+import com.rackspacecloud.blueflood.types.Token;
+import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.http.HttpResponse;
@@ -38,11 +40,20 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
-import static junit.framework.Assert.assertEquals;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Integration Tests for GET .../metric_name/search
+ *
+ * The current scope gives us one cluster for all test methods in the test.
+ * All indices and templates are deleted between each test.
+ *
+ * The following flags have to be set while running this test
+ * -Dtests.jarhell.check=false (to handle some bug in intellij https://github.com/elastic/elasticsearch/issues/14348)
+ * -Dtests.security.manager=false (https://github.com/elastic/elasticsearch/issues/16459)
+ *
  */
 public class HttpMetricNamesHandlerIntegrationTest extends HttpIntegrationTestBase {
 
@@ -54,7 +65,21 @@ public class HttpMetricNamesHandlerIntegrationTest extends HttpIntegrationTestBa
     @Before
     public void setup() throws Exception {
 
-        super.setUp();
+        // setup elasticsearch test clusters with blueflood mappings
+        createIndexAndMapping(ElasticIO.ELASTICSEARCH_INDEX_NAME_WRITE,
+                              ElasticIO.ES_DOCUMENT_TYPE,
+                              getMetricsMapping());
+
+        createIndexAndMapping(ElasticTokensIO.ELASTICSEARCH_TOKEN_INDEX_NAME_WRITE,
+                              ElasticTokensIO.ES_DOCUMENT_TYPE,
+                              getTokensMapping());
+
+        // create elasticsearch client and link it to ModuleLoader
+        elasticIO = new ElasticIO(getClient());
+        elasticTokensIO = new ElasticTokensIO(getClient());
+
+        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(getClient());
+        ((ElasticTokensIO) ModuleLoader.getInstance(TokenDiscoveryIO.class, CoreConfig.TOKEN_DISCOVERY_MODULES)).setClient(getClient());
 
         // setup metrics to be searchable
         MetricsRW metricsRW = IOContainer.fromConfig().getBasicMetricsRW();
@@ -63,12 +88,15 @@ public class HttpMetricNamesHandlerIntegrationTest extends HttpIntegrationTestBa
         for (int i = 0; i < numMetrics; i++) {
             long curMillis = baseMillis + i;
             Locator locator = Locator.createLocatorFromPathComponents(tenantId, metricPrefix + "." + i);
-            Metric metric = new Metric(locator, getRandomIntMetricValue(), curMillis, new TimeValue(1, TimeUnit.DAYS), locatorToUnitMap.get(locator));
+            Metric metric = new Metric(locator, getRandomIntMetricValue(), curMillis, new TimeValue(1, TimeUnit.DAYS), getLocatorToUnitMap().get(locator));
             metrics.add(metric);
         }
 
         elasticIO.insertDiscovery(new ArrayList<IMetric>(metrics));
-        esSetup.client().admin().indices().prepareRefresh().execute().actionGet();
+
+        Stream<Locator> locators = metrics.stream().map(IMetric::getLocator);
+        elasticTokensIO.insertDiscovery(Token.getUniqueTokens(locators).collect(toList()));
+        refreshChanges();
 
         metricsRW.insertMetrics(metrics);
     }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerIntegrationTest.java
@@ -17,16 +17,14 @@
 package com.rackspacecloud.blueflood.outputs.handlers;
 
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
-import com.rackspacecloud.blueflood.io.DiscoveryIO;
 import com.rackspacecloud.blueflood.io.ElasticIO;
+import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
 import com.rackspacecloud.blueflood.io.IOContainer;
 import com.rackspacecloud.blueflood.io.MetricsRW;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
-import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.IMetric;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.Metric;
-import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.http.HttpResponse;
@@ -63,10 +61,8 @@ public class HttpMetricsIndexHandlerIntegrationTest extends HttpIntegrationTestB
     @Before
     public void setup() throws Exception {
 
-        // setup elasticsearch test clusters with blueflood mappings
-        createIndexAndMapping(ElasticIO.ELASTICSEARCH_INDEX_NAME_WRITE,
-                              ElasticIO.ES_DOCUMENT_TYPE,
-                              getMetricsMapping());
+        super.esSetup();
+        ((EventElasticSearchIO) eventsSearchIO).setClient(getClient());
 
         // setup metrics to be searchable
         MetricsRW metricsRW = IOContainer.fromConfig().getBasicMetricsRW();
@@ -81,7 +77,6 @@ public class HttpMetricsIndexHandlerIntegrationTest extends HttpIntegrationTestB
 
         // create elasticsearch client and link it to ModuleLoader
         elasticIO = new ElasticIO(getClient());
-        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(getClient());
 
         elasticIO.insertDiscovery(new ArrayList<IMetric>(metrics));
         refreshChanges();

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -22,15 +22,12 @@ import com.google.gson.JsonParser;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.*;
-
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Integration Tests for POST .../views (aka Multiplot views)

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpOptionsHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpOptionsHandlerIntegrationTest.java
@@ -39,7 +39,7 @@ public class HttpOptionsHandlerIntegrationTest extends HttpIntegrationTestBase {
     private String allowedMaxAge;
 
     @Before
-    public void setUp() {
+    public void setUp1() {
         parameterMap = new HashMap<String, String>();
         allowedOrigins = Configuration.getInstance().getStringProperty(CoreConfig.CORS_ALLOWED_ORIGINS).split(",");
         allowedHeaders = Configuration.getInstance().getStringProperty(CoreConfig.CORS_ALLOWED_HEADERS).split(",");

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpOptionsHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpOptionsHandlerIntegrationTest.java
@@ -16,6 +16,7 @@
 package com.rackspacecloud.blueflood.outputs.handlers;
 
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
+import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import org.apache.http.Header;
@@ -39,7 +40,10 @@ public class HttpOptionsHandlerIntegrationTest extends HttpIntegrationTestBase {
     private String allowedMaxAge;
 
     @Before
-    public void setUp1() {
+    public void setUp1() throws Exception {
+        super.esSetup();
+        ((EventElasticSearchIO) eventsSearchIO).setClient(getClient());
+
         parameterMap = new HashMap<String, String>();
         allowedOrigins = Configuration.getInstance().getStringProperty(CoreConfig.CORS_ALLOWED_ORIGINS).split(",");
         allowedHeaders = Configuration.getInstance().getStringProperty(CoreConfig.CORS_ALLOWED_HEADERS).split(",");

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
@@ -57,6 +57,9 @@ public class HttpRollupHandlerIntegrationTest extends HttpIntegrationTestBase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
+        super.esSetup();
+        ((EventElasticSearchIO) eventsSearchIO).setClient(getClient());
+
         MetricsRW metricsRW = IOContainer.fromConfig().getBasicMetricsRW();
         IncomingMetricMetadataAnalyzer analyzer = new IncomingMetricMetadataAnalyzer(MetadataCache.getInstance());
         httpHandler = new HttpRollupsQueryHandler();

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerIntegrationTest.java
@@ -25,6 +25,7 @@ import com.rackspacecloud.blueflood.service.*;
 import com.rackspacecloud.blueflood.types.*;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
@@ -48,23 +49,10 @@ public class HttpRollupHandlerIntegrationTest extends HttpIntegrationTestBase {
             Locator.createLocatorFromPathComponents(tenantId, metricName),
             Locator.createLocatorFromPathComponents(tenantId, anotherMetricName)
     };
-    private static int queryPort = 20000;
-    private static HttpQueryService httpQueryService;
-    private static HttpClientVendor vendor;
-    private static DefaultHttpClient client;
+    private static int queryPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT);
 
     private HttpRollupsQueryHandler httpHandler;
     private final Map<Locator, Map<Granularity, Integer>> locatorToPoints = new HashMap<Locator, Map<Granularity,Integer>>();
-
-    @BeforeClass
-    public static void setUpHttp() throws Exception {
-        // this method suppress the @BeforeClass method of the parent
-        queryPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT);
-        httpQueryService = new HttpQueryService();
-        httpQueryService.startService();
-        vendor = new HttpClientVendor();
-        client = vendor.getClient();
-    }
 
     @Before
     public void setUp() throws Exception {
@@ -133,25 +121,25 @@ public class HttpRollupHandlerIntegrationTest extends HttpIntegrationTestBase {
         testHappyCaseMultiFetchHTTPRequest(Arrays.asList(locators), tenantId, client);
     }
 
-    public static void testHappyCaseHTTPRequest(String metricName, String tenantId, DefaultHttpClient client) throws Exception {
+    public static void testHappyCaseHTTPRequest(String metricName, String tenantId, HttpClient client) throws Exception {
         HttpGet get = new HttpGet(getMetricsQueryURI(metricName, tenantId));
         HttpResponse response = client.execute(get);
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
-    public static void testBadRequest(String metricName, String tenantId, DefaultHttpClient client) throws Exception {
+    public static void testBadRequest(String metricName, String tenantId, HttpClient client) throws Exception {
         HttpGet get = new HttpGet(getInvalidMetricsQueryURI(metricName, tenantId));
         HttpResponse response = client.execute(get);
         Assert.assertEquals(400, response.getStatusLine().getStatusCode());
     }
 
-    public static void testBadMethod(String metricName, String tenantId, DefaultHttpClient client) throws Exception {
+    public static void testBadMethod(String metricName, String tenantId, HttpClient client) throws Exception {
         HttpPost post = new HttpPost(getMetricsQueryURI(metricName, tenantId));
         HttpResponse response = client.execute(post);
         Assert.assertEquals(405, response.getStatusLine().getStatusCode());
     }
 
-    public static void testHappyCaseMultiFetchHTTPRequest(List<Locator> locators, String tenantId, DefaultHttpClient client) throws Exception {
+    public static void testHappyCaseMultiFetchHTTPRequest(List<Locator> locators, String tenantId, HttpClient client) throws Exception {
         HttpPost post = new HttpPost(getBatchMetricsQueryURI(tenantId));
         JSONArray metricsToGet = new JSONArray();
         for (Locator locator : locators) {
@@ -187,16 +175,5 @@ public class HttpRollupHandlerIntegrationTest extends HttpIntegrationTestBase {
                 .setParameter("from", String.valueOf(baseMillis))
                 .setParameter("resolution", "full");  // Misses parameter 'to'
         return builder.build();
-    }
-
-    @AfterClass
-    public static void shutdown() {
-        if (vendor != null) {
-            vendor.shutdown();
-        }
-
-        if (httpQueryService != null) {
-            httpQueryService.stopService();
-        }
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -21,10 +21,8 @@ import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
-import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.IncomingMetricMetadataAnalyzer;
 import com.rackspacecloud.blueflood.types.*;
-import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import com.rackspacecloud.blueflood.utils.Util;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -61,10 +59,8 @@ public class HttpRollupHandlerWithESIntegrationTest extends HttpIntegrationTestB
     @Before
     public void setup() throws Exception {
 
-        // setup elasticsearch test clusters with blueflood mappings
-        createIndexAndMapping(ElasticIO.ELASTICSEARCH_INDEX_NAME_WRITE,
-                              ElasticIO.ES_DOCUMENT_TYPE,
-                              getMetricsMapping());
+        super.esSetup();
+        ((EventElasticSearchIO) eventsSearchIO).setClient(getClient());
 
         MetricsRW metricsRW = IOContainer.fromConfig().getBasicMetricsRW();
         IncomingMetricMetadataAnalyzer analyzer = new IncomingMetricMetadataAnalyzer(MetadataCache.getInstance());
@@ -77,7 +73,6 @@ public class HttpRollupHandlerWithESIntegrationTest extends HttpIntegrationTestB
         }
 
         elasticIO = new ElasticIO(getClient());
-        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(getClient());
 
         elasticIO.insertDiscovery(new ArrayList<IMetric>(metrics));
         refreshChanges();

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupHandlerWithESIntegrationTest.java
@@ -16,64 +16,56 @@
 
 package com.rackspacecloud.blueflood.outputs.handlers;
 
-import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.cache.MetadataCache;
-import com.rackspacecloud.blueflood.http.HttpClientVendor;
+import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import com.rackspacecloud.blueflood.io.*;
 import com.rackspacecloud.blueflood.outputs.formats.MetricData;
 import com.rackspacecloud.blueflood.rollup.Granularity;
-import com.rackspacecloud.blueflood.service.*;
+import com.rackspacecloud.blueflood.service.CoreConfig;
+import com.rackspacecloud.blueflood.service.IncomingMetricMetadataAnalyzer;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.ModuleLoader;
 import com.rackspacecloud.blueflood.utils.Util;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 
-public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase {
+/**
+ *
+ * The current scope gives us one cluster for all test methods in the test.
+ * All indices and templates are deleted between each test.
+ *
+ * The following flags have to be set while running this test
+ * -Dtests.jarhell.check=false (to handle some bug in intellij https://github.com/elastic/elasticsearch/issues/14348)
+ * -Dtests.security.manager=false (https://github.com/elastic/elasticsearch/issues/16459)
+ *
+ */
+public class HttpRollupHandlerWithESIntegrationTest extends HttpIntegrationTestBase {
     //A time stamp 2 days ago
     private final long baseMillis = Calendar.getInstance().getTimeInMillis() - 172800000;
     private final String tenantId = "ac" + IntegrationTestBase.randString(8);
     private final String metricName = "met_" + IntegrationTestBase.randString(8);
     private final Locator locator = Locator.createLocatorFromPathComponents(tenantId, metricName);
-    private static int queryPort;
     private Map<Granularity, Integer> granToPoints = new HashMap<Granularity,Integer>();
     private HttpRollupsQueryHandler httpHandler;
     private static ElasticIO elasticIO;
-    private static EsSetup esSetup;
-    private static HttpQueryService httpQueryService;
-    private static HttpClientVendor vendor;
-    private static DefaultHttpClient client;
     IMetric metric;
-
-    @BeforeClass
-    public static void setUpHttp() throws Exception {
-        Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(),
-                "com.rackspacecloud.blueflood.io.ElasticIO");
-        Configuration.getInstance().setProperty(CoreConfig.USE_ES_FOR_UNITS.name(), "true");
-        queryPort = Configuration.getInstance().getIntegerProperty(HttpConfig.HTTP_METRIC_DATA_QUERY_PORT);
-        httpQueryService = new HttpQueryService();
-        httpQueryService.startService();
-        vendor = new HttpClientVendor();
-        client = vendor.getClient();
-
-        esSetup = new EsSetup();
-        esSetup.execute(EsSetup.deleteAll());
-        esSetup.execute(EsSetup.createIndex(ElasticIO.ELASTICSEARCH_INDEX_NAME_WRITE)
-                .withSettings(EsSetup.fromClassPath("index_settings.json"))
-                .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));
-        elasticIO = new ElasticIO(esSetup.client());
-    }
 
     @Before
     public void setup() throws Exception {
-        super.setUp();
+
+        // setup elasticsearch test clusters with blueflood mappings
+        createIndexAndMapping(ElasticIO.ELASTICSEARCH_INDEX_NAME_WRITE,
+                              ElasticIO.ES_DOCUMENT_TYPE,
+                              getMetricsMapping());
+
         MetricsRW metricsRW = IOContainer.fromConfig().getBasicMetricsRW();
         IncomingMetricMetadataAnalyzer analyzer = new IncomingMetricMetadataAnalyzer(MetadataCache.getInstance());
 
@@ -84,14 +76,16 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
             metrics.add(metric);
         }
 
+        elasticIO = new ElasticIO(getClient());
+        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(getClient());
+
         elasticIO.insertDiscovery(new ArrayList<IMetric>(metrics));
-        esSetup.client().admin().indices().prepareRefresh().execute().actionGet();
+        refreshChanges();
 
         analyzer.scanMetrics(new ArrayList<IMetric>(metrics));
         metricsRW.insertMetrics(metrics);
 
         httpHandler = new HttpRollupsQueryHandler();
-        ((ElasticIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES)).setClient(esSetup.client());
 
         // generate every level of rollup for the raw data
         Granularity g = Granularity.FULL;
@@ -147,7 +141,7 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
             //than 'gran'. Therefore the points returned will always be slightly less
             //than the points asked for.
             Assert.assertTrue((int) granToPoints.get(gran) > data.getData().getPoints().size());
-            Assert.assertEquals(locatorToUnitMap.get(locator), data.getUnit());
+            Assert.assertEquals(getLocatorToUnitMap().get(locator), data.getUnit());
 
             i++;
         }
@@ -171,7 +165,7 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
                     baseMillis + 86400000,
                     points.get(gran));
             Assert.assertEquals((int) granToPoints.get(gran), data.getData().getPoints().size());
-            Assert.assertEquals(locatorToUnitMap.get(locator), data.getUnit());
+            Assert.assertEquals(getLocatorToUnitMap().get(locator), data.getUnit());
         }
         Assert.assertFalse(MetadataCache.getInstance().containsKey(locator, MetricMetadata.UNIT.name()));
     }
@@ -198,7 +192,7 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
 
     private URI getMetricsQueryURI(String metricName, String tenantid, long fromTimestamp) throws URISyntaxException {
         URIBuilder builder = new URIBuilder().setScheme("http").setHost("127.0.0.1")
-                .setPort(queryPort).setPath("/v2.0/" + tenantid + "/views/" + metricName)
+                .setPort(httpPortQuery).setPath("/v2.0/" + tenantid + "/views/" + metricName)
                 .setParameter("from", String.valueOf(fromTimestamp))
                 .setParameter("to", String.valueOf(fromTimestamp + 86400000))
                 .setParameter("resolution", "full");
@@ -213,23 +207,5 @@ public class HttpRollupHandlerWithESIntegrationTest extends IntegrationTestBase 
         metricsRW.insertMetrics(metrics);
 
         return metric;
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception{
-        Configuration.getInstance().setProperty(CoreConfig.DISCOVERY_MODULES.name(), "");
-        Configuration.getInstance().setProperty(CoreConfig.USE_ES_FOR_UNITS.name(), "false");
-
-        if (esSetup != null) {
-            esSetup.terminate();
-        }
-
-        if (vendor != null) {
-            vendor.shutdown();
-        }
-
-        if (httpQueryService != null) {
-            httpQueryService.stopService();
-        }
     }
 }

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
@@ -16,19 +16,18 @@
 
 package com.rackspacecloud.blueflood.outputs.handlers;
 
-import com.google.common.base.Strings;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
+import com.rackspacecloud.blueflood.io.EventElasticSearchIO;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-
-import static org.junit.Assert.*;
 
 /**
  * Integration Tests for GET .../views/:metricName (aka Singleplot views)
@@ -39,6 +38,12 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
     private final long now = System.currentTimeMillis();
     private final long start = now - TIME_DIFF_MS;
     private final long end = now + TIME_DIFF_MS;
+
+    @Before
+    public void setup() throws Exception {
+        super.esSetup();
+        ((EventElasticSearchIO) eventsSearchIO).setClient(getClient());
+    }
 
     @Test
     public void testHttpRollupsQueryHandler() throws Exception {

--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpIngestionService.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/service/HttpIngestionService.java
@@ -37,7 +37,7 @@ public class HttpIngestionService implements IngestionService {
         this.server = server;
     }
 
-    private HttpMetricsIngestionServer getHttpMetricsIngestionServer() {
+    protected HttpMetricsIngestionServer getHttpMetricsIngestionServer() {
         if (this.server == null) {
             this.server = new HttpMetricsIngestionServer(this.context);
         }

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/TestUtils.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/TestUtils.java
@@ -68,7 +68,7 @@ public class TestUtils {
      * @throws Exception
      */
     public static String generateJSONMetricsData() throws Exception {
-        return generateJSONMetricsData( System.currentTimeMillis() );
+        return generateJSONMetricsData(System.currentTimeMillis());
     }
 
     /**
@@ -99,7 +99,7 @@ public class TestUtils {
      * @throws Exception
      */
     public static String generateJSONMetricsData( String metricPostfix ) throws Exception {
-        return generateJSONMetricsData( metricPostfix, System.currentTimeMillis() );
+        return generateJSONMetricsData(metricPostfix, System.currentTimeMillis());
     }
 
     /**

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMetricsIngestionHandlerTest.java
@@ -16,7 +16,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.elasticsearch.common.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;

--- a/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandlerTest.java
+++ b/blueflood-http/src/test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpMultitenantMetricsIngestionHandlerTest.java
@@ -12,7 +12,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.elasticsearch.common.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,8 @@
     <skip.integration.tests>false</skip.integration.tests>
     <skip.unit.tests>false</skip.unit.tests>
     <slf4j.version>1.7.6</slf4j.version>
+    <elasticsearch.version>2.4.4</elasticsearch.version>
+    <lucene.version>5.5.2</lucene.version>
     <jodatime.version>2.9</jodatime.version>
     <maven.build.timestamp.format>yyyyMMdd-HHmmss</maven.build.timestamp.format>
   </properties>


### PR DESCRIPTION
    Upgrading ES to 2.x
     - Upgrading ES to 2.4.4 and lucene to 5.5.2
     - Changes to mapping document: Change from index_analyzer to analyzer
     - Changing max limit from 100,000 to 10,000; Externalized this limit.
     - Adding ESIntegTestCase for integration tests
     - Changes to ingest ES client to ElasticIO and ElasticTokensIO
     - Remove references to shaded libraries of old ES
     - Removed old test library, elasticsearch-test
     - Common logic for ES setup is placed in HttpESIntegrationBase