### PR TITLE
fixes failing integration test

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -66,6 +66,21 @@
               </sources>
             </configuration>
           </execution>
+          <execution>
+            <id>add-integration-test-resources</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>add-test-resource</goal>
+            </goals>
+            <configuration>
+              <!-- Configures the resource directory of integration tests. -->
+              <resources>
+                <resource>
+                  <directory>src/integration-test/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
    
@@ -119,9 +134,6 @@
                 <CASSANDRA_DRIVER>datastax</CASSANDRA_DRIVER>
               </systemPropertyVariables>
               <testSourceDirectory>src/integration-test/java</testSourceDirectory>
-              <!-- do not require zookeeper for these tests. -->
-              <argLine>-DZOOKEEPER_CLUSTER=NONE</argLine>
-              <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties ${jacoco.agent.it.argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
               <!-- Skips integration tests if the value of skip.integration.tests property is true -->
               <skipTests>${skip.integration.tests}</skipTests>
               <includes>

--- a/blueflood-core/src/integration-test/resources/blueflood.properties
+++ b/blueflood-core/src/integration-test/resources/blueflood.properties
@@ -1,0 +1,4 @@
+# No need for zookeeper for integration testing.
+# I believe this is because zk is only/primarily used to coordinator multiple rollup nodes so a single shard doesn't
+# get rolled up multiple times, but if zk is missing, the rollup just happens anyway.
+ZOOKEEPER_CLUSTER=NONE

--- a/blueflood-core/src/integration-test/resources/log4j.properties
+++ b/blueflood-core/src/integration-test/resources/log4j.properties
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+log4j.appender.F=org.apache.log4j.RollingFileAppender
+log4j.appender.F.File=tests.log
+log4j.appender.F.MaxFileSize=8048KB
+log4j.appender.F.MaxBackupIndex=2
+
+log4j.appender.F.layout=org.apache.log4j.PatternLayout
+log4j.appender.F.layout.ConversionPattern=%p %t %c - %m%n
+
+log4j.logger.httpclient.wire.header=WARN
+log4j.logger.httpclient.wire.content=WARN
+
+-log4j.category.org.apache.zookeeper.ClientCnxn=WARN
+-log4j.category.org.apache.zookeeper.client.ZooKeeperSaslClient=ERROR
+
+log4j.logger.org.apache.http.client.protocol=INFO
+log4j.logger.org.apache.http.wire=INFO
+log4j.logger.org.apache.http.impl=INFO
+log4j.logger.org.apache.http.headers=INFO
+
+log4j.rootLogger=INFO, F

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -63,6 +63,21 @@
               </sources>
             </configuration>
           </execution>
+          <execution>
+            <id>add-integration-test-resources</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>add-test-resource</goal>
+            </goals>
+            <configuration>
+              <!-- Configures the resource directory of integration tests. -->
+              <resources>
+                <resource>
+                  <directory>src/integration-test/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -105,9 +120,6 @@
                 <CASSANDRA_DRIVER>datastax</CASSANDRA_DRIVER>
               </systemPropertyVariables>
               <testSourceDirectory>src/integration-test/java</testSourceDirectory>
-              <!-- do not require zookeeper for these tests. -->
-              <argLine>-DZOOKEEPER_CLUSTER=NONE</argLine>
-              <argLine>-Dlog4j.configuration=file://${basedir}/src/test/resources/log4j-test.properties ${jacoco.agent.it.argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
               <!-- Skips integration tests if the value of skip.integration.tests property is true -->
               <skipTests>${skip.integration.tests}</skipTests>
               <includes>

--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/http/HttpIntegrationTestBase.java
@@ -92,20 +92,6 @@ public class HttpIntegrationTestBase extends IntegrationTestBase {
 
     @BeforeClass
     public static void setUpHttp() throws Exception {
-
-        Configuration.getInstance().init();
-        Configuration.getInstance().setProperty(CoreConfig.CORS_ENABLED, "true");
-        Configuration.getInstance().setProperty(CoreConfig.CORS_ALLOWED_ORIGINS, configAllowedOrigins);
-        Configuration.getInstance().setProperty(CoreConfig.CORS_ALLOWED_HEADERS, configAllowedHeaders);
-        Configuration.getInstance().setProperty(CoreConfig.CORS_ALLOWED_METHODS, configAllowedMethods);
-        Configuration.getInstance().setProperty(CoreConfig.CORS_ALLOWED_MAX_AGE, configAllowedMaxAge);
-
-
-        // This is to help with Travis, which intermittently fail the following tests due
-        // to getting TimeoutException. This is done here because it needs to be before
-        // RollupHandler is instantiated.
-        Configuration.getInstance().setProperty(CoreConfig.ROLLUP_ON_READ_TIMEOUT_IN_SECONDS, "20");
-
         setupElasticSearch();
 
         setupIngestionServer();

--- a/blueflood-http/src/integration-test/resources/blueflood.properties
+++ b/blueflood-http/src/integration-test/resources/blueflood.properties
@@ -1,0 +1,17 @@
+# No need for zookeeper for integration testing.
+# I believe this is because zk is only/primarily used to coordinator multiple rollup nodes so a single shard doesn't
+# get rolled up multiple times, but if zk is missing, the rollup just happens anyway.
+ZOOKEEPER_CLUSTER=NONE
+
+# Some tests based on HttpIntegrationTestBase use these values to ensure CORS is enabled and working on the endpoints
+# under test.
+CORS_ENABLED=true
+CORS_ALLOWED_ORIGINS=test.domain1.com, test.domain2.com, test.domain3.com
+CORS_ALLOWED_HEADERS=XYZ, ABC
+CORS_ALLOWED_METHODS=GET, POST, PUT
+CORS_ALLOWED_MAX_AGE=6000
+
+# This is to help with Travis, which intermittently fail the following tests due
+# to getting TimeoutException. This is done here because it needs to be before
+# RollupHandler is instantiated.
+ROLLUP_ON_READ_TIMEOUT_IN_SECONDS=20

--- a/blueflood-http/src/integration-test/resources/log4j.properties
+++ b/blueflood-http/src/integration-test/resources/log4j.properties
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+log4j.appender.F=org.apache.log4j.RollingFileAppender
+log4j.appender.F.File=tests.log
+log4j.appender.F.MaxFileSize=8048KB
+log4j.appender.F.MaxBackupIndex=2
+
+log4j.appender.F.layout=org.apache.log4j.PatternLayout
+log4j.appender.F.layout.ConversionPattern=%p %t %c - %m%n
+
+log4j.logger.httpclient.wire.header=WARN
+log4j.logger.httpclient.wire.content=WARN
+
+log4j.category.org.apache.zookeeper.ClientCnxn=WARN
+log4j.category.org.apache.zookeeper.client.ZooKeeperSaslClient=ERROR
+
+log4j.logger.org.apache.http.client.protocol=INFO
+log4j.logger.org.apache.http.wire=INFO
+log4j.logger.org.apache.http.impl=INFO
+log4j.logger.org.apache.http.headers=INFO
+
+log4j.rootLogger=INFO, F

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,18 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.19.1</version>
+          <configuration>
+            <systemPropertyVariables>
+              <!-- Load properties for the IT's from the module-local properties file -->
+              <blueflood.config>file:${basedir}/src/integration-test/resources/blueflood.properties</blueflood.config>
+            </systemPropertyVariables>
+            <!--
+            Include the jacoco agent for maven builds; note that IntelliJ WILL NOT resolve this property and won't apply
+            the arg line as a result. Don't put anything else important here! Use the IT blueflood.properties or some
+            other config mechanism appropriate to the integration tests.
+            -->
+            <argLine>${jacoco.agent.it.argLine}</argLine>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>com.spotify</groupId>


### PR DESCRIPTION
This creates a conventional 'resources' dir in each of the
integration-test directories and places config files in them to be
loaded for integration testing.

The HttpEventsQueryHandlerIntegrationTest failed when I ran 'mvn
verify'. The reason for failure was that it was expected to return
CORS headers and didn't. I traced this back to the fact that
HttpMetricsIngestionServerShutdownIntegrationTest ran first, which
caused the HttpResponder class to be initialized and read the default
CORS_ENABLED value of false. Later, when the setting was changed by
HttpIntegrationTestBase, which the failing class inherits from, it
didn't affect HttpResponder because it uses static fields and
initialization that can only happen once.

The simplest solution would be to have the shutdown IT inherit from
the common base class, but it starts and manipulates its own server,
which conflicts with those started by the base class.

This means the integration tests need to be configurable without
assuming all will inherit from a common base class.  Along the way, I
discovered that Maven and IntelliJ were treating the failsafe plugin's
'argLine' settings differently, and it was broken in both cases. The
sum of the changes in this commit can be described as migrating the
settings from both the HTTP IT base class and the argLine setting into
src/integration-test/resources, where they arguably belong anyway.

Note: I omitted the JVM settings in the argLine because MaxPermSize is
no longer a thing, and if we need to increase the heap space, we can
do it in something like .mvn/jvm.config.