### PR TITLE
Added missing IOException to ingest related classes and changed log type to debug for a log text.

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelper.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelper.java
@@ -198,7 +198,7 @@ public class ElasticsearchRestHelper {
             callCount++;
             String url = callQ.remove();
 
-            logger.info("Using url [{}]", url);
+            logger.debug("Using url [{}]", url);
             HttpPost httpPost = new HttpPost(url);
             httpPost.setHeaders(getHeaders());
             HttpEntity httpEntity = new NStringEntity(queryDslString, ContentType.APPLICATION_JSON);
@@ -480,7 +480,7 @@ public class ElasticsearchRestHelper {
         while(!callQ.isEmpty() && callCount < MAX_CALL_COUNT) {
             callCount++;
             String url = callQ.remove();
-            logger.info("Using url [{}]", url);
+            logger.debug("Using url [{}]", url);
             HttpPost httpPost = new HttpPost(url);
             httpPost.setHeaders(getHeaders());
             httpPost.setEntity(entity);


### PR DESCRIPTION
Added IOException to the classes as DiscoveryWriter has some business logic that is dependent on that. Also, moved one of the log text from "Info" to "Debug" type so that it does not fill up the logs.
When Elasticsearch ingest fails, missing IOException will cause data-inconsistency issue between Elasticsearch and Cassandra.