### PR TITLE
Mrit cass es docker compose

### DIFF
--- a/contrib/blueflood-docker-compose/docker-compose-cass-es.yml
+++ b/contrib/blueflood-docker-compose/docker-compose-cass-es.yml
@@ -28,13 +28,13 @@ services:
       - dc1ring
 
     # Maps cassandra data to a local folder. This preserves data across
-    # container restarts. Note a folder n1data get created locally
+    # container restarts. Note a folder 'cassdata' gets created locally in HOME directory.
     volumes:
       - ${HOME}/cassdata:/var/lib/cassandra
 
     # Docker container environment variable. We are using the
     # CASSANDRA_CLUSTER_NAME to name the cluster. This needs to be the same
-    # across clusters. We are also declaring that DC1N1 is a seed node.
+    # across clusters. We are also declaring that 'cassandra' is a seed node.
     environment:
       - CASSANDRA_CLUSTER_NAME=dev_cluster
           - CASSANDRA_SEEDS=cassandra

--- a/contrib/blueflood-docker-compose/docker-compose-cass-es.yml
+++ b/contrib/blueflood-docker-compose/docker-compose-cass-es.yml
@@ -1,0 +1,61 @@
+# using Docker-Compose Version 3
+version: '3'
+
+services:
+  # Configuration for seed cassandra node. Also, this is the only node
+  cassandra:
+    container_name: cassandra-node
+    image: cassandra:2.1
+    ports:
+        - "7000:7000"
+        - "7001:7001"
+        - "9042:9042"
+        - "9160:9160"
+        - "7199:7199"
+
+    # Exposing ports for inter cluster communication.
+    expose:
+      - 7000 # Intra-node communication
+      - 7001 # TLS intra-node communication
+      - 7199 # JMX
+      - 9042 # CQL
+      - 9160 # Thrift service
+
+    command: bash -c 'if [ -z "$$(ls -A /var/lib/cassandra/)" ] ; then sleep 0; fi && /docker-entrypoint.sh cassandra -f'
+
+    # Network for the nodes to communicate
+    networks:
+      - dc1ring
+
+    # Maps cassandra data to a local folder. This preserves data across
+    # container restarts. Note a folder n1data get created locally
+    volumes:
+      - ${HOME}/cassdata:/var/lib/cassandra
+
+    # Docker container environment variable. We are using the
+    # CASSANDRA_CLUSTER_NAME to name the cluster. This needs to be the same
+    # across clusters. We are also declaring that DC1N1 is a seed node.
+    environment:
+      - CASSANDRA_CLUSTER_NAME=dev_cluster
+          - CASSANDRA_SEEDS=cassandra
+
+    # Cassandra ulimt recommended settings
+    ulimits:
+      memlock: -1
+      nproc: 32768
+      nofile: 100000
+
+  elasticsearch:
+    container_name: elasticsearch-node
+    image: elasticsearch:1.7
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    command: elasticsearch -Des.cluster.name="elasticsearch"
+    volumes:
+      - ${HOME}/esdata:/usr/share/elasticsearch/data
+    environment:
+      - cluster.name="elasticsearch"
+
+networks:
+  dc1ring:

--- a/contrib/blueflood-docker-compose/docker-compose-cass-es.yml
+++ b/contrib/blueflood-docker-compose/docker-compose-cass-es.yml
@@ -37,7 +37,7 @@ services:
     # across clusters. We are also declaring that 'cassandra' is a seed node.
     environment:
       - CASSANDRA_CLUSTER_NAME=dev_cluster
-          - CASSANDRA_SEEDS=cassandra
+      - CASSANDRA_SEEDS=cassandra
 
     # Cassandra ulimt recommended settings
     ulimits:


### PR DESCRIPTION
This PR contains a docker-compose file that helps in development process by running Cassandra and Elasticsearch as containers, and leave blueflood out of it. You can run or debug blueflood java code using IntelliJ and don't worry about Cassandra and Elasticsearch as they are taken care of by docker-compose file.
This will create two folders under your HOME directory cassdata (for persistence Cassandra data) and esdata (for persistence Elasticsearch data).