### PR TITLE
consolidates and cleans up surefire configs

### DIFF
--- a/blueflood-cloudfiles/pom.xml
+++ b/blueflood-cloudfiles/pom.xml
@@ -31,19 +31,6 @@
 
   <build>
     <plugins>
-      <!-- Used for unit tests -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
-        <configuration>
-          <!-- Skips unit tests if the value of skip.unit.tests property is true -->
-          <skipTests>${skip.unit.tests}</skipTests>
-          <!-- Excludes integration tests when unit tests are run. -->
-          <parallel>classes</parallel>
-          <threadCount>5</threadCount>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -82,24 +82,6 @@
        </executions>
       </plugin>
 
-      <!-- Used for unit tests -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <!-- Skips unit tests if the value of skip.unit.tests property is true -->
-          <skipTests>${skip.unit.tests}</skipTests>
-          <!-- Excludes integration tests when unit tests are run. -->
-          <excludes>
-            <exclude>**/*Integration*.java</exclude>
-          </excludes>
-          <!-- configuration values are static, and tests interfere with each
-               other when run in parallel. -->
-          <!--<parallel>classes</parallel>-->
-          <!--<threadCount>5</threadCount>-->
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -66,24 +66,6 @@
         </executions>
       </plugin>
 
-      <!-- Used for unit tests -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
-        <configuration>
-          <forkMode>always</forkMode>
-          <!-- Skips unit tests if the value of skip.unit.tests property is true -->
-          <skipTests>${skip.unit.tests}</skipTests>
-          <!-- Excludes integration tests when unit tests are run. -->
-          <excludes>
-            <exclude>**/*Integration*.java</exclude>
-          </excludes>
-          <parallel>classes</parallel>
-          <threadCount>5</threadCount>
-        </configuration>
-      </plugin>
-      
       <!-- Used for integration tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/blueflood-rollupTools/pom.xml
+++ b/blueflood-rollupTools/pom.xml
@@ -31,22 +31,6 @@
 
   <build>
     <plugins>
-      <!-- Used for unit tests -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
-        <configuration>
-          <systemPropertyVariables>
-            <kafka.config>file://${basedir}/src/test/resources/testKafka.conf</kafka.config>
-          </systemPropertyVariables>
-          <!-- Skips unit tests if the value of skip.unit.tests property is true -->
-          <skipTests>${skip.unit.tests}</skipTests>
-          <!-- Excludes integration tests when unit tests are run. -->
-          <parallel>classes</parallel>
-          <threadCount>5</threadCount>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,21 @@
           </execution>
         </executions>
       </plugin>
-      
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Skips unit tests if the value of skip.unit.tests property is true -->
+          <skipTests>${skip.unit.tests}</skipTests>
+          <!-- Excludes integration tests when unit tests are run. -->
+          <!-- This is only necessary because the failsafe plugin's test naming conventions are overridden. -->
+          <excludes>
+            <exclude>**/*Integration*.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>


### PR DESCRIPTION
For the uninitiated, surefire is the plugin that runs the project's
unit tests. It doesn't run integration tests. The failsafe plugin does
that.

Currently, the surefire plugin is configured in all but one child pom,
and mostly the same. The one that's missing it is missing the ability
to skip tests by enabling the skip-unit-tests profile. Rather than
making one more copy/paste, this moves the plugin config to the parent
pom, which all children will inherit.

It omits the plugin version because that's set in pluginManagement.

It omits forkMode=always because that spawns a new JVM for each test!
This is insanely slow: ~4 minutes with it vs ~1 without.

It omits parallel execution because it seems to cause test
interference everywhere, not just in core, where it's already
disabled.  Parallel also doesn't seem to have any great impact on the
length of the test run.

It omits the kafka.config entry from the rollupTools module becaue
that module doesn't even have any unit tests.