### PR TITLE
adds concurrency test for LocatorCache

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -134,6 +134,12 @@ public enum CoreConfig implements ConfigDefaults {
 
     METRIC_BATCH_SIZE("100"),
 
+    // The metrics batch writer uses a cache to determine if it's updated various marker "layers" with a metric
+    // recently. This setting tunes write concurrency of the cache.
+    // IMPORTANT: All threads writing to the database contend for access to this cache. Setting the concurrency too low
+    // will impact metric writing throughput.
+    LOCATOR_CACHE_CONCURRENCY("16"),
+
     CASSANDRA_REQUEST_TIMEOUT("10000"),
     // set <= 0 to not retry
     CASSANDRA_MAX_RETRIES("5"),


### PR DESCRIPTION
The LocatorCache is intended to support high concurrency, with
multiple database-writing threads accessing it concurrently. None of
the existing tests prove that it can handle that. This adds such a
test and fixes the bug that comes from using a mutable object (the
removed LocationCacheEntry) in a multi-threaded environment.