### PR TITLE
fixes clojars repo http url

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -380,7 +380,7 @@
   <repositories>
     <repository>
       <id>clojars.org</id>
-      <url>http://clojars.org/repo</url>
+      <url>https://clojars.org/repo</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Later versions of maven quite sensibly refuse to download from http
urls by default. This fixes a repo url that's using http.