### PR TITLE
Zookeeper: Set the correct lock state when releasing because of ZK disconnect

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ZKShardLockManager.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ZKShardLockManager.java
@@ -627,7 +627,7 @@ class ZKShardLockManager implements ConnectionStateListener, ShardLockManager, Z
          * Triggered during the connection loss. Release the lease, and clear the mutex.
          */
         void connectionLost() {
-            release(false);
+            release(true);
         }
 
         synchronized void setState(LockState newState) {
@@ -737,7 +737,7 @@ class ZKShardLockManager implements ConnectionStateListener, ShardLockManager, Z
                             return false;
                         } finally {
                             lockTaskCount.decrementAndGet();
-                            if (!disconnected) {
+                            if (disconnected) {
                                 setState(LockState.ERROR);
                             } else {
                                 setState(LockState.DISINTERESTED);


### PR DESCRIPTION
The rollup workers currently drop shards when losing connection to ZK because of this bug.