### PR TITLE
Changes for log4j2 upgrade

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -72,6 +72,10 @@
           <groupId>org.jboss.netty</groupId>
           <artifactId>netty</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -102,6 +106,10 @@
         <exclusion>
           <groupId>org.jboss.netty</groupId>
           <artifactId>netty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -136,9 +144,15 @@
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.api.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
 
     <dependency>
@@ -155,7 +169,7 @@
 
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-log4j</artifactId>
+      <artifactId>metrics-log4j2</artifactId>
       <version>3.1.2</version>
     </dependency>
 
@@ -189,8 +203,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
 

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/BluefloodServiceStarter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/BluefloodServiceStarter.java
@@ -23,7 +23,6 @@ import com.rackspacecloud.blueflood.cache.MetadataCache;
 import com.rackspacecloud.blueflood.utils.Metrics;
 import com.rackspacecloud.blueflood.utils.RestartGauge;
 import com.rackspacecloud.blueflood.utils.Util;
-import org.apache.log4j.PropertyConfigurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -249,12 +248,6 @@ public class BluefloodServiceStarter {
     public static void run() {
         // load configuration.
         Configuration config = Configuration.getInstance();
-
-        // if log4j configuration references an actual file, periodically reload it to catch changes.
-        String log4jConfig = System.getProperty("log4j.configuration");
-        if (log4jConfig != null && log4jConfig.startsWith("file:")) {
-            PropertyConfigurator.configureAndWatch(log4jConfig.substring("file:".length()), 5000);
-        }
 
         // check that we have cassandra hosts
         validateCassandraHosts();

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/tools/ops/Migration.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/tools/ops/Migration.java
@@ -29,17 +29,12 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 
 import javax.xml.bind.DatatypeConverter;
 import java.io.PrintStream;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -93,7 +88,9 @@ public class Migration {
     }
     
     public static void main(String args[]) {
-        nullRouteAllLog4j();
+//        While migrating from Log4j to Log4j2, we need to comment out this nullRouteAllLog4j function because was not able to find alternate way.
+//        We can work on this later if needed.
+//        nullRouteAllLog4j();
 
         Map<String, Object> options = parseOptions(args);
         
@@ -357,13 +354,13 @@ public class Migration {
         }
     }
     
-    private static void nullRouteAllLog4j() {
-        List<Logger> loggers = Collections.<Logger>list(LogManager.getCurrentLoggers());
-        loggers.add(LogManager.getRootLogger());
-        for ( Logger logger : loggers ) {
-            logger.setLevel(Level.OFF);
-        }
-    }
+//    private static void nullRouteAllLog4j() {
+//        List<Logger> loggers = Collections.<Logger>list(LogManager.getCurrentLoggers());
+//        loggers.add(LogManager.getRootLogger());
+//        for ( Logger logger : loggers ) {
+//            logger.setLevel(Level.OFF);
+//        }
+//    }
     
     private static AstyanaxContext<Keyspace> connect(String host, int port, String keyspace, int threads, NodeDiscoveryType discovery) {
         AstyanaxContext<Keyspace> context = new AstyanaxContext.Builder()

--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -51,8 +51,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
 

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -55,14 +55,14 @@
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.api.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,8 @@
     <build.profile.id>dev</build.profile.id>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <skip.unit.tests>false</skip.unit.tests>
-    <slf4j.version>1.7.6</slf4j.version>
+    <slf4j.api.version>2.0.11</slf4j.api.version>
+    <slf4j.version>2.22.0</slf4j.version>
     <jodatime.version>2.9</jodatime.version>
     <maven.build.timestamp.format>yyyyMMdd-HHmmss</maven.build.timestamp.format>
   </properties>


### PR DESCRIPTION
Here we make all the changes need for log42 to work. Some of the changes are in pom file to update log4j2 version and support it. We need to remove some code as they are not compatible in log4j2. For PropertyCOnfigurator change there is a property monitorInterval in log4j2. We also need to update the Metrics version to match log4j2 support.