### PR TITLE
Some updates for building new containers

### DIFF
--- a/contrib/blueflood-docker/Dockerfile
+++ b/contrib/blueflood-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7
+FROM java:8
 
 MAINTAINER gaurav.bajaj@rackspace.com
 
@@ -7,7 +7,7 @@ RUN apt-get install -y netcat
 RUN apt-get install -y git
 RUN apt-get install -y python python-dev python-pip python-virtualenv && \
     rm -rf /var/lib/apt/lists/*
-RUN pip install cqlsh==4.1.1
+RUN pip install cqlsh==4.1.1 thrift==0.9.3
 
 COPY ES-Setup /ES-Setup
 COPY load.cdl /blueflood.cdl

--- a/contrib/blueflood-docker/docker-entrypoint.sh
+++ b/contrib/blueflood-docker/docker-entrypoint.sh
@@ -40,7 +40,7 @@ done
 export CASSANDRA_HOSTS="$CASSANDRA_HOST:9160"
 export CASSANDRA_BINXPORT_HOSTS="$CASSANDRA_HOST:9042"
 
-if [ $ROLLUP_KEYSPACE != "DATA" ]
+if [ "$ROLLUP_KEYSPACE" != "DATA" ] && [ -n "$ROLLUP_KEYSPACE" ]
 then
     sed -i "s/\"DATA\"/\"$ROLLUP_KEYSPACE\"/g" blueflood.cdl
 fi


### PR DESCRIPTION
A couple changes I found useful for building a new docker image.

1. Since the work to move everything to java 8,a newly-built docker image barfs unless this is upgraded to Java 89
2. The new image pulls in thrift 0.10.0, which breaks things... similar to [this problem in pycassa](https://github.com/pycassa/pycassa/issues/245).  So, downgrading thrift to 0.9.3 is necessary.
3. I think that 'ROLLUP_KEYSPACE' conditional only worked by totally not working.  Fixed it to make sense and actually work.