### PR TITLE
stabilizes an it's timing

### DIFF
--- a/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-http/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -39,8 +39,6 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
 
     private final long TIME_DIFF = 2000;
     private final String tenant_id = "333333";
-    private long start = System.currentTimeMillis() - TIME_DIFF;
-    private long end = System.currentTimeMillis() + TIME_DIFF;
 
     @Test
     public void testHttpMultiRollupsQueryHandler() throws Exception {
@@ -48,10 +46,12 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
         String postfix = getPostfix();
 
         // post multi metrics for ingestion and verify
+        final long start = System.currentTimeMillis() - TIME_DIFF;
         HttpResponse response = postMetric(tenant_id, postAggregatedPath, "sample_payload.json", postfix);
         assertEquals( "Should get status 200 from ingestion server for POST", 200, response.getStatusLine().getStatusCode() );
         EntityUtils.consume(response.getEntity());
 
+        final long end = System.currentTimeMillis() + TIME_DIFF;
         JsonObject responseObject = getMultiMetricRetry( tenant_id, start, end, "200", "FULL", "",
                 "['3333333.G1s" + postfix + "','3333333.G10s" + postfix + "']", 2 );
 


### PR DESCRIPTION
This test grabs a start and end time at construction time and uses
that for a time window during the test.  The problem is that there's a
lot of "before" stuff that happens in the superclass. At one timing,
over 4 seconds elapsed between test construction and the execution of
the test method, which puts the metrics outside the time window being
queried.  Moving the start and end into the test ensures we're using
an appropriate time window.