### PR TITLE
unsynchronizes LocatorCache

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -374,13 +374,26 @@
         <version>3.18.2-GA</version>
         <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.tempus-fugit</groupId>
+      <artifactId>tempus-fugit</artifactId>
+      <version>1.2-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
   <repositories>
     <repository>
       <id>clojars.org</id>
       <url>http://clojars.org/repo</url>
+    </repository>
+    <repository>
+      <!-- For tempus-fugit 1.2-SNAPSHOT -->
+      <id>Sonatype</id>
+      <url>https://oss.sonatype.org/content/groups/public/</url>
     </repository>
   </repositories>
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/LocatorCache.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/cache/LocatorCache.java
@@ -100,7 +100,7 @@ public class LocatorCache {
      * @param loc
      * @return
      */
-    public synchronized boolean isLocatorCurrentInBatchLayer(Locator loc) {
+    public boolean isLocatorCurrentInBatchLayer(Locator loc) {
         LocatorCacheEntry entry = insertedLocators.getIfPresent(loc.toString());
         return entry != null && entry.isBatchCurrent();
     }
@@ -111,7 +111,7 @@ public class LocatorCache {
      * @param loc
      * @return
      */
-    public synchronized boolean isLocatorCurrentInDiscoveryLayer(Locator loc) {
+    public boolean isLocatorCurrentInDiscoveryLayer(Locator loc) {
         LocatorCacheEntry entry = insertedLocators.getIfPresent(loc.toString());
         return entry != null && entry.isDiscoveryCurrent();
     }
@@ -122,7 +122,7 @@ public class LocatorCache {
      * @param loc
      * @return
      */
-    public synchronized boolean isLocatorCurrentInTokenDiscoveryLayer(Locator loc) {
+    public boolean isLocatorCurrentInTokenDiscoveryLayer(Locator loc) {
         LocatorCacheEntry entry = insertedLocators.getIfPresent(loc.toString());
         return entry != null && entry.isTokenDiscoveryCurrent();
     }
@@ -134,7 +134,7 @@ public class LocatorCache {
      * @param locator
      * @return
      */
-    public synchronized boolean isDelayedLocatorForASlotCurrent(int slot, Locator locator) {
+    public boolean isDelayedLocatorForASlotCurrent(int slot, Locator locator) {
         return insertedDelayedLocators.getIfPresent(getLocatorSlotKey(slot, locator)) != null;
     }
 
@@ -157,7 +157,7 @@ public class LocatorCache {
      * Marks the Locator as recently inserted in the batch layer
      * @param loc
      */
-    public synchronized void setLocatorCurrentInBatchLayer(Locator loc) {
+    public void setLocatorCurrentInBatchLayer(Locator loc) {
         getOrCreateInsertedLocatorEntry(loc).setBatchCurrent();
     }
 
@@ -165,7 +165,7 @@ public class LocatorCache {
      * Marks the Locator as recently inserted in the discovery layer
      * @param loc
      */
-    public synchronized void setLocatorCurrentInDiscoveryLayer(Locator loc) {
+    public void setLocatorCurrentInDiscoveryLayer(Locator loc) {
         getOrCreateInsertedLocatorEntry(loc).setDiscoveryCurrent();
     }
 
@@ -173,7 +173,7 @@ public class LocatorCache {
      * Marks the Locator as recently inserted in the token discovery layer
      * @param loc
      */
-    public synchronized void setLocatorCurrentInTokenDiscoveryLayer(Locator loc) {
+    public void setLocatorCurrentInTokenDiscoveryLayer(Locator loc) {
         getOrCreateInsertedLocatorEntry(loc).setTokenDiscoveryCurrent();
     }
 
@@ -182,18 +182,18 @@ public class LocatorCache {
      * @param slot
      * @param locator
      */
-    public synchronized void setDelayedLocatorForASlotCurrent(int slot, Locator locator) {
+    public void setDelayedLocatorForASlotCurrent(int slot, Locator locator) {
         insertedDelayedLocators.put(getLocatorSlotKey(slot, locator), Boolean.TRUE);
     }
 
     @VisibleForTesting
-    public synchronized void resetCache() {
+    public void resetCache() {
         insertedLocators.invalidateAll();
         insertedDelayedLocators.invalidateAll();
     }
 
     @VisibleForTesting
-    public synchronized void resetInsertedLocatorsCache() {
+    public void resetInsertedLocatorsCache() {
         insertedLocators.invalidateAll();
     }
 

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/cache/LocatorCacheTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/cache/LocatorCacheTest.java
@@ -1,151 +1,235 @@
 package com.rackspacecloud.blueflood.cache;
 
+import com.google.code.tempusfugit.temporal.Condition;
 import com.rackspacecloud.blueflood.types.Locator;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.TimeUnit;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.*;
 
-import static org.junit.Assert.assertTrue;
+import static com.google.code.tempusfugit.temporal.Duration.millis;
+import static com.google.code.tempusfugit.temporal.Timeout.timeout;
+import static com.google.code.tempusfugit.temporal.WaitFor.waitOrTimeout;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 public class LocatorCacheTest {
 
-    private static final Locator LOCATOR = Locator.createLocatorFromDbKey("a.b.c.d");
-    private LocatorCache locatorCache;
+    private final LocatorCache cache = LocatorCache.getInstance(
+            60, SECONDS, 60, SECONDS);
 
     @Before
-    public void setup() {
-        locatorCache = LocatorCache.getInstance(2L, TimeUnit.SECONDS, 3L, TimeUnit.SECONDS);
-
+    public void setUp() {
+        cache.resetCache();
     }
 
-    @After
-    public void tearDown() {
-        locatorCache.resetCache();
+    /**
+     * Test helper that returns the current-ness of a locator in the cache in all layers. For simplicity, they're
+     * returned in alphabetical order of the layer names: batch, discovery, token discovery. A test should order itself
+     * in this way to keep things understandable.
+     *
+     * @param locator Locator value
+     * @param cache   LocatorCache to check
+     * @return a 3-length list where each item is a boolean describing the current-ness of the locator in the layer
+     */
+    public List<Boolean> getCurrents(Locator locator, LocatorCache cache) {
+        return Arrays.asList(
+                cache.isLocatorCurrentInBatchLayer(locator),
+                cache.isLocatorCurrentInDiscoveryLayer(locator),
+                cache.isLocatorCurrentInTokenDiscoveryLayer(locator)
+        );
     }
 
-    @Test
-    public void testSetLocatorCurrentInBatchLayer() throws InterruptedException {
-
-        locatorCache.setLocatorCurrentInBatchLayer(LOCATOR);
-
-        assertTrue("locator not stored in cache", locatorCache.isLocatorCurrentInBatchLayer(LOCATOR));
-
-        Thread.sleep(2000L); //sleeping for 2 seconds to let the locator expire from cache
-
-        assertTrue("locator not expired from cache", !locatorCache.isLocatorCurrentInBatchLayer(LOCATOR));
-    }
-
-    @Test
-    public void testSetLocatorCurrentInBatchLayerCheckForExpirationWithoutReads() throws InterruptedException {
-
-        locatorCache.setLocatorCurrentInBatchLayer(LOCATOR);
-
-        Thread.sleep(3001L);
-        // it has been more than 3 seconds since it was written.
-        assertTrue("locator not expired from cache", !locatorCache.isLocatorCurrentInBatchLayer(LOCATOR));
-
+    /**
+     * Test helper to shorten test code. Just creates a list of the inputs that can be compared to the result of
+     * {@link #getCurrents(Locator, LocatorCache)}
+     */
+    private List<Boolean> list(Boolean... b) {
+        return Arrays.asList(b);
     }
 
     @Test
-    public void testSetLocatorCurrentInBatchLayerCheckForExpiration() throws InterruptedException {
-
-        locatorCache.setLocatorCurrentInBatchLayer(LOCATOR);
-        assertTrue("locator not stored in cache", locatorCache.isLocatorCurrentInBatchLayer(LOCATOR));
-
-        Thread.sleep(1000L);
-        assertTrue("locator not stored in cache", locatorCache.isLocatorCurrentInBatchLayer(LOCATOR));
-
-        Thread.sleep(1000L);
-        assertTrue("locator not stored in cache", locatorCache.isLocatorCurrentInBatchLayer(LOCATOR));
-
-        Thread.sleep(1001L);
-        // it has been more than 3 seconds since it was written. So it has to expire even if it was accessed 1sec before.
-        assertTrue("locator not expired from cache", !locatorCache.isLocatorCurrentInBatchLayer(LOCATOR));
-
+    public void tracksCurrencyOfOneLocatorAcrossLayers() {
+        Locator locator = Locator.createLocatorFromDbKey("a.b.c.d");
+        assertThat(getCurrents(locator, cache), equalTo(list(false, false, false)));
+        cache.setLocatorCurrentInBatchLayer(locator);
+        assertThat(getCurrents(locator, cache), equalTo(list(true, false, false)));
+        cache.setLocatorCurrentInDiscoveryLayer(locator);
+        assertThat(getCurrents(locator, cache), equalTo(list(true, true, false)));
+        cache.setLocatorCurrentInTokenDiscoveryLayer(locator);
+        assertThat(getCurrents(locator, cache), equalTo(list(true, true, true)));
     }
 
     @Test
-    public void testIsLocatorCurrentInBatchLayer() throws InterruptedException {
-        assertTrue("locator which was never set is present in cache", !locatorCache.isLocatorCurrentInBatchLayer(LOCATOR));
-
-        locatorCache.setLocatorCurrentInBatchLayer(LOCATOR);
-        assertTrue("locator not stored in cache", locatorCache.isLocatorCurrentInBatchLayer(LOCATOR));
-
+    public void tracksCurrencyOfMultipleLocatorsInBatchLayer() {
+        Locator locator1 = Locator.createLocatorFromDbKey("1.1.1");
+        Locator locator2 = Locator.createLocatorFromDbKey("2.2.2");
+        Locator locator3 = Locator.createLocatorFromDbKey("3.3.3");
+        assertThat(getCurrents(locator1, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, false)));
+        cache.setLocatorCurrentInBatchLayer(locator1);
+        assertThat(getCurrents(locator1, cache), equalTo(list(true, false, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, false)));
+        cache.setLocatorCurrentInBatchLayer(locator2);
+        assertThat(getCurrents(locator1, cache), equalTo(list(true, false, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(true, false, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, false)));
+        cache.setLocatorCurrentInBatchLayer(locator3);
+        assertThat(getCurrents(locator1, cache), equalTo(list(true, false, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(true, false, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(true, false, false)));
     }
 
     @Test
-    public void testSetLocatorCurrentInDiscoveryLayer() throws InterruptedException {
-
-        locatorCache.setLocatorCurrentInDiscoveryLayer(LOCATOR);
-
-        assertTrue("locator not stored in cache", locatorCache.isLocatorCurrentInDiscoveryLayer(LOCATOR));
-
-        Thread.sleep(2000L); //sleeping for 2 seconds to let the locator expire from cache
-
-        assertTrue("locator not expired from cache", !locatorCache.isLocatorCurrentInDiscoveryLayer(LOCATOR));
+    public void tracksCurrencyOfMultipleLocatorsInDiscoveryLayer() {
+        Locator locator1 = Locator.createLocatorFromDbKey("1.1.1");
+        Locator locator2 = Locator.createLocatorFromDbKey("2.2.2");
+        Locator locator3 = Locator.createLocatorFromDbKey("3.3.3");
+        assertThat(getCurrents(locator1, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, false)));
+        cache.setLocatorCurrentInDiscoveryLayer(locator1);
+        assertThat(getCurrents(locator1, cache), equalTo(list(false, true, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, false)));
+        cache.setLocatorCurrentInDiscoveryLayer(locator2);
+        assertThat(getCurrents(locator1, cache), equalTo(list(false, true, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, true, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, false)));
+        cache.setLocatorCurrentInDiscoveryLayer(locator3);
+        assertThat(getCurrents(locator1, cache), equalTo(list(false, true, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, true, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, true, false)));
     }
 
     @Test
-    public void testSetLocatorCurrentInDiscoveryLayerCheckForExpirationWithoutReads() throws InterruptedException {
-
-        locatorCache.setLocatorCurrentInDiscoveryLayer(LOCATOR);
-
-        Thread.sleep(3001L);
-        // it has been more than 3 seconds since it was written.
-        assertTrue("locator not expired from cache", !locatorCache.isLocatorCurrentInDiscoveryLayer(LOCATOR));
-
+    // Repetitive? Yes. The rule of three suggests refactoring here. We could possibly introduce a Layer enum to the
+    // cache interface. Would that make it less easy to use than having a separate method for each layer?
+    public void tracksCurrencyOfMultipleLocatorsInTokenDiscoveryLayer() {
+        Locator locator1 = Locator.createLocatorFromDbKey("1.1.1");
+        Locator locator2 = Locator.createLocatorFromDbKey("2.2.2");
+        Locator locator3 = Locator.createLocatorFromDbKey("3.3.3");
+        assertThat(getCurrents(locator1, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, false)));
+        cache.setLocatorCurrentInTokenDiscoveryLayer(locator1);
+        assertThat(getCurrents(locator1, cache), equalTo(list(false, false, true)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, false)));
+        cache.setLocatorCurrentInTokenDiscoveryLayer(locator2);
+        assertThat(getCurrents(locator1, cache), equalTo(list(false, false, true)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, false, true)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, false)));
+        cache.setLocatorCurrentInTokenDiscoveryLayer(locator3);
+        assertThat(getCurrents(locator1, cache), equalTo(list(false, false, true)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, false, true)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, true)));
     }
 
     @Test
-    public void testSetLocatorCurrentInDiscoveryLayerCheckForExpiration() throws InterruptedException {
-
-        locatorCache.setLocatorCurrentInDiscoveryLayer(LOCATOR);
-        assertTrue("locator not stored in cache", locatorCache.isLocatorCurrentInDiscoveryLayer(LOCATOR));
-
-        Thread.sleep(1000L);
-        assertTrue("locator not stored in cache", locatorCache.isLocatorCurrentInDiscoveryLayer(LOCATOR));
-
-        Thread.sleep(1000L);
-        assertTrue("locator not stored in cache", locatorCache.isLocatorCurrentInDiscoveryLayer(LOCATOR));
-
-        Thread.sleep(1001L);
-        // it has been more than 3 seconds since it was written. So it has to expire even if it was accessed 1sec before.
-        assertTrue("locator not expired from cache", !locatorCache.isLocatorCurrentInDiscoveryLayer(LOCATOR));
-
+    public void canInvalidateTheLayerCacheValues() {
+        // When I set a different locator to current in each layer
+        Locator locator1 = Locator.createLocatorFromDbKey("1.1.1");
+        Locator locator2 = Locator.createLocatorFromDbKey("2.2.2");
+        Locator locator3 = Locator.createLocatorFromDbKey("3.3.3");
+        cache.setLocatorCurrentInBatchLayer(locator1);
+        cache.setLocatorCurrentInDiscoveryLayer(locator2);
+        cache.setLocatorCurrentInTokenDiscoveryLayer(locator3);
+        // Then the cache reflects that
+        assertThat(cache.getCurrentLocatorCount(), equalTo(3L));
+        assertThat(getCurrents(locator1, cache), equalTo(list(true, false, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, true, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, true)));
+        // When I reset the cache
+        cache.resetInsertedLocatorsCache();
+        // Then it all goes away
+        assertThat(cache.getCurrentLocatorCount(), equalTo(0L));
+        assertThat(getCurrents(locator1, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator2, cache), equalTo(list(false, false, false)));
+        assertThat(getCurrents(locator3, cache), equalTo(list(false, false, false)));
     }
 
     @Test
-    public void testIsLocatorCurrentInDiscoveryLayer() throws InterruptedException {
-        assertTrue("locator which was never set is present in cache", !locatorCache.isLocatorCurrentInDiscoveryLayer(LOCATOR));
-
-        locatorCache.setLocatorCurrentInDiscoveryLayer(LOCATOR);
-        assertTrue("locator not stored in cache", locatorCache.isLocatorCurrentInDiscoveryLayer(LOCATOR));
-
-    }
-
-
-    @Test
-    public void testSetDelayedLocatorCurrent() throws InterruptedException {
-        locatorCache.setDelayedLocatorForASlotCurrent(1, LOCATOR);
-        locatorCache.setDelayedLocatorForASlotCurrent(2, LOCATOR);
-
-        assertTrue("locator not stored in cache", locatorCache.isDelayedLocatorForASlotCurrent(1, LOCATOR));
-
-        Thread.sleep(2000L); //sleeping for 2 seconds to let the locator expire from cache
-
-        assertTrue("locator not expired from cache", !locatorCache.isDelayedLocatorForASlotCurrent(1, LOCATOR));
-        assertTrue("locator not expired from cache", !locatorCache.isDelayedLocatorForASlotCurrent(2, LOCATOR));
+    public void tracksDelayedLocatorsBySlot() {
+        Locator locator = Locator.createLocatorFromDbKey("i.m.delayed");
+        assertThat(cache.isDelayedLocatorForASlotCurrent(1, locator), is(false));
+        assertThat(cache.isDelayedLocatorForASlotCurrent(11, locator), is(false));
+        assertThat(cache.isDelayedLocatorForASlotCurrent(999, locator), is(false));
+        cache.setDelayedLocatorForASlotCurrent(1, locator);
+        assertThat(cache.isDelayedLocatorForASlotCurrent(1, locator), is(true));
+        assertThat(cache.isDelayedLocatorForASlotCurrent(11, locator), is(false));
+        assertThat(cache.isDelayedLocatorForASlotCurrent(999, locator), is(false));
+        cache.setDelayedLocatorForASlotCurrent(11, locator);
+        assertThat(cache.isDelayedLocatorForASlotCurrent(1, locator), is(true));
+        assertThat(cache.isDelayedLocatorForASlotCurrent(11, locator), is(true));
+        assertThat(cache.isDelayedLocatorForASlotCurrent(999, locator), is(false));
+        cache.setDelayedLocatorForASlotCurrent(999, locator);
+        assertThat(cache.isDelayedLocatorForASlotCurrent(1, locator), is(true));
+        assertThat(cache.isDelayedLocatorForASlotCurrent(11, locator), is(true));
+        assertThat(cache.isDelayedLocatorForASlotCurrent(999, locator), is(true));
     }
 
     @Test
-    public void testIsDelayedLocatorCurrent() throws InterruptedException {
-        assertTrue("locator not stored in cache", !locatorCache.isDelayedLocatorForASlotCurrent(1, LOCATOR));
+    public void canInvalidateDelayedLocatorSlots() {
+        Locator locator = Locator.createLocatorFromDbKey("i.m.2");
+        cache.setDelayedLocatorForASlotCurrent(1, locator);
+        cache.setDelayedLocatorForASlotCurrent(123, locator);
+        cache.setDelayedLocatorForASlotCurrent(90210, locator);
+        assertThat(cache.getCurrentDelayedLocatorCount(), equalTo(3L));
+        cache.resetCache();
+        assertThat(cache.getCurrentDelayedLocatorCount(), equalTo(0L));
+    }
 
-        locatorCache.setDelayedLocatorForASlotCurrent(1, LOCATOR);
+    @Test
+    public void expiresStuff() throws InterruptedException, TimeoutException {
+        // Given several random locators
+        Random r = new Random();
+        List<Locator> locators = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            locators.add(Locator.createLocatorFromDbKey("random." + r.nextInt(100)));
+        }
+        // And a cache with a fairly short timeout
+        LocatorCache cache = LocatorCache.getInstance(
+                100, MILLISECONDS, 100, MILLISECONDS);
+        // When I insert all the locators into the cache
+        locators.forEach(locator -> {
+            cache.setLocatorCurrentInBatchLayer(locator);
+            cache.setDelayedLocatorForASlotCurrent(1, locator);
+        });
+        // Then the cache reflects all of the entries
+        locators.forEach(locator -> {
+            assertThat(cache.isLocatorCurrentInBatchLayer(locator), is(true));
+            assertThat(cache.isDelayedLocatorForASlotCurrent(1, locator), is(true));
+        });
+        // And after the timeout, all of them are no longer cached
+        waitOrTimeout(
+                () -> locators.stream().noneMatch(cache::isLocatorCurrentInBatchLayer),
+                timeout(millis(200)));
+        locators.forEach(locator ->
+                assertThat(cache.isDelayedLocatorForASlotCurrent(1, locator), is(false)));
+    }
 
-        assertTrue("locator not stored in cache", locatorCache.isDelayedLocatorForASlotCurrent(1, LOCATOR));
-        assertTrue("locator present in cache for a slot which was never set", !locatorCache.isDelayedLocatorForASlotCurrent(10, LOCATOR));
+    @Test
+    // DO NOT synchronize this cache. It bottlenecks all the database writing threads and kills write performance!
+    // This is difficult to show in a unit test, but it's clearly observable in production.
+    public void mustNotBeSynchronized() throws IOException {
+        Path path = Paths.get("src/main/java/com/rackspacecloud/blueflood/cache/LocatorCache.java");
+        for (String line : Files.readAllLines(path)) {
+            if (line.contains("synchronized")) {
+                fail("Found 'synchronized' in line:\n" + line);
+            }
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>1.3</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>4.0.44.Final</version>


### PR DESCRIPTION
The Rackspace Blueflood instance was having problems with its
ingestion rate, and lots of threads were sitting and waiting for
access to the LocatorCache, especially as the number of threads in the
thread pools were increased. Since it's already using a thread-safe
Guava cache implementation, there should be no reason for
synchronizing access to the cache overall. Looking back at the commit
history, it appears it was synchronized because of flaky tests. This
is a terrible reason to play with synchronization in Java. Rely on
high-level concurrency constructs, like the Guava cache, to control
concurrency.

This removes all instances of 'synchronized' from the LocatorCache
class and rewrites the unit tests to be much more robust and faster. A
follow-up change will add a new test of cache concurrency, but it
fails with the current implementation because of the mutable cached
object.